### PR TITLE
[SWDEV-477447] Set _HAS_PYNVML to false if amdsmi not installed

### DIFF
--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -64,6 +64,7 @@ try:
 
         _HAS_PYNVML = True
     except ModuleNotFoundError:
+        _HAS_PYNVML = False
         pass
 except ImportError as err:
     _PYNVML_ERR = err  # sometimes a lib is installed but the import fails for some other reason, so we log the error for later

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -54,17 +54,13 @@ _HAS_PYNVML = False
 _PYNVML_ERR = None
 try:
     try:
-        import pynvml  # type: ignore[import]
+        if not torch.version.hip:
+            import pynvml  # type: ignore[import]
+        else:
+            import amdsmi  # type: ignore[import]
 
         _HAS_PYNVML = True
     except ModuleNotFoundError:
-        pass
-    try:
-        import amdsmi  # type: ignore[import]
-
-        _HAS_PYNVML = True
-    except ModuleNotFoundError:
-        _HAS_PYNVML = False
         pass
 except ImportError as err:
     _PYNVML_ERR = err  # sometimes a lib is installed but the import fails for some other reason, so we log the error for later


### PR DESCRIPTION
Fix from https://github.com/pytorch/pytorch/pull/132990 cherry picked into 6.2 to be resolved for 6.2.1

"""
This is a bugfix that was recently encountered in ROCm/Deepspeed. Currently if a library installs pynvml and runs on ROCm pytorch will break as _HAS_PYNVML is set to true and it will attempt to use amdsmi library for the device_count call which will not be installed.

This fix will set _HAS_PYNVML to false on ROCm if amdsmi is not installed.
"""

Will need to be cherry picked to release/2.3 and rocm6.3_internal_testing also