### PR TITLE
[release/2.2] SWDEV-472761: limit sympy version to 1.12.1 or lower

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests
 setuptools
 types-dataclasses
 typing-extensions>=4.8.0
-sympy
+sympy<=1.12.1
 filelock
 networkx
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -1070,7 +1070,7 @@ def main():
     install_requires = [
         "filelock",
         "typing-extensions>=4.8.0",
-        "sympy",
+        "sympy<=1.12.1",
         "networkx",
         "jinja2",
         "fsspec",


### PR DESCRIPTION
(cherry picked from rocm6.2_internal_testing branch, commit 1feb1a81136120c40dd0e68d38829109eb16af03)

fix for:

- test_dynamic_shapes.py::TestFloorDiv::test_floordiv_*
- test_dynamic_shapes.py::TestPySymInt::test_sym_*
