### PR TITLE
[release/2.2] Include ROCm patch version unconditionally in triton version

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -53,7 +53,7 @@ def patch_init_py(path: Path, *, version: str) -> None:
     with open(path, "w") as f:
         f.write(orig)
 
-def get_rocm_version(include_patch: bool = True) -> str:
+def get_rocm_version() -> str:
     rocm_path = os.environ.get('ROCM_HOME') or os.environ.get('ROCM_PATH') or "/opt/rocm"
     rocm_version = "0.0.0"
     rocm_version_h = f"{rocm_path}/include/rocm-core/rocm_version.h"
@@ -76,6 +76,7 @@ def get_rocm_version(include_patch: bool = True) -> str:
             match = RE_PATCH.search(line)
             if match:
                 patch = int(match.group(1))
+        include_patch = True if patch!=0 else False
         rocm_version = str(major)+"."+str(minor)+("."+str(patch) if include_patch else "")
     return rocm_version
 
@@ -97,7 +98,7 @@ def build_triton(
     if not release:
         # Nightly binaries include the triton commit hash, i.e. 2.1.0+e6216047b8
         # while release build should only include the version, i.e. 2.1.0
-        rocm_version = get_rocm_version(include_patch=False)
+        rocm_version = get_rocm_version()
         version_suffix = f"+rocm{rocm_version}_{commit_hash[:10]}"
         version += version_suffix
 

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -76,8 +76,7 @@ def get_rocm_version() -> str:
             match = RE_PATCH.search(line)
             if match:
                 patch = int(match.group(1))
-        include_patch = True if patch!=0 else False
-        rocm_version = str(major)+"."+str(minor)+("."+str(patch) if include_patch else "")
+        rocm_version = str(major)+"."+str(minor)+"."+str(patch)
     return rocm_version
 
 def build_triton(


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/pytorch/commit/16e830cee4530f2f97e4f45540400a158f270e86 to resolve issues with ROCm6.1.1 (and similar patch versions) where triton wheel wouldn't contain the patch version but torch wheel would have a dependency on the name with patch version.

Similar changes to https://github.com/ROCm/pytorch/commit/1c7726a612551daab5480f902e43ffc2cc400057, but makes patch version unconditional

This was requested by DC GPU team to simplify their scripts that use PyTorch wheels and determine the name using the ROCM build version shown here - http://mkdcvlnxapp01.amd.com/dashboard - under "Core/ROCm Release".

Tested via: http://ml-ci-internal.amd.com:8080/job/pytorch/job/dev/job/manylinux_rocm_wheels_test/56