### PR TITLE
[release/2.0] Include rocm_version in triton version

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -98,7 +98,7 @@ def build_triton(
         # Nightly binaries include the triton commit hash, i.e. 2.1.0+e6216047b8
         # while release build should only include the version, i.e. 2.1.0
         rocm_version = get_rocm_version()
-        version = f"{version}+rocm{rocm_version}_{commit_hash[:10]}"
+        version = f"{version}+rocm{rocm_version}.{commit_hash[:10]}"
 
     with TemporaryDirectory() as tmpdir:
         triton_basedir = Path(tmpdir) / "triton"

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -53,7 +53,7 @@ def patch_init_py(path: Path, *, version: str) -> None:
     with open(path, "w") as f:
         f.write(orig)
 
-def get_rocm_version() -> str:
+def get_rocm_version(include_patch: bool = True) -> str:
     rocm_path = os.environ.get('ROCM_HOME') or os.environ.get('ROCM_PATH') or "/opt/rocm"
     rocm_version = "0.0.0"
     rocm_version_h = f"{rocm_path}/include/rocm-core/rocm_version.h"
@@ -76,7 +76,7 @@ def get_rocm_version() -> str:
             match = RE_PATCH.search(line)
             if match:
                 patch = int(match.group(1))
-        rocm_version = str(major)+"."+str(minor)+"."+str(patch)
+        rocm_version = str(major)+"."+str(minor)+("."+str(patch) if include_patch else "")
     return rocm_version
 
 def build_triton(
@@ -96,7 +96,8 @@ def build_triton(
     if not release:
         # Nightly binaries include the triton commit hash, i.e. 2.1.0+e6216047b8
         # while release build should only include the version, i.e. 2.1.0
-        version = f"{version}+{commit_hash[:10]}"
+        rocm_version = get_rocm_version(include_patch=False)
+        version = f"{version}+rocm{rocm_version}_{commit_hash[:10]}"
 
     with TemporaryDirectory() as tmpdir:
         triton_basedir = Path(tmpdir) / "triton"

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -53,7 +53,7 @@ def patch_init_py(path: Path, *, version: str) -> None:
     with open(path, "w") as f:
         f.write(orig)
 
-def get_rocm_version(include_patch: bool = True) -> str:
+def get_rocm_version() -> str:
     rocm_path = os.environ.get('ROCM_HOME') or os.environ.get('ROCM_PATH') or "/opt/rocm"
     rocm_version = "0.0.0"
     rocm_version_h = f"{rocm_path}/include/rocm-core/rocm_version.h"
@@ -76,6 +76,7 @@ def get_rocm_version(include_patch: bool = True) -> str:
             match = RE_PATCH.search(line)
             if match:
                 patch = int(match.group(1))
+        include_patch = True if patch!=0 else False
         rocm_version = str(major)+"."+str(minor)+("."+str(patch) if include_patch else "")
     return rocm_version
 
@@ -96,7 +97,7 @@ def build_triton(
     if not release:
         # Nightly binaries include the triton commit hash, i.e. 2.1.0+e6216047b8
         # while release build should only include the version, i.e. 2.1.0
-        rocm_version = get_rocm_version(include_patch=False)
+        rocm_version = get_rocm_version()
         version = f"{version}+rocm{rocm_version}_{commit_hash[:10]}"
 
     with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Tested via: http://rocm-ci.amd.com/job/rocm-pytorch-manylinux-wheel-builder/163

cc @pruthvistony