### PR TITLE
Autocast RNN support

### DIFF
--- a/aten/src/ATen/miopen/AutocastRNN.cpp
+++ b/aten/src/ATen/miopen/AutocastRNN.cpp
@@ -3,71 +3,62 @@
 #include <ATen/cuda/CUDAConfig.h>
 #include <torch/library.h>
 
-
 namespace at {
 namespace autocast {
-
 
 /**********************************************************************
 Autocast wrapper for MIOpen RNNs
 **********************************************************************/
 std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor>
 miopen_rnn(const Tensor & input_r,
-		   TensorList weight,
-		   int64_t weight_stride0,
-		   const Tensor & hx,
-		   const c10::optional<Tensor>& cx_opt,
-		   int64_t fn_mode,
-		   int64_t fn_hidden_size,
-		   int64_t fn_num_layers,
-		   bool batch_first,
-		   double fn_dropout,
-		   bool fn_train,
-		   bool fn_bidirectional,
-		   IntArrayRef fn_batch_sizes,
-		   const c10::optional<Tensor>& fn_dropout_state_opt) {
+           TensorList weight,
+           int64_t weight_stride0,
+           const Tensor & hx,
+           const c10::optional<Tensor>& cx_opt,
+           int64_t fn_mode,
+           int64_t fn_hidden_size,
+           int64_t fn_num_layers,
+           bool batch_first,
+           double fn_dropout,
+           bool fn_train,
+           bool fn_bidirectional,
+           IntArrayRef fn_batch_sizes,
+           const c10::optional<Tensor>& fn_dropout_state_opt) {
 
 #if AT_ROCM_ENABLED()
 
-	c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
+    c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
 
-	return at::miopen_rnn(
-				cached_cast(at::kHalf, input_r),
-				cached_cast(at::kHalf, weight),
-				weight_stride0,
-				cached_cast(at::kHalf, hx),
-				cached_cast(at::kHalf, cx_opt),
-				fn_mode,
-				fn_hidden_size,
-				fn_num_layers,
-				batch_first,
-				fn_dropout,
-				fn_train,
-				fn_bidirectional,
-				fn_batch_sizes,
-				fn_dropout_state_opt);
-
-
+    return at::miopen_rnn(
+                cached_cast(at::kHalf, input_r),
+                cached_cast(at::kHalf, weight),
+                weight_stride0,
+                cached_cast(at::kHalf, hx),
+                cached_cast(at::kHalf, cx_opt),
+                fn_mode,
+                fn_hidden_size,
+                fn_num_layers,
+                batch_first,
+                fn_dropout,
+                fn_train,
+                fn_bidirectional,
+                fn_batch_sizes,
+                fn_dropout_state_opt);
 
 #else
-	AT_ERROR("autocast::miopen_rnn: ATen not compiled with ROCm enabled");
-	return {Tensor{}, Tensor{}, Tensor{}, Tensor{}, Tensor{}}; // placate the compiler
+    AT_ERROR("autocast::miopen_rnn: ATen not compiled with ROCm enabled");
+    return {Tensor{}, Tensor{}, Tensor{}, Tensor{}, Tensor{}}; // placate the compiler
 #endif
 
 }
-
-
-
-
-
 
 // Register Autocast dispatch
 namespace {
 TORCH_LIBRARY_IMPL(aten, Autocast, m) {
   m.impl("miopen_rnn",
-		 TORCH_FN((&at::autocast::miopen_rnn)));
+         TORCH_FN((&at::autocast::miopen_rnn)));
 }
-} // anonymous namesspace
+} // anonymous namespace
 
 } // namespace autocast
 } // namespace at

--- a/aten/src/ATen/miopen/AutocastRNN.cpp
+++ b/aten/src/ATen/miopen/AutocastRNN.cpp
@@ -4,7 +4,6 @@
 #include <torch/library.h>
 
 
