### PR TITLE
WIP: rocblas_gemm_ext2 API integration

### DIFF
--- a/caffe2/operators/fully_connected_op.h
+++ b/caffe2/operators/fully_connected_op.h
@@ -99,26 +99,26 @@ class FullyConnectedOp final : public Operator<Context> {
     //auto C = caffe2::empty({N}, at::dtype<T_B>()).device(Context::GetDeviceType());
     if(FuseBiasAdd) {
     //std::cout << "-------------> Rohith: calling GemmExt2\n";
-    std::cout << "In wrapper - M: " << M << std::endl;
-    std::cout << "In wrapper - N: " << N << std::endl;
-    std::cout << "In wrapper - K: " << K << std::endl;
-    std::cout << "In wrapper - TransposeWeight: " << TransposeWeight << std::endl;
-    math::Gemm<float, Context, Engine, FuseBiasAdd>(
+    //std::cout << "In wrapper - M: " << M << std::endl;
+    //std::cout << "In wrapper - N: " << N << std::endl;
+    //std::cout << "In wrapper - K: " << K << std::endl;
+    //std::cout << "In wrapper - TransposeWeight: " << TransposeWeight << std::endl;
+    math::Gemm<T_X, Context, Engine, FuseBiasAdd>(
         CblasNoTrans,
         TransposeWeight ? CblasTrans : CblasNoTrans,
         M,
         N,
         K,
         1,
-        X.template data<float>(),
-        W.template data<float>(),
+        X.template data<T_X>(),
+        W.template data<T_W>(),
         1,
-        b.template data<float>(),
-        Y->template mutable_data<float>(),
+        b.template data<T_B>(),
+        Y->template mutable_data<T_Y>(),
         &context_
     ); 
     } else {
-    std::cout << "-------------> Rohith: calling Gemm\n";
+    //std::cout << "-------------> Rohith: calling Gemm\n";
     math::Gemm<T_X, Context, Engine>(
         CblasNoTrans,
         TransposeWeight ? CblasTrans : CblasNoTrans,

--- a/caffe2/operators/fully_connected_op.h
+++ b/caffe2/operators/fully_connected_op.h
@@ -91,18 +91,8 @@ class FullyConnectedOp final : public Operator<Context> {
     if (fp16_type<MATH>()) {
       math_type = TensorProto_DataType_FLOAT16;
     }
-    //std::cout << "--------------> Rohith: in fc op\n";
-    // W * x
-    //#if defined(__HIP_DEVICE_COMPILE__)
-    //const float alpha = 1;
-    //const float beta = 1;
-    //auto C = caffe2::empty({N}, at::dtype<T_B>()).device(Context::GetDeviceType());
+    
     if(FuseBiasAdd && X.template IsType<float>()) {
-    //std::cout << "-------------> Rohith: calling GemmExt2\n";
-    //std::cout << "In wrapper - M: " << M << std::endl;
-    //std::cout << "In wrapper - N: " << N << std::endl;
-    //std::cout << "In wrapper - K: " << K << std::endl;
-    //std::cout << "In wrapper - TransposeWeight: " << TransposeWeight << std::endl;
     math::Gemm<T_X, Context, Engine, FuseBiasAdd>(
         CblasNoTrans,
         TransposeWeight ? CblasTrans : CblasNoTrans,
@@ -118,7 +108,6 @@ class FullyConnectedOp final : public Operator<Context> {
         &context_
     ); 
     } else {
-    //std::cout << "-------------> Rohith: calling Gemm\n";
     math::Gemm<T_X, Context, Engine>(
         CblasNoTrans,
         TransposeWeight ? CblasTrans : CblasNoTrans,

--- a/caffe2/operators/fully_connected_op.h
+++ b/caffe2/operators/fully_connected_op.h
@@ -97,7 +97,7 @@ class FullyConnectedOp final : public Operator<Context> {
     //const float alpha = 1;
     //const float beta = 1;
     //auto C = caffe2::empty({N}, at::dtype<T_B>()).device(Context::GetDeviceType());
-    if(FuseBiasAdd) {
+    if(FuseBiasAdd && X.template IsType<float>()) {
     //std::cout << "-------------> Rohith: calling GemmExt2\n";
     //std::cout << "In wrapper - M: " << M << std::endl;
     //std::cout << "In wrapper - N: " << N << std::endl;

--- a/caffe2/operators/fully_connected_op_gpu.cc
+++ b/caffe2/operators/fully_connected_op_gpu.cc
@@ -112,6 +112,12 @@ bool RunFullyConnectedGradientOpOnCUDADevice(
 
 // The RunFullyConnectedOpOnCUDADevice Function will use the pointer of current
 // op and the DoRunWithType will make sure to run the correct things.
+#ifdef __HIP_PLATFORM_HCC__
+template <>
+bool FullyConnectedOp<CUDAContext, DefaultEngine, true, true>::RunOnDevice() {
+  return RunFullyConnectedOpOnCUDADevice(float16_compute_, this);
+}
+#endif
 template <>
 bool FullyConnectedOp<CUDAContext>::RunOnDevice() {
   return RunFullyConnectedOpOnCUDADevice(float16_compute_, this);
@@ -175,7 +181,11 @@ bool FullyConnectedGradientOp<
 
 #endif
 
+#ifdef __HIP_PLATFORM_HCC__
+REGISTER_CUDA_OPERATOR(FC, FullyConnectedOp<CUDAContext, DefaultEngine, true, true>);
+#else
 REGISTER_CUDA_OPERATOR(FC, FullyConnectedOp<CUDAContext>);
+#endif
 REGISTER_CUDA_OPERATOR(FCGradient, FullyConnectedGradientOp<CUDAContext>);
 
 REGISTER_CUDA_OPERATOR(

--- a/caffe2/python/operator_test/fc_operator_test.py
+++ b/caffe2/python/operator_test/fc_operator_test.py
@@ -80,7 +80,7 @@ class TestFcOperator(serial.SerializedTestCase):
             self.assertGradientChecks(gc, op, [X, W, b], i, [0],
                                       threshold=threshold, stepsize=stepsize)
 
-    @settings(max_examples=50, deadline=20000, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(max_examples=50, suppress_health_check=[HealthCheck.filter_too_much])
     @serial.given(n=st.integers(1, 5),
            m=st.integers(0, 5),
            k=st.integers(1, 5),

--- a/caffe2/python/operator_test/fc_operator_test.py
+++ b/caffe2/python/operator_test/fc_operator_test.py
@@ -40,7 +40,7 @@ class TestFcOperator(serial.SerializedTestCase):
             else:
                 W = np.random.rand(n, k).astype(dtype) - 0.5
         b = np.random.rand(n).astype(dtype) - 0.5
-
+        print("Rohith: bias - ", b)
         def fc_op(X, W, b):
             return [np.dot(X, W.reshape(n, k).transpose()) + b.reshape(n)]
 
@@ -80,14 +80,15 @@ class TestFcOperator(serial.SerializedTestCase):
             self.assertGradientChecks(gc, op, [X, W, b], i, [0],
                                       threshold=threshold, stepsize=stepsize)
 
-    @settings(max_examples=50, suppress_health_check=[HealthCheck.filter_too_much])
-    @serial.given(n=st.integers(1, 5),
-           m=st.integers(0, 5),
-           k=st.integers(1, 5),
+    #@settings(max_examples=50, deadline=20000, suppress_health_check=[HealthCheck.filter_too_much])
+    @settings(max_examples=1, deadline=20000)
+    @serial.given(n=st.integers(5, 5),
+           m=st.integers(5, 5),
+           k=st.integers(5, 5),
            multi_dim=st.sampled_from([True, False]),
-           dtype=st.sampled_from([np.float32, np.float16]),
-           engine=st.sampled_from(['', 'TENSORCORE']),
-           **hu.gcs)
+           dtype=st.sampled_from([np.float32]),
+           engine=st.sampled_from(['']),
+           **hu.gcs_gpu_only)
     def test_fc(self, **kwargs):
         self._run_test(transposed=False, **kwargs)
 
@@ -98,7 +99,7 @@ class TestFcOperator(serial.SerializedTestCase):
            multi_dim=st.sampled_from([True, False]),
            dtype=st.sampled_from([np.float32, np.float16]),
            engine=st.sampled_from(['', 'TENSORCORE']),
-           **hu.gcs)
+           **hu.gcs_gpu_only)
     def test_fc_transposed(self, **kwargs):
         self._run_test(transposed=True, **kwargs)
 

--- a/caffe2/python/operator_test/fc_operator_test.py
+++ b/caffe2/python/operator_test/fc_operator_test.py
@@ -40,7 +40,7 @@ class TestFcOperator(serial.SerializedTestCase):
             else:
                 W = np.random.rand(n, k).astype(dtype) - 0.5
         b = np.random.rand(n).astype(dtype) - 0.5
-        print("Rohith: bias - ", b)
+        
         def fc_op(X, W, b):
             return [np.dot(X, W.reshape(n, k).transpose()) + b.reshape(n)]
 
@@ -80,15 +80,14 @@ class TestFcOperator(serial.SerializedTestCase):
             self.assertGradientChecks(gc, op, [X, W, b], i, [0],
                                       threshold=threshold, stepsize=stepsize)
 
-    #@settings(max_examples=50, deadline=20000, suppress_health_check=[HealthCheck.filter_too_much])
-    @settings(max_examples=1, deadline=20000)
-    @serial.given(n=st.integers(5, 5),
-           m=st.integers(5, 5),
-           k=st.integers(5, 5),
+    @settings(max_examples=50, deadline=20000, suppress_health_check=[HealthCheck.filter_too_much])
+    @serial.given(n=st.integers(1, 5),
+           m=st.integers(0, 5),
+           k=st.integers(1, 5),
            multi_dim=st.sampled_from([True, False]),
-           dtype=st.sampled_from([np.float32]),
-           engine=st.sampled_from(['']),
-           **hu.gcs_gpu_only)
+           dtype=st.sampled_from([np.float32, np.float16]),
+           engine=st.sampled_from(['', 'TENSORCORE']),
+           **hu.gcs)
     def test_fc(self, **kwargs):
         self._run_test(transposed=False, **kwargs)
 
@@ -99,7 +98,7 @@ class TestFcOperator(serial.SerializedTestCase):
            multi_dim=st.sampled_from([True, False]),
            dtype=st.sampled_from([np.float32, np.float16]),
            engine=st.sampled_from(['', 'TENSORCORE']),
-           **hu.gcs_gpu_only)
+           **hu.gcs)
     def test_fc_transposed(self, **kwargs):
         self._run_test(transposed=True, **kwargs)
 

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -165,6 +165,23 @@ template <typename T, class Context>
 CAFFE2_API void
 Maximum(const int N, const float alpha, const T* x, T* y, Context* context);
 
+#ifdef __HIP_PLATFORM_HCC__
+template <typename T, class Context, class Engine = DefaultEngine, bool FuseBiasAdd = false>
+CAFFE2_API void Gemm(
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int M,
+    const int N,
+    const int K,
+    const float alpha,
+    const float* A,
+    const float* B,
+    const float beta,
+    const float* C,
+    float* D,
+    Context* context);
+#endif
+
 // Decaf gemm provides a simpler interface to the gemm functions, with the
 // limitation that the data has to be contiguous in memory.
 template <typename T, class Context, class Engine = DefaultEngine>

--- a/caffe2/utils/math.h
+++ b/caffe2/utils/math.h
@@ -174,11 +174,11 @@ CAFFE2_API void Gemm(
     const int N,
     const int K,
     const float alpha,
-    const float* A,
-    const float* B,
+    const T* A,
+    const T* B,
     const float beta,
-    const float* C,
-    float* D,
+    const T* C,
+    T* D,
     Context* context);
 #endif
 

--- a/caffe2/utils/math_gpu.cu
+++ b/caffe2/utils/math_gpu.cu
@@ -542,7 +542,7 @@ CAFFE2_CUDA_EXPORT void Gemm<float, CUDAContext, DefaultEngine, true>(
     const float* C,
     float* D,
     CUDAContext* context) {
-    std::cout << "----------------------> calling rocblas_ext2\n"; 
+    //std::cout << "----------------------> calling rocblas_ext2\n"; 
     //std::cout << "Rohit: In rbext2 - M: " << M << std::endl;
     //std::cout << "Rohit: In rbext2 - N: " << N << std::endl;
     //std::cout << "Rohit: In rbext2 - K: " << K << std::endl;
@@ -572,6 +572,60 @@ CAFFE2_CUDA_EXPORT void Gemm<float, CUDAContext, DefaultEngine, true>(
         0,
         D,
         rocblas_datatype_f32_r,
+        1,
+        N,
+        rocblas_datatype_f32_r,
+        rocblas_gemm_algo_standard,
+        0,
+        0));
+  
+
+}
+
+template<>
+CAFFE2_CUDA_EXPORT void Gemm<at::Half, CUDAContext, DefaultEngine, true>(
+    const CBLAS_TRANSPOSE trans_A,
+    const CBLAS_TRANSPOSE trans_B,
+    const int M,
+    const int N,
+    const int K,
+    const float alpha,
+    const at::Half* A,
+    const at::Half* B,
+    const float beta,
+    const at::Half* C,
+    at::Half* D,
+    CUDAContext* context) {
+    //std::cout << "----------------------> calling rocblas_ext2\n"; 
+    //std::cout << "Rohit: In rbext2 - M: " << M << std::endl;
+    //std::cout << "Rohit: In rbext2 - N: " << N << std::endl;
+    //std::cout << "Rohit: In rbext2 - K: " << K << std::endl;
+    //std::cout << "Rohit: In rbext2 - M: " << M << std::endl;
+    const int row_stride_A = (trans_A == CblasNoTrans) ? 1 : K;
+    const int col_stride_A = (trans_A == CblasNoTrans) ? K : 1;
+    const int row_stride_B = (trans_B == CblasNoTrans) ? 1 : N;
+    const int col_stride_B = (trans_B == CblasNoTrans) ? N : 1;
+    ROCBLAS_ENFORCE(rocblas_gemm_ext2(
+        context->rocblashandle(),
+        N,
+        M,
+        K,
+        &alpha,
+        B,
+        rocblas_datatype_f16_r,
+        row_stride_B,
+        col_stride_B,
+        A,
+        rocblas_datatype_f16_r,
+        row_stride_A,
+        col_stride_A,
+        &beta,
+        C,
+        rocblas_datatype_f16_r,
+        1,
+        0,
+        D,
+        rocblas_datatype_f16_r,
         1,
         N,
         rocblas_datatype_f32_r,

--- a/caffe2/utils/math_gpu.cu
+++ b/caffe2/utils/math_gpu.cu
@@ -542,11 +542,6 @@ CAFFE2_CUDA_EXPORT void Gemm<float, CUDAContext, DefaultEngine, true>(
     const float* C,
     float* D,
     CUDAContext* context) {
-    //std::cout << "----------------------> calling rocblas_ext2\n"; 
-    //std::cout << "Rohit: In rbext2 - M: " << M << std::endl;
-    //std::cout << "Rohit: In rbext2 - N: " << N << std::endl;
-    //std::cout << "Rohit: In rbext2 - K: " << K << std::endl;
-    //std::cout << "Rohit: In rbext2 - M: " << M << std::endl;
     const int row_stride_A = (trans_A == CblasNoTrans) ? 1 : K;
     const int col_stride_A = (trans_A == CblasNoTrans) ? K : 1;
     const int row_stride_B = (trans_B == CblasNoTrans) ? 1 : N;
@@ -596,11 +591,6 @@ CAFFE2_CUDA_EXPORT void Gemm<at::Half, CUDAContext, DefaultEngine, true>(
     const at::Half* C,
     at::Half* D,
     CUDAContext* context) {
-    //std::cout << "----------------------> calling rocblas_ext2\n"; 
-    //std::cout << "Rohit: In rbext2 - M: " << M << std::endl;
-    //std::cout << "Rohit: In rbext2 - N: " << N << std::endl;
-    //std::cout << "Rohit: In rbext2 - K: " << K << std::endl;
-    //std::cout << "Rohit: In rbext2 - M: " << M << std::endl;
     const int row_stride_A = (trans_A == CblasNoTrans) ? 1 : K;
     const int col_stride_A = (trans_A == CblasNoTrans) ? K : 1;
     const int row_stride_B = (trans_B == CblasNoTrans) ? 1 : N;
@@ -636,6 +626,7 @@ CAFFE2_CUDA_EXPORT void Gemm<at::Half, CUDAContext, DefaultEngine, true>(
 
 }
 #endif
+
 // Caffe2 gemm provides a simpler interface to the gemm functions, with the
 // limitation that the data has to be contiguous in memory.
 template <>


### PR DESCRIPTION
Test to run the below change:

`python3 fc_operator_test.py` ( test under `caffe2/python/operator_test/`)

Also added  fp16 path as well but we may choose not to upstream it depending on the support from rocblas. I have currently guarded fp16 path with this condition `if(FuseBiasAdd && X.template IsType<float>())`, that is run ext2 API only for fp32.

@ashishfarmer @jeffdaily @sunway513 