### PR TITLE
[release/2.3] Fix test_oom_tracing by increasing tensor size

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1064,7 +1064,7 @@ class TestProfiler(TestCase):
 
         def create_cuda_tensor_oom():
             device = torch.device("cuda:0")
-            return torch.empty(1024, 1024, 1024, 20, dtype=torch.float32, device=device)
+            return torch.empty(1024, 1024, 1024, 1024, dtype=torch.float32, device=device)
 
         def check_trace(fname):
             prof.export_chrome_trace(fname)


### PR DESCRIPTION
test_oom_tracing expects OutOfMemory exception by allocating a large tensor. MI300X has enough memory to allocate test tensor
This PR increases tensor size with a large margin to force OutOfMemory exception on MI300X and future GPU generations