### PR TITLE
[rocm6.2_internal_testing] [ROCm] [SWDEV-472265] Return correct AMDSMI socket_power metric

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1039,11 +1039,11 @@ def _get_amdsmi_temperature(device: Optional[Union[Device, int]] = None) -> int:
 
 def _get_amdsmi_power_draw(device: Optional[Union[Device, int]] = None) -> int:
     handle = _get_amdsmi_handler(device)
-    socket_power = amdsmi.amdsmi_get_power_info(handle)["current_socket_power"]
+    socket_power = amdsmi.amdsmi_get_power_info(handle)["average_socket_power"]
     if socket_power != "N/A":
         return socket_power
     else:
-        return amdsmi.amdsmi_get_power_info(handle)["average_socket_power"]
+        return amdsmi.amdsmi_get_power_info(handle)["current_socket_power"]
 
 
 def _get_amdsmi_clock_rate(device: Optional[Union[Device, int]] = None) -> int:

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1039,7 +1039,11 @@ def _get_amdsmi_temperature(device: Optional[Union[Device, int]] = None) -> int:
 
 def _get_amdsmi_power_draw(device: Optional[Union[Device, int]] = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_power_info(handle)["current_socket_power"]
+    socket_power = amdsmi.amdsmi_get_power_info(handle)["current_socket_power"]
+    if socket_power != "N/A":
+        return socket_power
+    else:
+        return amdsmi.amdsmi_get_power_info(handle)["average_socket_power"]
 
 
 def _get_amdsmi_clock_rate(device: Optional[Union[Device, int]] = None) -> int:


### PR DESCRIPTION
Cherry pick of https://github.com/pytorch/pytorch/pull/130331/files

```
Extending on the change in https://github.com/pytorch/pytorch/pull/127729

Depending on gcnArch the API to return socket power will change. This will help us handle both cases for now until this is consolidated in the future.
```

MI200
Current socket power: N/A
Average socket power: 94

MI300
Current socket power: 717
Average socket power: N/A

Fixes https://ontrack-internal.amd.com/browse/SWDEV-472265
