### PR TITLE
[release/1.13] pin pillow version to 10.3.0

### DIFF
--- a/.circleci/docker/requirements-ci.txt
+++ b/.circleci/docker/requirements-ci.txt
@@ -129,9 +129,9 @@ opt-einsum==3.3
 #Pinned versions: 3.3
 #test that import: test_linalg.py
 
-#pillow==10.3.0
+pillow==10.3.0
 #Description:  Python Imaging Library fork
-#Pinned versions:
+#Pinned versions: 10.3.0
 #test that import:
 
 protobuf==3.20.2


### PR DESCRIPTION
Fixed a typo from https://github.com/ROCm/pytorch/pull/1524
Now the version should be properly pinned
