### PR TITLE
[Release 2.3] [SWDEV-461863] Don't cache device_count if CUDA isn't initialised yet

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3082,6 +3082,24 @@ exit(2)
             rc = check_output(f"import torch; import ctypes;x=ctypes.c_int(-1);print({cuda_driver_api_call})")
             self.assertEqual(rc, "3")
 
+    @unittest.skipIf(not TEST_MULTIGPU, "requires multiple devices")
+    @unittest.skipIf(TEST_WITH_ROCM, "too lazy to debug this on ROCm")
+    def test_device_count_not_cached_pre_init(self):
+        test_script = """\
+import torch
+import os
+r1 = torch.cuda.device_count()
+os.environ['CUDA_VISIBLE_DEVICES'] = '0'
+r2 = torch.cuda.device_count()
+torch.empty(10, device='cuda')
+print(f"{r1}, {r2}")
+"""
+
+        r = subprocess.check_output([sys.executable, "-c", test_script]).decode("ascii").strip()
+
+        x = torch.cuda.device_count()
+        self.assertEqual(f"{x}, 1", r)
+
 
 
 

--- a/test/test_cuda_nvml_based_avail.py
+++ b/test/test_cuda_nvml_based_avail.py
@@ -34,7 +34,7 @@ class TestExtendedCUDAIsAvail(TestCase):
 
     def setUp(self):
         super().setUp()
-        torch.cuda.device_count.cache_clear()  # clear the lru_cache on this method before our test
+        torch.cuda._cached_device_count = None  # clear the lru_cache on this method before our test
 
     @staticmethod
     def in_bad_fork_test() -> bool:


### PR DESCRIPTION
Before initializing CUDA, it can change by modifying CUDA_VISIBLE_DEVICES

Cherry pick of - https://github.com/pytorch/pytorch/pull/122815 

Fixes https://ontrack-internal.amd.com/browse/SWDEV-461863
