### PR TITLE
Enable NHWC batchnorm for miopen

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -14,6 +14,7 @@
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/batch_norm.h>
 #include <ATen/native/Normalization.h>
+#include <ATen/native/ConvUtils.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/cpu/mixed_data_type.h>
 #include <c10/util/irange.h>
@@ -522,7 +523,7 @@ BatchNormBackend _select_batch_norm_backend(
       && detail::getCUDAHooks().compiledWithMIOpen()
       && cudnn_enabled
       && ((input.suggest_memory_format() == MemoryFormat::Contiguous )
-        || (input.suggest_memory_format() == MemoryFormat::ChannelsLast && PYTORCH_MIOPEN_SUGGEST_NHWC))
+        || (miopen_conv_use_channels_last(input, weight)))
       && input.suggest_memory_format() != MemoryFormat::ChannelsLast3d
   ) {
     return BatchNormBackend::Miopen;

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -8,12 +8,12 @@
 #include <ATen/TensorIterator.h>
 #include <ATen/TensorMeta.h>
 #include <ATen/TensorOperators.h>
+#include <ATen/TensorUtils.h>
 
 #include <ATen/detail/CUDAHooksInterface.h>
 #include <ATen/native/cpu/Loops.h>
 #include <ATen/native/batch_norm.h>
 #include <ATen/native/Normalization.h>
-#include <ATen/native/ConvUtils.h>
 #include <ATen/native/Resize.h>
 #include <ATen/native/cpu/mixed_data_type.h>
 #include <c10/util/irange.h>

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -512,7 +512,8 @@ BatchNormBackend _select_batch_norm_backend(
 
   // TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
   // See #64427
-  static bool PYTORCH_MIOPEN_SUGGEST_NHWC = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC").value_or(false);
+  // non static variable is used to be able to change environment variable in runtime for testing
+  bool PYTORCH_MIOPEN_SUGGEST_NHWC = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC").value_or(false);
 
   if (
       input.is_cuda()

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -153,7 +153,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
   // save_mean and save_var can be undefined
   // If this causes problems, we can initialize them to empty tensors
   // of the correct type
-  return std::tuple<Tensor, Tensor, Tensor>{*output, save_mean, save_var};
+  return std::tuple<Tensor, Tensor, Tensor>{output_t, save_mean, save_var};
 }
 
 std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -83,7 +83,8 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     checkAllSameType(c, {input, weight});
   }
   checkAllSameType(c, {weight, bias, running_mean, running_var});
-  checkAllContiguous(c, {input, weight, bias, running_mean, running_var});
+  checkAllContiguous(c, {weight, bias, running_mean, running_var});
+  TORCH_CHECK(input->is_contiguous(input->suggest_memory_format()));
   checkDimRange(c, input, 2, 6 /* exclusive */);
   auto num_features = input->size(1);
   for (auto t : {weight, bias, running_mean, running_var}) {
@@ -99,7 +100,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     mode = miopenBNSpatial;
   }
 
-  auto output_t = at::empty(input->sizes(), input->options());
+  auto output_t = at::empty(input->sizes(), input->options(), input->suggest_memory_format());
   TensorArg output{ output_t, "output", 0 };
 
   auto handle = getMiopenHandle();
@@ -152,7 +153,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
   // save_mean and save_var can be undefined
   // If this causes problems, we can initialize them to empty tensors
   // of the correct type
-  return std::tuple<Tensor, Tensor, Tensor>{output_t, save_mean, save_var};
+  return std::tuple<Tensor, Tensor, Tensor>{*output, save_mean, save_var};
 }
 
 std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
@@ -176,8 +177,10 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
   const Tensor& save_var_t =
       c10::value_or_else(save_var_t_opt, [] { return Tensor(); });
 
+  auto grad_output_contig =
+      grad_output_t.contiguous(input_t.suggest_memory_format());
   TensorArg input{ input_t, "input", 1 },
-            grad_output{ grad_output_t, "grad_output", 2 },
+            grad_output{ grad_output_contig, "grad_output", 2 },
             weight{ weight_t, "weight", 3 },
             save_mean{ save_mean_t, "save_mean", 4 },
             save_var{ save_var_t, "save_var", 5 };
@@ -192,7 +195,9 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
   }
   checkAllSameType(c, {input, grad_output});
   checkAllSameType(c, {weight, save_mean, save_var});
