### PR TITLE
[release/2.2][SWDEV-476861] Skip test_aot_inductor distributed UTs

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -293,8 +293,11 @@ test_inductor_distributed() {
   # Smuggle a few multi-gpu tests here so that we don't have to request another large node
   echo "Testing multi_gpu tests in test_torchinductor"
   pytest test/inductor/test_torchinductor.py -k test_multi_gpu
-  pytest test/inductor/test_aot_inductor.py -k test_non_default_cuda_device
-  pytest test/inductor/test_aot_inductor.py -k test_replicate_on_devices
+  #test_aot_inductor is not supported in release/2.2.
+  if [[ "$BUILD_ENVIRONMENT" != *rocm* ]]; then
+    pytest test/inductor/test_aot_inductor.py -k test_non_default_cuda_device
+    pytest test/inductor/test_aot_inductor.py -k test_replicate_on_devices
+  fi
   pytest test/distributed/_tensor/test_dtensor_compile.py
   pytest test/distributed/tensor/parallel/test_fsdp_2d_parallel.py
 


### PR DESCRIPTION
test_aot_inductor was not enabled in 2.2, however, there are direct calls to run test_aot_inductor UTs in inductor_distributed.

Fixes #ISSUE_NUMBER