-
 namespace at {
 namespace autocast {
 
@@ -32,10 +31,9 @@ miopen_rnn(const Tensor & input_r,
 
 	c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
 
-
 	return at::miopen_rnn(
 				cached_cast(at::kHalf, input_r),
-				weight,
+				cached_cast(at::kHalf, weight),
 				weight_stride0,
 				cached_cast(at::kHalf, hx),
 				cached_cast(at::kHalf, cx_opt),

--- a/aten/src/ATen/miopen/AutocastRNN.cpp
+++ b/aten/src/ATen/miopen/AutocastRNN.cpp
@@ -1,0 +1,50 @@
+#include <ATen/ATen.h>
+#include <ATen/autocast_mode.h>
+#include <ATen/cuda/CUDAConfig.h>
+
+
+
+
+namespace at {
+namespace autocast {
+
+
+/**********************************************************************
+Autocast wrapper for MIOpen RNNs
+**********************************************************************/
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor>
+miopen_rnn(const Tensor & input_r,
+		   TensorList weight,
+		   int64_t weight_stride0,
+		   const Tensor & hx,
+		   const c10::optional<Tensor>& cx_opt,
+		   int64_t fn_mode,
+		   int64_t fn_hidden_size,
+		   int64_t fn_num_layers,
+		   bool batch_first,
+		   double fn_dropout,
+		   bool fn_train,
+		   bool fn_bidirectional,
+		   IntArrayRef fn_batch_sizes,
+		   const c10::optional<Tensor>& fn_dropout_state_opt) {
+
+
+
+
+}
+
+
+
+
+
+
+// Register Autocast dispatch
+namespace {
+TORCH_LIBRARY_IMPL(aten, Autocast, m) {
+  m.impl("miopen_rnn",
+		 TORCH_FN((&at::autocast::miopen_rnn)));
+}
+} // anonymous namesspace
+
+} // namespace autocast
+} // namespace at

--- a/aten/src/ATen/miopen/AutocastRNN.cpp
+++ b/aten/src/ATen/miopen/AutocastRNN.cpp
@@ -28,8 +28,33 @@ miopen_rnn(const Tensor & input_r,
 		   IntArrayRef fn_batch_sizes,
 		   const c10::optional<Tensor>& fn_dropout_state_opt) {
 
+#if AT_ROCM_ENABLED()
+
+	c10::impl::ExcludeDispatchKeyGuard no_autocast(DispatchKey::Autocast);
 
 
+	return at::miopen_rnn(
+				cached_cast(at::kHalf, input_r),
+				weight,
+				weight_stride0,
+				cached_cast(at::kHalf, hx),
+				cached_cast(at::kHalf, cx_opt),
+				fn_mode,
+				fn_hidden_size,
+				fn_num_layers,
+				batch_first,
+				fn_dropout,
+				fn_train,
+				fn_bidirectional,
+				fn_batch_sizes,
+				fn_dropout_state_opt);
+
+
+
+#else
+	AT_ERROR("autocast::miopen_rnn: ATen not compiled with ROCm enabled");
+	return {Tensor{}, Tensor{}, Tensor{}, Tensor{}, Tensor{}}; // placate the compiler
+#endif
 
 }
 

--- a/aten/src/ATen/miopen/AutocastRNN.cpp
+++ b/aten/src/ATen/miopen/AutocastRNN.cpp
@@ -1,7 +1,7 @@
 #include <ATen/ATen.h>
 #include <ATen/autocast_mode.h>
 #include <ATen/cuda/CUDAConfig.h>
-
+#include <torch/library.h>
 
 
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2080,7 +2080,7 @@ torch.cuda.synchronize()
                 # Autocast wrapper requires at::_cudnn_rnn is autograd-exposed.  This check can't guarantee
                 # at::_cudnn_rnn is autograd-exposed, but if it fires, it indicates some funny business has
                 # occurred and we should double check that at::_cudnn_rnn remains autograd-exposed.
-                self.assertEqual(out.grad_fn.name(), "MiopenRnnBackward0" if TEST_WITH_ROCM else "CudnnRnnBackward0")
+                self.assertEqual(out.grad_fn.name(), "MiopenRnnBackward0" if torch.version.hip else "CudnnRnnBackward0")
                 out.sum().backward()
                 grads = [p.grad.clone() for p in rnn.parameters()]
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2032,7 +2032,7 @@ torch.cuda.synchronize()
     # cudnn RNNs require special backend handling (weights are cast to FP16 and reflattened)
     # so they get a dedicated test.
     # Despite the large number of RNN cases it tries, the test takes < 15 seconds on a Titan V (similar to V100).
-    @skipIfRocm
+    #@skipIfRocm
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     def test_autocast_rnn(self):
         with torch.backends.cudnn.flags(enabled=True, deterministic=True):
@@ -2081,7 +2081,7 @@ torch.cuda.synchronize()
                 # Autocast wrapper requires at::_cudnn_rnn is autograd-exposed.  This check can't guarantee
                 # at::_cudnn_rnn is autograd-exposed, but if it fires, it indicates some funny business has
                 # occurred and we should double check that at::_cudnn_rnn remains autograd-exposed.
-                self.assertEqual(out.grad_fn.name(), "CudnnRnnBackward0")
+                self.assertEqual(out.grad_fn.name(), "MiopenRnnBackward0" if TEST_WITH_ROCM else "CudnnRnnBackward0")
                 out.sum().backward()
                 grads = [p.grad.clone() for p in rnn.parameters()]
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -2032,7 +2032,6 @@ torch.cuda.synchronize()
     # cudnn RNNs require special backend handling (weights are cast to FP16 and reflattened)
     # so they get a dedicated test.
     # Despite the large number of RNN cases it tries, the test takes < 15 seconds on a Titan V (similar to V100).
-    #@skipIfRocm
     @unittest.skipIf(not TEST_CUDNN, 'CUDNN not available')
     def test_autocast_rnn(self):
         with torch.backends.cudnn.flags(enabled=True, deterministic=True):


### PR DESCRIPTION
support for autocast with rnns. Fixes test_autocast_rnn

```
root@713353bd62ea:/var/lib/jenkins/pytorch# rtest test/test_cuda.py TestCuda.test_autocast_rnn

Running tests...
----------------------------------------------------------------------
/var/lib/jenkins/pytorch/torch/backends/cudnn/__init__.py:141: UserWarning: cuDNN Benchmark limit is not supported in MIOpen and will have no effect. (Triggered internally at /var/lib/jenkins/pytorch/torch/csrc/cuda/Module.cpp:1357.)
  torch._C._cuda_set_cudnn_benchmark_limit(_benchmark_limit)
.
----------------------------------------------------------------------
Ran 1 test in 20.334s

OK

Generating XML reports...
```

