### PR TITLE
[release/2.1] Skip certificate check for CentOS7 since certificate expired

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -29,9 +29,9 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
 
   pushd /tmp
   if [ -n $CENTOS_VERSION ] && [[ $CENTOS_VERSION == 7.* ]]; then
-    CHECK_CERTIFICATE_FLAG="--no-check-certificate"
+    NO_CHECK_CERTIFICATE_FLAG="--no-check-certificate"
   fi
-  wget -q "${BASE_URL}/${CONDA_FILE}" ${CHECK_CERTIFICATE_FLAG}
+  wget -q "${BASE_URL}/${CONDA_FILE}" ${NO_CHECK_CERTIFICATE_FLAG}
   # NB: Manually invoke bash per https://github.com/conda/conda/issues/10431
   as_jenkins bash "${CONDA_FILE}" -b -f -p "/opt/conda"
   popd

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -28,7 +28,10 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
 
   pushd /tmp
-  wget -q "${BASE_URL}/${CONDA_FILE}" --no-check-certificate
+  if [ -n $CENTOS_VERSION ] && [[ $CENTOS_VERSION == 7.* ]]; then
+    CHECK_CERTIFICATE_FLAG="--no-check-certificate"
+  fi
+  wget -q "${BASE_URL}/${CONDA_FILE}" ${CHECK_CERTIFICATE_FLAG}
   # NB: Manually invoke bash per https://github.com/conda/conda/issues/10431
   as_jenkins bash "${CONDA_FILE}" -b -f -p "/opt/conda"
   popd


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-457714

Tested successfully here: http://rocm-ci.amd.com/job/framework-pytorch-2.1-ci_rel-6.1/61