### PR TITLE
[release/1.13] limit pytest version in requirements-ci.txt

### DIFF
--- a/.circleci/docker/requirements-ci.txt
+++ b/.circleci/docker/requirements-ci.txt
@@ -144,7 +144,7 @@ psutil
 #Pinned versions:
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
 
-pytest
+pytest==7.3.2
 #Description: testing framework
 #Pinned versions:
 #test that import: test_typing.py, test_cpp_extensions_aot.py, run_test.py


### PR DESCRIPTION
limits `pytest==7.3.2' in .ci/docker/requirements-ci.txt file like in [release/2.1+](https://github.com/ROCm/pytorch/blob/9712f03685c162337c2b15c75821b22592456e5d/.ci/docker/requirements-ci.txt#L143)
 

Fix some distributed tests from https://ontrack-internal.amd.com/browse/SWDEV-471962
```
FAILED distributed/pipeline/sync/test_pipe.py::test_batch_size_indivisible - TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
FAILED distributed/pipeline/sync/test_pipe.py::test_batch_size_small - TypeError: exceptions must be derived from Warning, not <class 'NoneType'>
```

verified in the test build http://rocm-ci.amd.com/job/framework-pytorch-2.2-ci_rel-6.2/46/
```
distributed/pipeline/sync/test_pipe.py::test_batch_size_indivisible PASSED
distributed/pipeline/sync/test_pipe.py::test_batch_size_small PASSED 
```

@jithunnair-amd do I need to fix pytorch 2.0 also? release/2.1 and higher already contains `pytest==7.3.2' constrain in requirements-ci.txt