### PR TITLE
SWDEV-469009 - skips for flaky distributed tests

### DIFF
--- a/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
+++ b/test/distributed/fsdp/test_fsdp_clip_grad_norm.py
@@ -28,6 +28,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
+    skipIfRocm
 )
 
 if not dist.is_available():
@@ -301,6 +302,7 @@ class TestClipGradNorm(FSDPTest):
                 )
 
     @skip_if_lt_x_gpu(2)
+    @skipIfRocm
     def test_no_gradients(self):
         """
         Tests that calling ``clip_grad_norm_()`` when the FDSP module has no

--- a/test/distributed/fsdp/test_fsdp_optim_state.py
+++ b/test/distributed/fsdp/test_fsdp_optim_state.py
@@ -39,6 +39,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
+    skipIfRocm
 )
 
 STATE_DICT_TYPES = [StateDictType.FULL_STATE_DICT, StateDictType.SHARDED_STATE_DICT]
@@ -512,6 +513,7 @@ class TestFSDPOptimState(FSDPTest):
                     continue
                 self.assertEqual(full_osd_value, ref_osd_pg[name])
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", STATE_DICT_TYPES)
     @parametrize("use_multiple_param_groups", [False, True])
@@ -653,6 +655,7 @@ class TestFSDPOptimState(FSDPTest):
         with self.assertRaisesRegex(RuntimeError, error_regex):
             FSDP.full_optim_state_dict(model, optim)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("use_multiple_param_groups", [False, True])
     @parametrize("wrap_alt", [False, True])
@@ -754,6 +757,7 @@ class TestFSDPOptimState(FSDPTest):
             num_iters=3,
         )
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("use_multiple_param_groups", [False, True])
     @parametrize("wrap_alt", [False, True])
@@ -1133,6 +1137,7 @@ class TestFSDPOptimState(FSDPTest):
         optim2.load_state_dict(sharded_osd2)
         self._step_model(model2, optim2, num_iters=num_iters)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", STATE_DICT_TYPES)
     @parametrize("add_to_fsdp_module", [False, True])
@@ -1249,6 +1254,7 @@ class TestFSDPOptimState(FSDPTest):
             # Check that we can load the optimizer state dict
             optim.load_state_dict(flattened_osd)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("state_dict_type", STATE_DICT_TYPES)
     @parametrize("use_multiple_param_groups", [False, True])

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -42,6 +42,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
+    skipIfRocm
 )
 
 if not dist.is_available():
@@ -728,6 +729,7 @@ class TestFSDPUseOrigParamsParamAccess(FSDPTest):
         # sharding strategy to check sharded parameter parity
         return 2
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     def test_access_params_after_forward(self):
         """

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -51,6 +51,7 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle,
     TestCase,
+    skipIfRocm
 )
 
 
@@ -1356,6 +1357,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
 
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
+    @skipIfRocm
     def test_reduce_stress_cuda(self):
         inputs = [torch.tensor([i + self.rank]).cuda() for i in range(1000)]
         self._test_reduce_stress(inputs)


### PR DESCRIPTION
I see this one failing consistently failing due to tensor-likes are not equal:

python test/distributed/test_c10d_gloo.py -k test_reduce_stress_cuda



These are flaky. I see them run fine when I run individually, however, they timeout in the bunch:

test/distributed/fsdp/test_fsdp_clip_grad_norm.py -k test_no_gradients

test/distributed/fsdp/test_fsdp_optim_state.py -k test_optim_state_dict_nested

test/distributed/fsdp/test_fsdp_optim_state.py -k test_scatter_full_optim_state_dict

test/distributed/fsdp/test_fsdp_optim_state.py -k test_rekey_optim_state_dict

test/distributed/fsdp/test_fsdp_optim_state.py -k test_shard_full_optim_state_dict

test/distributed/fsdp/test_fsdp_optim_state.py -k test_full_optim_state

test/distributed/fsdp/test_fsdp_use_orig_params.py -k test_access_params_after_forward 