### PR TITLE
[Release 2.0] [SWDEV-461863] Temporarily increased compile time limit of #GPUs to 120 

### DIFF
--- a/c10/cuda/CUDAMacros.h
+++ b/c10/cuda/CUDAMacros.h
@@ -39,6 +39,13 @@
 #endif
 
 /**
- * The maximum number of GPUs that we recognizes.
- */
+ * The maximum number of GPUs that we recognizes. Increasing this beyond the
+ * initial limit of 16 broke Caffe2 testing, hence the ifdef guards.
+ * This value cannot be more than 128 because our DeviceIndex is a uint8_t.
+o */
+#ifdef FBCODE_CAFFE2
+// fbcode depends on this value being 16
 #define C10_COMPILE_TIME_MAX_GPUS 16
+#else
+#define C10_COMPILE_TIME_MAX_GPUS 120
+#endif


### PR DESCRIPTION
This is an ongoing pain point of PyTorch - https://github.com/pytorch/pytorch/issues/115331%C2%A0

We will bring this change into the earlier release branches which will let us increase compile limit to 120 GPUs (setting this to 128 causes some issues according to upstream developers) https://github.com/pytorch/pytorch/pull/121076%C2%A0

Besides this there is ongoing work to increase max gpus to 512 by upstream developers https://github.com/pytorch/pytorch/pull/119639%C2%A0 but this is unable to be merged until caffe2 is removed via https://github.com/pytorch/pytorch/pull/122527.

I have left a comment asking for an update https://github.com/pytorch/pytorch/pull/119639#issuecomment-2242609917%C2%A0for now lets use the 120 limit and if required in the future we can see if we can get the draft fix enabled on our side, but I'm not sure if its possible for us to remove Caffe2 in our release branches before upstream does