-  checkAllContiguous(c, {input, grad_output, save_mean, save_var});
+  checkAllContiguous(c, {save_mean, save_var});
+  TORCH_CHECK(input->is_contiguous(input->suggest_memory_format()));
+  TORCH_CHECK(grad_output->is_contiguous(input->suggest_memory_format()));
   checkDimRange(c, input, 2, 6 /* exclusive */);
   checkSameSize(c, input, grad_output);
   auto num_features = input->size(1);
@@ -207,7 +212,8 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
     mode = miopenBNSpatial;
   }
 
-  auto grad_input_t  = at::empty(input->sizes(), input->options());
+  auto grad_input_t = at::empty(
+      input->sizes(), input->options(), input->suggest_memory_format());
   auto grad_weight_t = at::empty(weight->sizes(), weight->options());
   auto grad_bias_t   = at::empty(weight->sizes(), weight->options());
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4916,9 +4916,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             ref_mod.load_state_dict(mod.state_dict())
             out = mod(input)
             out.backward(grad_output)
-            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm                
+            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm
                 ref_out = ref_mod(ref_input)
-                ref_out.backward(ref_grad)            
+                ref_out.backward(ref_grad)
             self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
             self.assertTrue(ref_out.is_contiguous(memory_format=torch.channels_last))
             self.assertEqual(out, ref_out)
@@ -4930,7 +4930,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
         prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
         try:
-            
             os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
             input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
             input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12912,4 +12912,14 @@ instantiate_parametrized_tests(TestNN)
 
 if __name__ == '__main__':
     TestCase._default_dtype_check_enabled = True
-    run_tests()
+    # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
+    PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
+    prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
+    try:
+        os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
+        run_tests()
+    finally:
+        if prev_val is None:
+            del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
+        else:
+            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4950,8 +4950,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             else:
                 os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
 
-
-
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):
         # THNN

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4904,42 +4904,54 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
-    def test_batchnorm_miopen_nhwc_compare_cpu(self):
+    def test_batchnorm_nhwc_miopen(self):
         def run_test(input, grad_output):
             c = input.size(1)
             mod = nn.BatchNorm2d(c).cuda().float()
             mod.weight.data.uniform_()
             mod.bias.data.uniform_()
-            ref_input = input.detach().cpu().contiguous().requires_grad_(True)
-            ref_grad = grad.detach().cpu().contiguous()
-            ref_mod = nn.BatchNorm2d(c).cpu().float()
+            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
+            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
+            ref_mod = nn.BatchNorm2d(c).cuda().float()
             ref_mod.load_state_dict(mod.state_dict())
             out = mod(input)
             out.backward(grad_output)
-            ref_out = ref_mod(ref_input)
-            ref_out.backward(ref_grad)
+            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm                
+                ref_out = ref_mod(ref_input)
+                ref_out.backward(ref_grad)            
             self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-            self.assertTrue(ref_out.is_contiguous())
+            self.assertTrue(ref_out.is_contiguous(memory_format=torch.channels_last))
             self.assertEqual(out, ref_out)
             self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
             self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
             self.assertEqual(input.grad, ref_input.grad)
 
-        self.assertTrue("PYTORCH_MIOPEN_SUGGEST_NHWC" in os.environ and os.environ["PYTORCH_MIOPEN_SUGGEST_NHWC"] == "1",
-                        "PYTORCH_MIOPEN_SUGGEST_NHWC=1 environment variable is required for this test")
-        input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-        input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
+        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
+        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
+        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
+        try:
+            
+            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
+            input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
+            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
 
-        grad = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-        grad = grad.contiguous(memory_format=torch.channels_last)
-        run_test(input, grad)
-        # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
-        # not channels_last
-        input = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-        input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
-        grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-        grad = grad.permute(0, 2, 1, 3)
-        run_test(input, grad)
+            grad = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
+            grad = grad.contiguous(memory_format=torch.channels_last)
+            run_test(input, grad)
+            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
+            # not channels_last
+            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
+            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
+            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
+            grad = grad.permute(0, 2, 1, 3)
+            run_test(input, grad)
+        finally:
+            if prev_val is None:
+                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
+            else:
+                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
+
+
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):


### PR DESCRIPTION
* Non-static PYTORCH_MIOPEN_SUGGEST_NHWC env variable enables MIOpen batchnorm for NHWC and can be changed at runtime
* New unit test `test_batchnorm_nhwc_miopen` compares NHWC MIOpen batchnorm with native NHWC batchnorm to verify miopen. It works only with fp32 input, fp16 and fp64 will be done soon in another PR

