### PR TITLE
[release/2.0] update torchvision in related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
-ubuntu|pytorch|apex|release/1.0.0|06c33eee43f7a22f3ed7d9c3e5be0ddd757dc345|https://github.com/ROCmSoftwarePlatform/apex
-centos|pytorch|apex|release/1.0.0|06c33eee43f7a22f3ed7d9c3e5be0ddd757dc345|https://github.com/ROCmSoftwarePlatform/apex
-ubuntu|pytorch|torchvision|release/0.15|c1ce9c9b3160986a9b9e979cc44790b5d8429676|https://github.com/ROCmSoftwarePlatform/vision
-centos|pytorch|torchvision|release/0.15|c1ce9c9b3160986a9b9e979cc44790b5d8429676|https://github.com/ROCmSoftwarePlatform/vision
+ubuntu|pytorch|apex|release/1.0.0|06c33eee43f7a22f3ed7d9c3e5be0ddd757dc345|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.0.0|06c33eee43f7a22f3ed7d9c3e5be0ddd757dc345|https://github.com/ROCm/apex
+ubuntu|pytorch|torchvision|release/0.15|c5e28d62174bb69801e5512ea2e63409151060b6|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.15|c5e28d62174bb69801e5512ea2e63409151060b6|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.15|4571036cf66c539e50625218aeb99a288d79f3e1|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.15|4571036cf66c539e50625218aeb99a288d79f3e1|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.6|e1feeb2542293e42f083d24301386db6c003eeee|https://github.com/pytorch/data


### PR DESCRIPTION
Update `related_commits` for `release/2.0` to use torchvision with numpy<2 requirements from `ROCm/vision` repo
Also change `ROCmSoftwarePlatform/apex` repo link to `ROCm/apex`

Uses torchvision fix in https://github.com/ROCm/vision/commit/c5e28d62174bb69801e5512ea2e63409151060b6