### PR TITLE
[NO CP] [SWDEV-472647] Revert default_num_stages change on ROCm

### DIFF
--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -1277,8 +1277,8 @@ def triton_config_reduction(size_hints, x, r, num_stages=1, num_warps=None) -> C
         num_warps = conditional_product(x, r) // 128
     # On AMD GPU each warp has 64 lanes which is double the size on NV GPU,
     # therefore using half the number of warps here correspondingly.i
-    default_num_warps = 4 if torch.version.hip else 8
-    min_num_warps = 1 if torch.version.hip else 2
+    default_num_warps = 8
+    min_num_warps = 2
     num_warps = next_power_of_2(min(max(num_warps, min_num_warps), default_num_warps))
 
     # Check if maxGridSize is exceeded - if so then must scale XBLOCK further 


### PR DESCRIPTION
As part of our previous fix for https://ontrack-internal.amd.com/browse/SWDEV-463139 I brought in an additional small change from upstream developments to more sensibly set ROCm defaults for num_warps in reduction kernels as this has reported to improve performance for some workloads by upstream developers https://github.com/pytorch/pytorch/pull/125084

More analysis is needed for us to investigate this change as some regressions are observed with this.

AMD Triton team recommend num_warps=8 as ROCm default to improve our latency, but for the case mentioned upstream it benefits from this change as the TTGIR implements a wider load and has improved vectorisation. We will need to seek out a better middle ground in the future. Current thoughts are that we could reduce num_warps and increase waves_per_eu to get the benefit of both the wider load and increasing the number of workgroups scheduled which will improve the latency.

For now I suggest to revert this in 6.2 and we will aim to provide a better solution in upstream and 6.3.