### PR TITLE
[release/1.13] CXX11 ABI fix to respect GLIBCXX_USE_CXX11_ABI=0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,14 +36,19 @@ endif()
 set(CMAKE_CXX_STANDARD 17 CACHE STRING "The C++ standard whose features are requested to build this target.")
 set(CMAKE_C_STANDARD   11 CACHE STRING "The C standard whose features are requested to build this target.")
 
-if(DEFINED GLIBCXX_USE_CXX11_ABI)
+# ---[ Utils
+include(cmake/public/utils.cmake)
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  include(cmake/CheckAbi.cmake)
+  string(APPEND CMAKE_CXX_FLAGS " -D_GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI}")
   if(${GLIBCXX_USE_CXX11_ABI} EQUAL 1)
     set(CXX_STANDARD_REQUIRED ON)
-    string(APPEND CMAKE_CXX_FLAGS " -D_GLIBCXX_USE_CXX11_ABI=1")
   else()
     # Please note this is required in order to ensure compatibility between gcc 9 and gcc 7
     # This could be removed when all Linux PyTorch binary builds are compiled by the same toolchain again
-    string(APPEND CMAKE_CXX_FLAGS " -fabi-version=11")
+    include(CheckCXXCompilerFlag)
+    append_cxx_flag_if_supported("-fabi-version=11" CMAKE_CXX_FLAGS)
   endif()
 endif()
 
@@ -633,9 +638,6 @@ if(INTERN_BUILD_MOBILE)
   # Enable it elsewhere to capture build error.
   set(INTERN_DISABLE_MOBILE_INTERP ON)
 endif()
-
-# ---[ Utils
-include(cmake/public/utils.cmake)
 
 # ---[ Version numbers for generated libraries
 file(READ version.txt TORCH_DEFAULT_VERSION)

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1192,31 +1192,8 @@ if(BUILD_TEST)
   endif()
 endif()
 
-# XXX This ABI check cannot be run with arm-linux-androideabi-g++
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-  if(DEFINED GLIBCXX_USE_CXX11_ABI)
-    message(STATUS "_GLIBCXX_USE_CXX11_ABI is already defined as a cmake variable")
-  else()
-    message(STATUS "${CMAKE_CXX_COMPILER} ${TORCH_SRC_DIR}/abi-check.cpp -o ${CMAKE_BINARY_DIR}/abi-check")
-    execute_process(
-      COMMAND
-      "${CMAKE_CXX_COMPILER}"
-      "${TORCH_SRC_DIR}/abi-check.cpp"
-      "-o"
-      "${CMAKE_BINARY_DIR}/abi-check"
-      RESULT_VARIABLE ABI_CHECK_COMPILE_RESULT)
-    if(ABI_CHECK_COMPILE_RESULT)
-      message(FATAL_ERROR "Could not compile ABI Check: ${ABI_CHECK_COMPILE_RESULT}")
-    endif()
-    execute_process(
-      COMMAND "${CMAKE_BINARY_DIR}/abi-check"
-      RESULT_VARIABLE ABI_CHECK_RESULT
-      OUTPUT_VARIABLE GLIBCXX_USE_CXX11_ABI)
-    if(ABI_CHECK_RESULT)
-      message(WARNING "Could not run ABI Check: ${ABI_CHECK_RESULT}")
-    endif()
-  endif()
-  message(STATUS "Determined _GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI}")
+  include(../cmake/CheckAbi.cmake)
 endif()
 
 # CMake config for external projects.

--- a/cmake/CheckAbi.cmake
+++ b/cmake/CheckAbi.cmake
@@ -1,0 +1,27 @@
+if(DEFINED GLIBCXX_USE_CXX11_ABI)
+  message(STATUS "_GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI} is already defined as a cmake variable")
+  return()
+endif()
+
+# XXX This ABI check cannot be run with arm-linux-androideabi-g++
+message(STATUS "${CMAKE_CXX_COMPILER} ${PROJECT_SOURCE_DIR}/torch/abi-check.cpp -o ${CMAKE_BINARY_DIR}/abi-check")
+execute_process(
+  COMMAND
+  "${CMAKE_CXX_COMPILER}"
+  "${PROJECT_SOURCE_DIR}/torch/abi-check.cpp"
+  "-o"
+  "${CMAKE_BINARY_DIR}/abi-check"
+  RESULT_VARIABLE ABI_CHECK_COMPILE_RESULT)
+if(ABI_CHECK_COMPILE_RESULT)
+  message(FATAL_ERROR "Could not compile ABI Check: ${ABI_CHECK_COMPILE_RESULT}")
+  set(GLIBCXX_USE_CXX11_ABI 0)
+endif()
+execute_process(
+  COMMAND "${CMAKE_BINARY_DIR}/abi-check"
+  RESULT_VARIABLE ABI_CHECK_RESULT
+  OUTPUT_VARIABLE GLIBCXX_USE_CXX11_ABI)
+if(ABI_CHECK_RESULT)
+  message(WARNING "Could not run ABI Check: ${ABI_CHECK_RESULT}")
+  set(GLIBCXX_USE_CXX11_ABI 0)
+endif()
+message(STATUS "Determined _GLIBCXX_USE_CXX11_ABI=${GLIBCXX_USE_CXX11_ABI}")


### PR DESCRIPTION
Fixes issue whereby setting the `_GLIBCXX_USE_CXX11_ABI` env var (and thus the Cmake define `GLIBCXX_USE_CXX11_ABI`) would still not explicitly set the compiler cxx flags
