### PR TITLE
[release/2.0] pin sympy==1.12.1 in the requirements-ci.txt file

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,6 +15,12 @@ click
 #Pinned versions:
 #test that import:
 
+sympy==1.12.1
+#Description: Python library for symbolic mathematics
+# installed before coremltools to avoid installation of greater sympy version
+#Pinned versions: 1.12.1
+#test that import:
+
 coremltools==5.0b5
 #Description: Apple framework for ML integration
 #Pinned versions: 5.0b5


### PR DESCRIPTION
Just pin sympy==1.12.1 in the requirements-ci.txt file to fix some **dynamic_shapes** tests
