### PR TITLE
[NO CP] [Inductor] Use torch.version.hip to conditionalise out dynamic rblock scaling

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -227,7 +227,7 @@ class CachingAutotuner(KernelInterface):
                 and self.heuristic_type == HeuristicType.REDUCTION
                 and self.size_hints is not None
                 # Disable for AMDGPU as Triton is not ready to return n_regs for a compiled_binary.
-                and not self.inductor_meta.get("is_hip")
+                and not torch.version.hip
                 # Disable for Intel GPU as Triton is not ready to return n_regs for a compiled_binary.
                 and self.device_type != "xpu"
                 and device_prop.major >= 8


### PR DESCRIPTION
The `is_hip` logic is flakey on 6.2_internal_testing, bringing in this change to avoid unexpected issues due to `device_prop.regs_per_multiprocessor` not being available on ROCm in this branch. This will be adopted upstream and cherry picked into 6.3 via https://github.com/pytorch/pytorch/pull/129663

This issue was raised in trying to reproduce a defect in PLAT-160450 and will help the investigation into this issue.