### PR TITLE
Fix SWDEV-443861

### DIFF
--- a/cmake/External/oort.cmake
+++ b/cmake/External/oort.cmake
@@ -5,8 +5,8 @@ if(NOT __OORT_INCLUDED)
   set(__OORT_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/oort/build")
   set(__OORT_INSTALL_DIR "${PROJECT_SOURCE_DIR}/torch")
   ExternalProject_Add(oort_external
-    GIT_REPOSITORY https://github.com/ROCmSoftwarePlatform/triton.git
-    GIT_TAG 29e1252c1ac8e6a54deb883701e553e5b201a1ba
+    GIT_REPOSITORY https://github.com/ROCm/triton.git
+    GIT_TAG 848dea1a1aeb0fb1060d0232861323256f40881b
     SOURCE_DIR ${__OORT_SOURCE_DIR}
     SOURCE_SUBDIR mathaot
     BINARY_DIR ${__OORT_BUILD_DIR}


### PR DESCRIPTION
by adding /opt/rocm/lib to RUNPATH during the build process.

Note: /opt/rocm is configurable with ROCM_PATH environment variable.

Fixes #SWDEV-443861

The actual fix is inside the triton repository: https://github.com/ROCm/triton/commit/848dea1a1aeb0fb1060d0232861323256f40881b
