### PR TITLE
Tunableop improvements: record untuned gemm and provide a API to tune them offline

### DIFF
--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -125,6 +125,7 @@ All python APIs exist in the `torch.cuda.tunable` module.
 | write_file_on_exit(val: bool) -> None | Default is True. |
 | write_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
 | read_file(filename: Optional[str] = None) -> None | If filename not given, it will call get_filename(). |
+| tune_gemm_in_file(filename: str) -> None | read a untuned file and tune GEMMs in it. |
 
 ### C++ Interface
 Example:

--- a/aten/src/ATen/cuda/tunable/README.md
+++ b/aten/src/ATen/cuda/tunable/README.md
@@ -90,6 +90,8 @@ programmatically since the settings become fixed. Use the C++ or Python APIs ins
 | -------------------- | ----------- |
 | PYTORCH_TUNABLEOP_ENABLED | Default is 0. Set to 1 to enable. |
 | PYTORCH_TUNABLEOP_TUNING | Default is 1. Set to 0 to disable. |
+| PYTORCH_TUNABLEOP_RECORD_UNTUNED | Default is 0. Set to 1 to enable. |
+| PYTORCH_TUNABLEOP_UNTUNED_FILENAME | Default is 'untuned.csv'. |
 | PYTORCH_TUNABLEOP_VERBOSE | Default is 0. Set to 1 to enable basic logging. 2 for basic tuning status. 3 for full trace. |
 | PYTORCH_TUNABLEOP_VERBOSE_FILENAME | Default is "err" for stderr. Set to "out" for stdout or a filename for capturing verbose logging. |
 | PYTORCH_TUNABLEOP_FILENAME | Default is 'tunableop_results.csv'. |

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -109,7 +109,6 @@ void TuningResultsManager::Add(const std::string& op_signature, const std::strin
 
 void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature, const std::string& params_signature) {
   std::scoped_lock l{lock_};
-  
   if (!untuned_file.good()){
     TORCH_WARN("failed to open file for writing; untuned gemm will not be saved");
   }
@@ -128,9 +127,9 @@ void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std
     }
     if (isNew){
       untuned_file << "Untuned," << op_signature << "," << params_signature << std::endl;
+      TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
     }
   }
-  TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
 }
 
 void TuningResultsManager::Delete(const std::string& op_signature, const std::string& params_signature) {

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -107,6 +107,32 @@ void TuningResultsManager::Add(const std::string& op_signature, const std::strin
   AddImpl(op_signature, params_signature, best, it->second);
 }
 
+void TuningResultsManager::RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature, const std::string& params_signature) {
+  std::scoped_lock l{lock_};
+  
+  if (!untuned_file.good()){
+    TORCH_WARN("failed to open file for writing; untuned gemm will not be saved");
+  }
+  else{
+    bool isNew = false;
+    auto it = untuned_results_.find(op_signature);
+    if (it == untuned_results_.end()) {
+      it = untuned_results_.insert({op_signature, {}}).first;
+      isNew = true;
+    }
+    auto it_kernel_map = it->second.find(params_signature);
+    if (it_kernel_map == it->second.end())
+    {
+      it->second.insert(params_signature);
+      isNew = true;
+    }
+    if (isNew){
+      untuned_file << "Untuned," << op_signature << "," << params_signature << std::endl;
+    }
+  }
+  TUNABLE_LOG3("Untuned,", op_signature, ",", params_signature);
+}
+
 void TuningResultsManager::Delete(const std::string& op_signature, const std::string& params_signature) {
   std::scoped_lock l{lock_};
 
@@ -303,6 +329,7 @@ TuningContext::TuningContext() :
     icache_flush_{true},
     rotating_buffer_size_{-1},
     filename_{},
+    untuned_file_{},
     results_count_from_input_file_{0}
 {
 }
@@ -327,6 +354,10 @@ TuningContext::~TuningContext() {
         TUNABLE_LOG1("failed to write file ", filename);
       }
     }
