### PR TITLE
skip vmapvjpvjp_linalg_householder_product_cuda_float32

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -936,7 +936,7 @@ class TestOperators(TestCase):
                 # (3) encountering this error in PyTorch internals.
                 xfail("index_reduce", "prod"),
                 decorate(
-                    "linalg.householder_product", decorator=runOnRocm
+                    "linalg.householder_product", decorator=skipIfRocm
                 ),  # works on ROCm
                 xfail(
                     "nanquantile", device_type="cpu"


### PR DESCRIPTION
skip failing functorch test
