### PR TITLE
[release/2.0] cudagraph explicit sync only after capture_begin() (#1492)

### DIFF
--- a/aten/src/ATen/cuda/CUDAGraph.cpp
+++ b/aten/src/ATen/cuda/CUDAGraph.cpp
@@ -324,8 +324,11 @@ CUDAGraph::~CUDAGraph() {
 // hipGraphLaunch are finished before we release any memory. This feature was enabled in rocm6.2. 
 // We need to ensure all async opreations finish before deleting the object. 
 #if (defined(USE_ROCM) && ROCM_VERSION >= 60200)
-  AT_CUDA_CHECK(cudaSetDevice(capture_dev_));
-  AT_CUDA_CHECK(cudaDeviceSynchronize());
+  if (capture_dev_ != UNDEFINED_DEVICE) // check if capture_dev_ contains the real device id
+  {
+    AT_CUDA_CHECK(cudaSetDevice(capture_dev_));
+    AT_CUDA_CHECK(cudaDeviceSynchronize());
+  }
 #endif
 }
 

--- a/aten/src/ATen/cuda/CUDAGraph.h
+++ b/aten/src/ATen/cuda/CUDAGraph.h
@@ -68,7 +68,9 @@ struct TORCH_CUDA_CPP_API CUDAGraph {
   // in a capture to run on the same device, but this is a limitation of CUDAGraph,
   // not CUDA itself.  We can straightforwardly modify CUDAGraph to support multi-device
   // captures if needed.
-  int capture_dev_;
+  // init capture_dev_ as UNDEFINED_DEVICE to check that it stores the real device id in the destructor
+  static constexpr int UNDEFINED_DEVICE = -1;
+  int capture_dev_ = UNDEFINED_DEVICE;
 
   // RNG state trackers
   at::Tensor seed_extragraph_;


### PR DESCRIPTION
Skip device sync in the ~CUDAGraph() destructor if capture_begin() method was not used and capture_dev_ variable is not initialized
* cudagraph explicit sync only after capture_begin

* use 'capture_dev_=-1' as not initialized value

* use named constant instead of magic '-1' value

(cherry picked from release/2.2 commit eb433b9aa6433632df92e1a1d728f00f56212ed2)


