### PR TITLE
[release/1.13] pin pillow version to 10.3.0

### DIFF
--- a/.circleci/docker/requirements-ci.txt
+++ b/.circleci/docker/requirements-ci.txt
@@ -129,7 +129,7 @@ opt-einsum==3.3
 #Pinned versions: 3.3
 #test that import: test_linalg.py
 
-#pillow
+#pillow==10.3.0
 #Description:  Python Imaging Library fork
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
Fix "numpy.typing has no attribute NDArray" for release/1.13
The latest version of `pillow` 10.4.0 uses a higher version of `numpy` (https://github.com/python-pillow/Pillow/blob/9b4fae77178e827ab17118fbc89c739ffd6a0fab/src/PIL/_typing.py#L10)