+  }
+
+  if (untuned_file_.good()) {
+    untuned_file_.close();
   }
 }
 
@@ -364,6 +395,24 @@ bool TuningContext::IsTuningEnabled() const {
     return false;
   }
   return tuning_enable_;
+}
+
+bool TuningContext::IsRecordUntunedEnabled() const {
+  static const char *env = std::getenv("PYTORCH_TUNABLEOP_RECORD_UNTUNED");
+  if (env != nullptr && strcmp(env, "1") == 0) {
+    return true;
+  }
+  return false;
+}
+
+std::ofstream& TuningContext::GetUntunedFile(){
+  if (!untuned_file_.good())
+  {
+    const char *env = std::getenv("PYTORCH_TUNABLEOP_UNTUNED_FILENAME");
+    std::string filename = (env == nullptr) ? "untuned.csv" : env;
+    untuned_file_ = std::ofstream(filename, std::ios::out | std::ios::trunc);
+  }
+  return untuned_file_;
 }
 
 void TuningContext::WriteFileOnExit(bool value) {

--- a/aten/src/ATen/cuda/tunable/Tunable.h
+++ b/aten/src/ATen/cuda/tunable/Tunable.h
@@ -19,6 +19,7 @@
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -87,6 +88,7 @@ class TORCH_CUDA_CPP_API ResultEntry {
 
 typedef std::unordered_map<std::string, ResultEntry> KernelMap;
 typedef std::unordered_map<std::string, KernelMap> ResultsMap;
+typedef std::unordered_map<std::string, std::unordered_set<std::string>> UntunedMap;
 
 struct TORCH_CUDA_CPP_API TuningResults {
   // Validates if these results are compatible with the libraries
@@ -129,9 +131,12 @@ class TORCH_CUDA_CPP_API TuningResultsManager {
 
     size_t GetSize();
 
+    void RecordUntuned( std::ofstream& untuned_file, const std::string& op_signature, const std::string& params_signature);
   private:
     std::mutex lock_;
     ResultsMap results_;
+    UntunedMap untuned_results_;
+
 };
 
 class TORCH_CUDA_CPP_API TuningResultsValidator {
@@ -173,6 +178,9 @@ class TORCH_CUDA_CPP_API TuningContext {
     void EnableTuning(bool value);
     bool IsTuningEnabled() const;
 
+    bool IsRecordUntunedEnabled() const;
+    std::ofstream& GetUntunedFile();
+
     void EnableNumericsCheck(bool value);
     bool IsNumericsCheckEnabled() const;
 
@@ -213,6 +221,7 @@ class TORCH_CUDA_CPP_API TuningContext {
   private:
     bool enable_;
     bool tuning_enable_;
+    bool record_untuned_;
     bool manager_initialized_;
     bool write_file_on_exit_;
     bool numerics_check_enable_;
@@ -226,6 +235,7 @@ class TORCH_CUDA_CPP_API TuningContext {
     mutable c10::once_flag manager_init_once_;
     TuningResultsValidator validator_;
     std::string filename_;
+    std::ofstream untuned_file_;
     size_t results_count_from_input_file_;
 };
 

--- a/aten/src/ATen/cuda/tunable/TunableOp.h
+++ b/aten/src/ATen/cuda/tunable/TunableOp.h
@@ -58,6 +58,9 @@ class TunableOp {
           result = FindFastest(params);
           mgr.Add(op_sig, params_sig, result);
         }
+        else if (result == ResultEntry::Null() && ctx->IsRecordUntunedEnabled()){
+          mgr.RecordUntuned(ctx->GetUntunedFile(), op_sig, params_sig);
+        }
       }
       else {
         result = ResultEntry::Default();

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -246,7 +246,7 @@ def tune_gemm_in_file(filename: Optional[str] = None) -> None:
     r"""tune gemm in file."""
 
     assert is_enabled()
-    assert tuning_is_enabled() == False
+    assert tuning_is_enabled()
 
     if filename is None:
         print(f'must have filename ')

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -133,6 +133,7 @@ __all__ = [
     "write_file_on_exit",
     "write_file",
     "read_file",
+    "tune_gemm_in_file",
 ]
 
 
@@ -240,3 +241,57 @@ def read_file(filename: Optional[str] = None) -> bool:
     if filename is None:
         filename = get_filename()
     return torch._C._cuda_tunableop_read_file(filename)
+
+def tune_gemm_in_file(filename: Optional[str] = None) -> None:
+    r"""tune gemm in file."""
+
+    assert is_enabled()
+    assert tuning_is_enabled() == False
+
+    if filename is None:
+        print(f'must have filename ')
+
+    with open(filename, 'r') as file:
+        for line in file:
+            if line.startswith("Untuned"):
+                untuned_gemm = line.strip().split(',')[1:]
+                [op_sig,data_type, layout] = untuned_gemm[0].split('_')
+
+                transA = True if layout[0] == 'T'  else False
+                transB = True if layout[1] == 'T'  else False
+
+                if data_type == "float":
+                    dtype = torch.float32
+                elif data_type == "double":
+                    dtype = torch.float64
+                elif data_type == "BFloat16":
+                    dtype = torch.bfloat16
+                elif data_type == "Half":
+                    dtype = torch.half
+                elif data_type == "Float8_e4m3fn":
+                    dtype = torch.float8_e4m3fn
+                elif data_type == "Float8_e5m2":
+                    dtype = torch.float8_e5m2
+                elif data_type == "Float8_e4m3fnuz":
+                    dtype = torch.float8_e4m3fnuz
+                elif data_type == "Float8_e5m2fnuz":
+                    dtype = torch.float8_e5m2fnuz
+                elif data_type == "c10::complex<double>":
+                    dtype = torch.complex128
+                elif data_type == "c10::complex<float>":
+                    dtype = torch.complex64
+
+                if op_sig == "GemmTunableOp":
+                    [n,m,k] = [int(g) for g in untuned_gemm[1].split('_')[1:]]
+                    matA = torch.rand(k,m, dtype=dtype, device='cuda').t() if transB else torch.rand(m,k, dtype=dtype, device='cuda')
+                    matB = torch.rand(n,k, dtype=dtype, device='cuda').t() if transA else torch.rand(k,n, dtype=dtype, device='cuda')
+                    torch.mm(matA, matB)
+                elif op_sig == "GemmStridedBatchedTunableOp":
+                    [n,m,k,_,b] = untuned_gemm[1].split('_')[1:]
+                    matA = torch.rand(int(b),int(m),int(k), dtype=dtype, device='cuda')
+                    matB = torch.rand(int(b),int(k),int(n), dtype=dtype, device='cuda')
+                    matA = matA.transpose(1,2) if transB else matA
+                    matB = matB.transpose(1,2) if transA else matB
+                    torch.bmm(matA, matB)
+                else:
+                    print(f'error: unkown op')

--- a/torch/cuda/tunable.py
+++ b/torch/cuda/tunable.py
@@ -242,14 +242,11 @@ def read_file(filename: Optional[str] = None) -> bool:
         filename = get_filename()
     return torch._C._cuda_tunableop_read_file(filename)
 
-def tune_gemm_in_file(filename: Optional[str] = None) -> None:
-    r"""tune gemm in file."""
+def tune_gemm_in_file(filename: str) -> None:
+    r"""tune GEMM in file."""
 
     assert is_enabled()
     assert tuning_is_enabled()
-
-    if filename is None:
-        print(f'must have filename ')
 
     with open(filename, 'r') as file:
         for line in file:


### PR DESCRIPTION
This change provide an offline mode for tunableOp: 
It is easy to have OOM since APP usually needs large video memory size when running a LLM for inference. When the GEMM size is also very large, the APP will crash due to OOM.

For this case, we need a offline mode to tune the GEMMs. This is the first PR which record untuned GEMMs to file. 

The API named tune_gemm_in_file is added to read the untuned file and tune the GEMMs in file