### PR TITLE
fix TEST_ROCM definition to disable test_jit_cudnn_extension on rocm6.0

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -20,8 +20,9 @@ from torch.testing._internal.common_utils import gradcheck
 import torch.multiprocessing as mp
 from torch.utils.cpp_extension import _TORCH_PATH, remove_extension_h_precompiler_headers, get_cxx_compiler, check_compiler_is_gcc
 
-TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
+# define TEST_ROCM before changing TEST_CUDA
 TEST_ROCM = TEST_CUDA and torch.version.hip is not None and ROCM_HOME is not None
+TEST_CUDA = TEST_CUDA and CUDA_HOME is not None
 TEST_MPS = torch.backends.mps.is_available()
 IS_WINDOWS = sys.platform == "win32"
 IS_LINUX = sys.platform.startswith('linux')


### PR DESCRIPTION
Cherry-picked from upstream PR https://github.com/pytorch/pytorch/pull/110385
Define TEST_ROCM before modification TEST_CUDA. Otherwise TEST_ROCM will always be false and will not disable test_jit_cudnn_extension for rocm 
@jithunnair-amd @pruthvistony 
