### PR TITLE
[release/2.2] cudagraph explicit sync only after capture_begin()

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -117,9 +117,6 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
   capture_stream_ = stream;
   capture_gen_ = gen;
   capture_dev_ = c10::cuda::current_device();
-  #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
-    device_captured_ = true;
-  #endif
 
   id_ = capture_sequence_id();
 
@@ -362,7 +359,7 @@ CUDAGraph::~CUDAGraph() {
 // hipGraphLaunch are finished before we release any memory. This feature was enabled in rocm6.2. 
 // We need to ensure all async opreations finish before deleting the object. 
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
-  if (device_captured_)
+  if (capture_dev_ >= 0) // check if capture_dev_ contains the real device id
   {
     AT_CUDA_CHECK(cudaSetDevice(capture_dev_));
     AT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -117,6 +117,9 @@ void CUDAGraph::capture_begin(MempoolId_t pool/*=0*/, cudaStreamCaptureMode capt
   capture_stream_ = stream;
   capture_gen_ = gen;
   capture_dev_ = c10::cuda::current_device();
+  #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
+    device_captured_ = true;
+  #endif
 
   id_ = capture_sequence_id();
 
@@ -359,8 +362,11 @@ CUDAGraph::~CUDAGraph() {
 // hipGraphLaunch are finished before we release any memory. This feature was enabled in rocm6.2. 
 // We need to ensure all async opreations finish before deleting the object. 
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
-  AT_CUDA_CHECK(cudaSetDevice(capture_dev_));
-  AT_CUDA_CHECK(cudaDeviceSynchronize());
+  if (device_captured_)
+  {
+    AT_CUDA_CHECK(cudaSetDevice(capture_dev_));
+    AT_CUDA_CHECK(cudaDeviceSynchronize());
+  }
 #endif
 }
 

--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -359,7 +359,7 @@ CUDAGraph::~CUDAGraph() {
 // hipGraphLaunch are finished before we release any memory. This feature was enabled in rocm6.2. 
 // We need to ensure all async opreations finish before deleting the object. 
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
-  if (capture_dev_ >= 0) // check if capture_dev_ contains the real device id
+  if (capture_dev_ != UNDEFINED_DEVICE) // check if capture_dev_ contains the real device id
   {
     AT_CUDA_CHECK(cudaSetDevice(capture_dev_));
     AT_CUDA_CHECK(cudaDeviceSynchronize());

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -76,6 +76,9 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   // not CUDA itself.  We can straightforwardly modify CUDAGraph to support multi-device
   // captures if needed.
   int capture_dev_;
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
+  bool device_captured_ = false;
+#endif
 
   // RNG state trackers
   at::Tensor seed_extragraph_;

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -75,8 +75,9 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   // in a capture to run on the same device, but this is a limitation of CUDAGraph,
   // not CUDA itself.  We can straightforwardly modify CUDAGraph to support multi-device
   // captures if needed.
-  // init capture_dev_ as -1 to check that it stores the real device id in the destructor
-  int capture_dev_ = -1;
+  // init capture_dev_ as UNDEFINED_DEVICE to check that it stores the real device id in the destructor
+  static constexpr int UNDEFINED_DEVICE = -1;
+  int capture_dev_ = UNDEFINED_DEVICE;
 
   // RNG state trackers
   at::Tensor seed_extragraph_;

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -75,10 +75,8 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   // in a capture to run on the same device, but this is a limitation of CUDAGraph,
   // not CUDA itself.  We can straightforwardly modify CUDAGraph to support multi-device
   // captures if needed.
-  int capture_dev_;
-#if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
-  bool device_captured_ = false;
-#endif
+  // init capture_dev_ as -1 to check that it stores the real device id in the destructor
+  int capture_dev_ = -1;
 
   // RNG state trackers
   at::Tensor seed_extragraph_;


### PR DESCRIPTION
Fix CUDAGraph `HIP error: invalid device ordinal. Aborted (core dumped)` error after this PR https://github.com/ROCm/pytorch/pull/1471 for some CUDAGraph tests 

Tested on `test_cuda.py::TestCuda::test_graph_make_graphed_callables_*`
and `distributed/test_c10d_nccl.py::ProcessGroupNCCLTest::test_allreduce_in_cudagraph`

Skip device sync in the `~CUDAGraph()` destructor if `capture_begin()` method was not used and `capture_dev_` variable is not initialized
Additional bool variable `device_captured_` was introduced and used to track `capture_dev_` variable initialization for ROCm>=6.2. 
Also it can be done in another way using a magic value (-1) as not initialized `capture_dev_` value
