### PR TITLE
[release/2.3] Update apex commit to pick up wheel-related changes

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.3.0|a4d9af3e08152db491057f9a59a017c37b985694|https://github.com/ROCmSoftwarePlatform/apex
-centos|pytorch|apex|release/1.3.0|a4d9af3e08152db491057f9a59a017c37b985694|https://github.com/ROCmSoftwarePlatform/apex
+ubuntu|pytorch|apex|release/1.3.0|15beaca6a246e6251a16242a51f3a3e289833f40|https://github.com/ROCmSoftwarePlatform/apex
+centos|pytorch|apex|release/1.3.0|15beaca6a246e6251a16242a51f3a3e289833f40|https://github.com/ROCmSoftwarePlatform/apex
 ubuntu|pytorch|torchvision|release/0.18|593b6f9738fe9aed18a7f77d18005e035e038a89|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.18|593b6f9738fe9aed18a7f77d18005e035e038a89|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|656a3b48d14c18d816f071dfb7449daa852fc219|https://github.com/pytorch/text


### PR DESCRIPTION
Tested using http://rocm-ci.amd.com/job/rocm-pytorch-manylinux-wheel-builder/427
Artifacts generated: http://rocm-ci.amd.com/job/rocm-pytorch-manylinux-wheel-builder/427/artifact/result.cp39/*view*/
`apex-1.3.0+rocm6.2.0-cp39-cp39-linux_x86_64.whl pushed to http://compute-artifactory.amd.com/artifactory/compute-pytorch-rocm/compute-rocm-rel-6.2/4/apex-1.3.0+rocm6.2.0-cp39-cp39-linux_x86_64.whl`

L0 tests ran fine with: `bash run_rocm.sh 2>&1 | tee run_rocm.log`