### PR TITLE
Enable gesvda and fix geqrf

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1519,24 +1519,20 @@ void getrsBatched<c10::complex<double>>(CUDABLAS_GETRS_ARGTYPES(c10::complex<dou
 #ifdef USE_ROCM
 template <>
 void geqrfBatched<float>(HIPBLAS_GEQRF_BATCHED_ARGTYPES(float)) {
-#if ROCM_VERSION >= 50700 && ROCM_VERSION < 50800
   if (batchsize == 0) {
     *info = 0;
     return ;
   }
-#endif
   TORCH_HIPBLAS_CHECK(cublasSgeqrfBatched(
       handle, m, n, A_array, lda, tau_array, info, batchsize));
 }
 
 template <>
 void geqrfBatched<double>(HIPBLAS_GEQRF_BATCHED_ARGTYPES(double)) {
-#if ROCM_VERSION >= 50700 && ROCM_VERSION < 50800
   if (batchsize == 0) {
     *info = 0;
     return ;
   }
-#endif
   TORCH_HIPBLAS_CHECK(cublasDgeqrfBatched(
       handle, m, n, A_array, lda, tau_array, info, batchsize));
 }
@@ -1546,12 +1542,10 @@ void geqrfBatched<double>(HIPBLAS_GEQRF_BATCHED_ARGTYPES(double)) {
 template <>
 void geqrfBatched<c10::complex<float>>(
     HIPBLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<float>)) {
-#if ROCM_VERSION >= 50700 && ROCM_VERSION < 50800
   if (batchsize == 0) {
     *info = 0;
     return ;
   }
-#endif
   TORCH_HIPBLAS_CHECK(cublasCgeqrfBatched(
       handle,
       m,
@@ -1566,12 +1560,10 @@ void geqrfBatched<c10::complex<float>>(
 template <>
 void geqrfBatched<c10::complex<double>>(
     HIPBLAS_GEQRF_BATCHED_ARGTYPES(c10::complex<double>)) {
-#if ROCM_VERSION >= 50700 && ROCM_VERSION < 50800
   if (batchsize == 0) {
     *info = 0;
     return ;
   }
-#endif
   TORCH_HIPBLAS_CHECK(cublasZgeqrfBatched(
       handle,
       m,

--- a/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
+++ b/aten/src/ATen/native/cuda/linalg/BatchLinearAlgebraLib.cpp
@@ -761,8 +761,8 @@ inline static void svd_cusolver_gesvdjBatched(const Tensor& A, const Tensor& U, 
 template<typename scalar_t>
 inline static void apply_svd_cusolver_gesvdaStridedBatched(const Tensor& A, const Tensor& U, const Tensor& S, const Tensor& V,
     const Tensor& infos, bool full_matrices, bool compute_uv) {
-#ifndef CUDART_VERSION
-  TORCH_CHECK(false, "gesvda: Batched version is supported only with cuBLAS backend.")
+#ifndef CUDART_VERSION || defined(USE_ROCM) && ROCM_VERSION < 50700
+  TORCH_CHECK(false, "gesvda: Batched version is supported only with cuBLAS backend or ROCM >= 5.7.0.")
 #else
   using value_t = typename c10::scalar_value_type<scalar_t>::type;
   int m = cuda_int_cast(A.size(-2), "m");
@@ -900,7 +900,7 @@ void svd_cusolver(const Tensor& A,
   static const char* check_svd_doc = "Check doc at https://pytorch.org/docs/stable/generated/torch.linalg.svd.html";
 
   // The default heuristic is to use gesvdj driver
-#ifdef ROCM_VERSION
+#ifdef ROCM_VERSION && ROCM_VERSION < 50700
   const auto driver_v = c10::string_view("gesvdj");
 #else
   const auto driver_v = driver.value_or("gesvdj");

--- a/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
+++ b/aten/src/ATen/native/cuda/linalg/CUDASolver.cpp
@@ -470,8 +470,8 @@ void gesvdjBatched<c10::complex<double>>(
 }
 
 
-// ROCM does not implement gesdva yet
-#ifdef CUDART_VERSION
+// ROCM does not implement gesdva before 5.7
+#ifdef CUDART_VERSION || defined(ROCM_VERSION) && ROCM_VERSION >= 50700
 template<>
 void gesvdaStridedBatched_buffersize<float>(
     cusolverDnHandle_t handle, cusolverEigMode_t jobz, int rank, int m, int n, float *A, int lda, long long int strideA,


### PR DESCRIPTION
Fixes SWDEV-407984 and SWDEV-392430

According to Math Library team, it is expected behavior to return error when batch_count == 0. Hence I'm making the temporary workaround permanent.

`PYTORCH_TEST_WITH_ROCM=1 python test/run_test.py --verbose --use-pytest -i test_linalg.py` shows
```=========================== short test summary info ============================                                       
FAILED [0.0052s] test_linalg.py::TestLinalgCUDA::test_linalg_lstsq_batch_broadcasting_cuda_complex128                                                                                                                                         
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
======== 1 failed, 233 passed, 39 skipped, 2 rerun in 96.84s (0:01:36) =========```
