### PR TITLE
Update requirements-ci.txt

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -308,7 +308,7 @@ pywavelets==1.5.0 ; python_version >= "3.12"
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==5.0.0.
+lxml==5.0.0
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries


### PR DESCRIPTION
To fix SWDEV-478957


It seems 3rd party issue.  While running https://github.com/ROCm/pytorch/blob/rocm6.2_internal_testing/.ci/docker/common/install_conda.sh ,

https://github.com/ROCm/pytorch/blob/658ccaae6b9b6d481c682876a051e9fabcbae223/.ci/docker/requirements-ci.txt#L311  line looks having incoorect syntax:

lxml==5.0.0.

05:03:44  + as_jenkins conda run -n py_3.10 pip install --progress-bar off -r /opt/conda/requirements-ci.txt
05:03:44  + sudo -E -H -u jenkins env -u SUDO_UID -u SUDO_GID -u SUDO_COMMAND -u SUDO_USER env PATH=/opt/conda/bin:/opt/conda/envs/py_3.10/bin:/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin LD_LIBRARY_PATH= conda run -n py_3.10 pip install --progress-bar off -r /opt/conda/requirements-ci.txt
05:03:44  [0m[91mERROR: Invalid requirement: 'lxml==5.0.0.': Expected end or semicolon (after version specifier)
05:03:44      lxml==5.0.0.
05:03:44          ~~~~~~~^ (from line 311 of /opt/conda/requirements-ci.txt)
05:03:44  
05:03:44  ERROR conda.cli.main_run:execute(125): `conda run pip install --progress-bar off -r /opt/conda/requirements-ci.txt` failed. (See above for error)
05:03:45  [0mThe command '/bin/sh -c bash ./install_conda.sh && rm install_conda.sh common_utils.sh /opt/conda/requirements-ci.txt' returned a non-zero code: 1
