### PR TITLE
[ROCm] Integrate hipblasLT AMAX_D pointer

### DIFF
--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1485,10 +1485,11 @@ void scaled_gemm(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, mat1_scale_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, mat2_scale_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, result_scale_ptr);
+  if (isFloat8Type(result_dtype)) {
+    computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_AMAX_D_POINTER, amax_ptr);
+  }
+
 #ifndef USE_ROCM
-if (isFloat8Type(result_dtype)) {
-  computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_AMAX_D_POINTER, amax_ptr);
-}
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);
 #endif
   CuBlasLtMatrixLayout Adesc(ScalarTypeToCudaDataType(mat1_dtype), m, k, mat1_ld, transa == 't');

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1485,10 +1485,12 @@ void scaled_gemm(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, mat1_scale_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, mat2_scale_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, result_scale_ptr);
+#if defined(USE_ROCM) && ROCM_VERSION >= 60200
+  // Amax support in ROCm as of 6.2
   if (isFloat8Type(result_dtype)) {
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_AMAX_D_POINTER, amax_ptr);
   }
-
+#endif
 #ifndef USE_ROCM
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_FAST_ACCUM, fastAccuMode);
 #endif

--- a/aten/src/ATen/cuda/CUDABlas.cpp
+++ b/aten/src/ATen/cuda/CUDABlas.cpp
@@ -1485,7 +1485,7 @@ void scaled_gemm(
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_A_SCALE_POINTER, mat1_scale_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_B_SCALE_POINTER, mat2_scale_ptr);
   computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_D_SCALE_POINTER, result_scale_ptr);
-#if defined(USE_ROCM) && ROCM_VERSION >= 60200
+#if !defined(USE_ROCM) || (defined(USE_ROCM) && ROCM_VERSION >= 60200)
   // Amax support in ROCm as of 6.2
   if (isFloat8Type(result_dtype)) {
     computeDesc.setAttribute(CUBLASLT_MATMUL_DESC_AMAX_D_POINTER, amax_ptr);

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -31,6 +31,7 @@
 #include <ATen/ops/mm_native.h>
 #include <ATen/ops/mul.h>
 #include <ATen/ops/relu.h>
+#include <ATen/ops/ones.h>
 #include <ATen/ops/scalar_tensor_native.h>
 #include <ATen/ops/vdot_native.h>
 #endif
@@ -891,6 +892,12 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   cublasCommonArgs args(mat1, mat2, out);
   const auto out_dtype_ = args.result->scalar_type();
   TORCH_CHECK(args.transa == 't' && args.transb == 'n', "Only multiplication of row-major and column-major matrices is supported by cuBLASLt");
+
+#if defined(USE_ROCM)
+  auto dummy_options = TensorOptions().dtype(kFloat).device(kCUDA);
+  auto dummy_scale = at::ones(1, dummy_options);
+#endif
+
   at::cuda::blas::scaled_gemm(
       args.transa,
       args.transb,
@@ -908,7 +915,11 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
       bias ? bias->data_ptr(): nullptr,
       bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_,
       args.result->data_ptr(),
+#if !defined(USE_ROCM)
       scale_result ? scale_result->data_ptr() : nullptr,
+#else
+      scale_result ? scale_result->data_ptr() : dummy_scale.data_ptr(),
+#endif
       args.result_ld,
       out_dtype_,
       amax.data_ptr(),

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -916,10 +916,10 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
       bias ? bias->data_ptr(): nullptr,
       bias ? bias->scalar_type() : isFloat8Type(out_dtype_) ? at::ScalarType::Half : out_dtype_,
       args.result->data_ptr(),
-#if !defined(USE_ROCM)
-      scale_result ? scale_result->data_ptr() : nullptr,
-#elif defined(USE_ROCM) && ROCM_VERSION >= 60200
+#if defined(USE_ROCM) && ROCM_VERSION >= 60200
       scale_result ? scale_result->data_ptr() : dummy_scale.data_ptr(),
+#else
+      scale_result ? scale_result->data_ptr() : nullptr,
 #endif
       args.result_ld,
       out_dtype_,

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -893,7 +893,8 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   const auto out_dtype_ = args.result->scalar_type();
   TORCH_CHECK(args.transa == 't' && args.transb == 'n', "Only multiplication of row-major and column-major matrices is supported by cuBLASLt");
 
-#if defined(USE_ROCM)
+#if defined(USE_ROCM) && ROCM_VERSION >= 60200
+  // hipBlasLT requires scaleD to be set to something in order to use AMAX
   auto dummy_options = TensorOptions().dtype(kFloat).device(kCUDA);
   auto dummy_scale = at::ones(1, dummy_options);
 #endif
@@ -917,7 +918,7 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
       args.result->data_ptr(),
 #if !defined(USE_ROCM)
       scale_result ? scale_result->data_ptr() : nullptr,
-#else
+#elif defined(USE_ROCM) && ROCM_VERSION >= 60200
       scale_result ? scale_result->data_ptr() : dummy_scale.data_ptr(),
 #endif
       args.result_ld,
@@ -928,8 +929,8 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
   TORCH_CHECK(false, "_scaled_mm_out_cuda is not compiled for this platform.");
 #endif
 
-#if defined(USE_ROCM) && ROCM_VERSION >= 60000
-  // rocm's hipblaslt does not yet support amax, so calculate separately
+#if defined(USE_ROCM) && ROCM_VERSION >= 60000 && ROCM_VERSION < 60200
+  // ROCm's hipBLASLt does not support amax before 6.2, so calculate separately
   amax = at::max(at::abs(out.to(kFloat)));
 #endif
 

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -465,9 +465,7 @@ class TestFP8MatmulCuda(TestCase):
         bias = torch.full((m,), 4.0, device=device, dtype=torch.half)
         out_fp8, amax_fp8 = torch._scaled_mm(x, y)
         outb_fp8, amaxb_fp8 = torch._scaled_mm(x, y, bias=bias)
-        # this fails on ROCm currently because hipblaslt doesn't have amax op
-        if torch.version.hip is None:
-            self.assertEqual((amaxb_fp8 - amax_fp8).item(), 4.0)
+        self.assertEqual((amaxb_fp8 - amax_fp8).item(), 4.0)
 
     @unittest.skipIf(not scaled_mm_supported_device(), f8_msg)
     @parametrize("bias", [True, False])


### PR DESCRIPTION
Reverts the AMAX workaround now that hipblasLT supports AMAX. hipblasLT does not like getting nullptr for scale D so we create a dummy scalar tensor with the value of 1.0 to pass in the event we are about to pass a nullptr
