### PR TITLE
[release2.3] fix test_vmapvjpvjp and skip test_profiler_experimental_tree

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -840,6 +840,8 @@ class TestOperators(TestCase):
              {torch.float32: tol(atol=2e-03, rtol=2e-02)}),
         tol1('svd',
              {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
+        tol1('linalg.householder_product',
+             {torch.float32: tol(atol=5e-04, rtol=5e-04)}),
         tol1('matrix_exp',
              {torch.float32: tol(atol=1e-03, rtol=5e-04)}),
     ))

--- a/test/inductor/test_select_algorithm.py
+++ b/test/inductor/test_select_algorithm.py
@@ -107,6 +107,7 @@ class TestSelectAlgorithm(TestCase):
         )
         self.assertEqual(counters["inductor"]["select_algorithm_autotune"], 1)
 
+    @skipIfRocm
     @patches
     def test__int_mm(self):
         @torch.compile

--- a/test/profiler/test_profiler_tree.py
+++ b/test/profiler/test_profiler_tree.py
@@ -12,7 +12,7 @@ import expecttest
 import torch
 from torch._C._profiler import _ExtraFields_PyCall, _ExtraFields_PyCCall
 from torch.testing._internal.common_utils import (
-    TestCase, run_tests, IS_WINDOWS, TEST_WITH_CROSSREF, IS_ARM64, skipIfTorchDynamo)
+    skipIfRocm, TestCase, run_tests, IS_WINDOWS, TEST_WITH_CROSSREF, IS_ARM64, skipIfTorchDynamo)
 from torch.utils._pytree import tree_map
 
 # These functions can vary from based on platform and build (e.g. with CUDA)
@@ -247,6 +247,7 @@ class TestProfilerTree(TestCase):
                 else:
                     raise
 
+    @skipIfRocm
     @ProfilerTree.test
     def test_profiler_experimental_tree(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)
@@ -346,6 +347,7 @@ class TestProfilerTree(TestCase):
                       aten::copy_"""
         )
 
+    @skipIfRocm
     @ProfilerTree.test
     def test_profiler_experimental_tree_with_memory(self):
         t1, t2 = torch.ones(1, requires_grad=True), torch.ones(1, requires_grad=True)

--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -247,21 +247,24 @@ class TestFP8MatmulCuda(TestCase):
     @unittest.skipIf(not scaled_mm_supported_device(), f8_msg)
     def test_float8_basics(self, device) -> None:
         self._test_tautological_mm(device, e4m3_type, e4m3_type, size=16)
-        # hipblaslt does not yet support mixed e4m3_type input
         if torch.version.hip is None:
-            self._test_tautological_mm(device, e4m3_type, e5m2_type, size=32)
-            self._test_tautological_mm(device, e5m2_type, e4m3_type, size=48)
-        # According to https://docs.nvidia.com/cuda/cublas/#id99 8F_E5M2 MM is unsupported
-        with self.assertRaises(RuntimeError):
+            # According to https://docs.nvidia.com/cuda/cublas/#id99 8F_E5M2 MM is unsupported
+            with self.assertRaises(RuntimeError):
+                self._test_tautological_mm(device, e5m2_type, e5m2_type)
+        else:
             self._test_tautological_mm(device, e5m2_type, e5m2_type)
+
+
+        self._test_tautological_mm(device, e4m3_type, e5m2_type, size=32)
+        self._test_tautological_mm(device, e5m2_type, e4m3_type, size=48)
 
         self._test_tautological_mm(device, size=64, out_dtype=torch.float16)
         self._test_tautological_mm(device, size=96, out_dtype=torch.float32)
-        # hipblaslt does not yet support bfloat16 output
+        self._test_tautological_mm(device, size=80, out_dtype=torch.bfloat16)
+
         if torch.version.hip is None:
-            self._test_tautological_mm(device, size=80, out_dtype=torch.bfloat16)
-        with self.assertRaises(RuntimeError):
-            self._test_tautological_mm(device, out_dtype=e5m2_type)
+            with self.assertRaises(RuntimeError):
+                self._test_tautological_mm(device, out_dtype=e5m2_type)
 
     @unittest.skipIf(not scaled_mm_supported_device(), f8_msg)
     def test_float8_scale(self, device) -> None:


### PR DESCRIPTION
Fixes for SWDEV-462203 
cherry-picked from https://github.com/ROCm/pytorch/commit/bf4c47816ef0c631545973384fc704dca0f9523e
Skipping for 

- test/inductor/test_select_algorithm.py::TestSelectAlgorithm::test__int_mm

Cherry-picked from release/2.2 https://github.com/ROCm/pytorch/commit/0766b9c680c93bdd3516eed9ac65358df921d3a6
Skipping the following test

- profiler/test_profiler_tree.py:test_profiler_experimental_tree
- profiler/test_profiler_tree.py:test_profiler_experimental_tree_with_memory

Fixing

- functorch/test_ops.py:test_vmapvjpvjp_linalg_householder_product_cuda_float32 by adjusting the TOL value.

cherry-picked from rocm6.3_internal_testing https://github.com/ROCm/pytorch/commit/cb0e9ad04d09b4f28f984f47ce25b56880770bdb
Fixing

- test_matmul_cuda.py::TestFP8MatmulCudaCUDA::test_float8_basics

> 