### PR TITLE
[SWDEV-430417] Disable max_autotune UTs device not "is_big_gpu"

### DIFF
--- a/test/inductor/test_max_autotune.py
+++ b/test/inductor/test_max_autotune.py
@@ -319,5 +319,8 @@ class TestDoBench(TestCase):
 
 
 if __name__ == "__main__":
-    if HAS_CUDA:
+    from torch._inductor.utils import is_big_gpu
+
+    # Set env to make it work in CI.
+    if HAS_CUDA and HAS_CPU and is_big_gpu(0):
         run_tests()


### PR DESCRIPTION
Introduce skip logic from upstream nightly into 2.1 branch to skip for Navi31.