### PR TITLE
skip test_inductor_freezing failing UTs

### DIFF
--- a/test/inductor/test_inductor_freezing.py
+++ b/test/inductor/test_inductor_freezing.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
+    skipIfRocm,
     TestCase as TorchTestCase,
 )
 
@@ -429,6 +430,7 @@ class OptimizeForInferenceTemplate(TestCase):
         self.assertEqual(eager, compiled)
         self.assertTrue(weight_ref() is None)
 
+    @skipIfRocm
     def test_conv_with_as_strided(self):
         class Model(nn.Module):
             def __init__(self, groups):
@@ -509,7 +511,7 @@ class OptimizeForInferenceTemplate(TestCase):
             x = torch.rand(2, 3, 5, 5).to(self.device)
             mod_eager = mod(x)
             self.assertEqual(foo(mod, x), mod_eager)
-
+    @skipIfRocm
     def test_conv_weight_layout_convert(self):
         class Model(torch.nn.Module):
             def __init__(self):
@@ -565,6 +567,7 @@ class OptimizeForInferenceTemplate(TestCase):
         if self.device == "cuda":
             self.assertTrue(nconv == 1)
 
+    @skipIfRocm
     def test_redundant_clone_for_layout_convert(self):
         class Model(torch.nn.Module):
             def __init__(self):


### PR DESCRIPTION
These UT are disabled upstream as well. Trying to skip them in code so we remove the disabled issues and try to fix them in CI.