### PR TITLE
[SWDEV-445217] test_pattern_matcher: skip bfloat16 UTs

### DIFF
--- a/test/inductor/test_pattern_matcher.py
+++ b/test/inductor/test_pattern_matcher.py
@@ -128,12 +128,12 @@ class TestPaternMatcher(TestCase):
                 torch.randn(8, device="cuda"),
                 torch.randn(8, device="cuda"),
             ),
-            (
-                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
-                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
-                torch.randn(8, device="cuda", dtype=torch.bfloat16),
-            ),
+#            (
+#                torch.randn(8, 2, device="cuda", dtype=torch.bfloat16),
+#                torch.randint(-128, 127, (2, 8), dtype=torch.int8, device="cuda"),
+#                torch.randn(8, device="cuda", dtype=torch.bfloat16),
+#                torch.randn(8, device="cuda", dtype=torch.bfloat16),
+#            ),
             (
                 torch.randn(8, 5, device="cuda", dtype=torch.float16),
                 torch.randint(0, 255, (5, 2), dtype=torch.uint8, device="cuda"),


### PR DESCRIPTION
There was a known issue with triton where we saw errors with bfloat16. This is now fixed upstream with
https://github.com/pytorch/pytorch/pull/111129 . However, it seems that we branched off release/2.1 before the change was merged upstream. In the meantime, we can just skip these UTs.

Fixes #ISSUE_NUMBER
