### PR TITLE
[release/2.2] update torchvision in related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
-ubuntu|pytorch|apex|release/1.2.0|f8af327cad2f8d94401a9f6c21e716e586251506|https://github.com/ROCmSoftwarePlatform/apex
-centos|pytorch|apex|release/1.2.0|f8af327cad2f8d94401a9f6c21e716e586251506|https://github.com/ROCmSoftwarePlatform/apex
-ubuntu|pytorch|torchvision|release/0.17|4fd856bfbcf59a4da3a91f0e12515c7ef0709777|https://github.com/pytorch/vision
-centos|pytorch|torchvision|release/0.17|4fd856bfbcf59a4da3a91f0e12515c7ef0709777|https://github.com/pytorch/vision
+ubuntu|pytorch|apex|release/1.2.0|f8af327cad2f8d94401a9f6c21e716e586251506|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.2.0|f8af327cad2f8d94401a9f6c21e716e586251506|https://github.com/ROCm/apex
+ubuntu|pytorch|torchvision|release/0.17|f74325507630b1fff230abdf618e03c8af17de89|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.17|f74325507630b1fff230abdf618e03c8af17de89|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.17|15e55dd73b5de8c179c7bd5cc9e2cc813830fb34|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.17|15e55dd73b5de8c179c7bd5cc9e2cc813830fb34|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.7|5e6f7b7dc5f8c8409a6a140f520a045da8700451|https://github.com/pytorch/data


### PR DESCRIPTION
Update `related_commits` for `release/2.2` to use torchvision with numpy<2 requirements from `ROCm/vision` repo
Also `ROCmSoftwarePlatform/apex` repo link was changed to `ROCm/apex`

Uses https://github.com/ROCm/vision/commit/f74325507630b1fff230abdf618e03c8af17de89