### PR TITLE
Update clock info metric AMDSMI

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -1106,7 +1106,11 @@ def _get_amdsmi_power_draw(device: Optional[Union[Device, int]] = None) -> int:
 
 def _get_amdsmi_clock_rate(device: Optional[Union[Device, int]] = None) -> int:
     handle = _get_amdsmi_handler(device)
-    return amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)["cur_clk"]
+    clock_info = amdsmi.amdsmi_get_clock_info(handle, amdsmi.AmdSmiClkType.GFX)
+    if "cur_clk" in clock_info:
+        return clock_info["cur_clk"]
+    else:
+        return clock_info["clk"]
 
 
 def memory_usage(device: Optional[Union[Device, int]] = None) -> int:


### PR DESCRIPTION
ROCm6.1 provided info in the `cur_clk` field
ROCm6.2 provided info in the `clk` field
Keep conditional logic for backward-compatibility

Cherry pick of https://github.com/ROCm/pytorch/commit/20086f5d363cf9fb2c378c46d9d90143ba3835bf + https://github.com/ROCm/pytorch/commit/4d3bd90442cae7bc9f22e30a28e03b6467dd81fd

Will upstream change shortly