### PR TITLE
[release/2.2] fix test_vmapvjpvjp and skip test_profiler_experimental_tree

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -834,7 +834,7 @@ class TestOperators(TestCase):
              {torch.float32: tol(atol=2e-03, rtol=2e-02)}),
         tol1('svd',
              {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
-        tol1('linalg.householder_product',   
+        tol1('linalg.householder_product',
              {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
         tol1('matrix_exp',
              {torch.float32: tol(atol=1e-03, rtol=5e-04)}),

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -834,6 +834,8 @@ class TestOperators(TestCase):
              {torch.float32: tol(atol=2e-03, rtol=2e-02)}),
         tol1('svd',
              {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
+        tol1('linalg.householder_product',   
+             {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
         tol1('matrix_exp',
              {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
     ))

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -12,7 +12,7 @@ import expecttest
 import torch
 from torch._C._profiler import _ExtraFields_PyCall, _ExtraFields_PyCCall
 from torch.testing._internal.common_utils import (
-    TestCase, run_tests, IS_WINDOWS, TEST_WITH_CROSSREF, IS_ARM64)
+    skipIfRocm, TestCase, run_tests, IS_WINDOWS, TEST_WITH_CROSSREF, IS_ARM64)
 from torch.utils._pytree import tree_map
 
 # These functions can vary from based on platform and build (e.g. with CUDA)
@@ -249,6 +249,7 @@ class TestProfilerTree(TestCase):
                 else:
                     raise
 
+    @skipIfRocm
     @ProfilerTree.test
     def test_profiler_experimental_tree(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
@@ -348,6 +349,7 @@ class TestProfilerTree(TestCase):
                       aten::copy_"""
         )
 
+    @skipIfRocm
     @ProfilerTree.test
     def test_profiler_experimental_tree_with_memory(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)


### PR DESCRIPTION
cherry-picked from https://github.com/ROCm/pytorch/commit/7e963910dcebdb6726bd3f08b4784338c19d8869 for release/2.2

Skipping the following test
test/profiler/test_profiler_tree.py:test_profiler_experimental_tree
test/profiler/test_profiler_tree.py:test_profiler_experimental_tree_with_memory

Fixing
test/functorch/test_ops.py:test_vmapvjpvjp_linalg_householder_product_cuda_float32
by adjusting the TOL value.
