### PR TITLE
[release/2.2] fix test_oom_tracing and skip test_profiler_ cuda_sync_events

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1535,6 +1535,7 @@ class TestProfiler(TestCase):
     @unittest.skipIf(not kineto_available(), "Kineto is required")
     @unittest.skipIf(IS_WINDOWS, "Test does not work on Windows")
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")
+    @unittest.skipIf(TEST_WITH_ROCM, "Failing on ROCm, skipped. Issue #106027")
     def test_profiler_cuda_sync_events(self):
         device = torch.device("cuda:0")
         t1, t2 = torch.ones(1, device=device), torch.ones(1, device=device)

--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -969,7 +969,7 @@ class TestProfiler(TestCase):
 
         def create_cuda_tensor_oom():
             device = torch.device("cuda:0")
-            return torch.empty(1024, 1024, 1024, 20, dtype=torch.float32, device=device)
+            return torch.empty(1024, 1024, 1024, 1024, dtype=torch.float32, device=device)
 
         def check_trace(fname):
             prof.export_chrome_trace(fname)


### PR DESCRIPTION
`test_oom_tracing` expects OutOfMemory exception by allocating a large tensor. MI300X has enough memory to allocate test tensor
This PR increases tensor size with a large margin to force OutOfMemory exception on MI300X and future GPU generations

@SkipIfRocm  for `test_profiler_cuda_sync_events` was cherry-picked from upstream https://github.com/ROCm/pytorch/commit/57fb8860f3d55c2f24986e4afbd643766c649a03 for [SWDEV-452384](https://ontrack-internal.amd.com/browse/SWDEV-452384)

