### PR TITLE
Added gcnArchName

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -98,7 +98,7 @@ def discover_tests(
             rc |= any(name.startswith(pattern) for pattern in blocklisted_patterns)
         if blocklisted_tests is not None:
             rc |= name in blocklisted_tests
-        if is_gfx94x_arch and blocklisted_tests_inductor is not None:
+        if is_gfx94x_arch() and blocklisted_tests_inductor is not None:
             rc |= name in blocklisted_tests_inductor
         return rc
     cwd = pathlib.Path(__file__).resolve().parent if base_dir is None else base_dir

--- a/test/run_test.py
+++ b/test/run_test.py
@@ -26,6 +26,7 @@ from torch.testing._internal.common_utils import (
     set_cwd,
     parser as common_parser,
     is_slow_gradcheck_env,
+    is_gfx94x_arch,
 )
 import torch.distributed as dist
 from torch.multiprocessing import current_process, get_context
@@ -68,13 +69,6 @@ def maybe_set_hip_visible_devies():
         if p.name != 'MainProcess':
             # this is a Process from a parallel Pool, not the MainProcess
             os.environ['HIP_VISIBLE_DEVICES'] = str(p._identity[0] % NUM_PROCS)
-
-def is_gfx94x_arch():
-    if TEST_WITH_ROCM:
-        prop = torch.cuda.get_device_properties(0)
-        if "gfx94" in prop.gcnArchName.split(":")[0]:
-            return True
-    return False
 
 
 def strtobool(s):

--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1296,6 +1296,7 @@ class _CudaDeviceProperties:
     total_memory: _int
     is_integrated: _int
     is_multi_gpu_board: _int
+    gcnArchName: str
 
 # Defined in torch/csrc/cuda/python_comm.cpp
 def _broadcast(tensor: Tensor, devices: List[_int]) -> List[Tensor]: ...

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -888,10 +888,22 @@ static void registerCudaDeviceProperties(PyObject* module) {
       .def_readonly(
           "multi_processor_count", &cudaDeviceProp::multiProcessorCount)
       .def_readonly("total_memory", &cudaDeviceProp::totalGlobalMem)
+      // HIP-only property; reuse name attribute for CUDA builds
+      .def_readonly(
+          "gcnArchName",
+#if USE_ROCM
+          &cudaDeviceProp::gcnArchName
+#else
+          &cudaDeviceProp::name
+#endif // USE_ROCM
+          )
       .def("__repr__", [](const cudaDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_CudaDeviceProperties(name='" << prop.name
                << "', major=" << prop.major << ", minor=" << prop.minor
+#if USE_ROCM
+               << ", gcnArchName='" << prop.gcnArchName << "'"
+#endif // USE_ROCM
                << ", total_memory=" << prop.totalGlobalMem / (1024 * 1024)
                << "MB, multi_processor_count=" << prop.multiProcessorCount
                << ")";

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -810,6 +810,13 @@ IS_PPC = platform.machine() == "ppc64le"
 IS_X86 = platform.machine() in ('x86_64', 'i386')
 IS_ARM64 = platform.machine() == 'arm64'
 
+def is_gfx94x_arch():
+    if TEST_WITH_ROCM:
+        prop = torch.cuda.get_device_properties(0)
+        if "gfx94" in prop.gcnArchName.split(":")[0]:
+            return True
+    return False
+
 def is_avx512_vnni_supported():
     if sys.platform != 'linux':
         return False

--- a/torch/utils/collect_env.py
+++ b/torch/utils/collect_env.py
@@ -135,7 +135,8 @@ def get_nvidia_driver_version(run_lambda):
 def get_gpu_info(run_lambda):
     if get_platform() == 'darwin' or (TORCH_AVAILABLE and hasattr(torch.version, 'hip') and torch.version.hip is not None):
         if TORCH_AVAILABLE and torch.cuda.is_available():
-            return torch.cuda.get_device_name(None)
+            return torch.cuda.get_device_name(None) + \
+                (" ({})".format(torch.cuda.get_device_properties(0).gcnArchName) if torch.version.hip is not None else "")
         return None
     smi = get_nvidia_smi()
     uuid_regex = re.compile(r' \(UUID: .+?\)')


### PR DESCRIPTION
This PR is to add gcnArchName in release/2.0 branch.

This is also a follow up PR (https://github.com/ROCm/pytorch/pull/1382) to fix API call and move helper location.

Rebuilt PyTorch and quick tests run fine.