### PR TITLE
[release/2.3] Use newer version of optree for py3.12+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,6 @@ fsspec==2024.6.1
 # setuptools was removed from default python install
 setuptools==69.5.1 ; python_version >= "3.12"
 packaging==24.1
-optree==0.9.1
+optree==0.9.1 ; python_version < "3.12"
+optree==0.10.0 ; python_version >= "3.12"
 lark==0.12.0


### PR DESCRIPTION
To resolve issue when building triton for py3.12 eg. http://rocm-ci.amd.com/blue/organizations/jenkins/framework-pytorch-ci-phantom_rel-6.2/detail/framework-pytorch-ci-phantom_rel-6.2/41/pipeline/:
```
[2024-08-16T23:15:02.632Z]       downloading and extracting https://oaitriton.blob.core.windows.net/public/llvm-builds/llvm-ed4e505c-ubuntu-x64.tar.gz ...
[2024-08-16T23:15:02.632Z]       error: HTTP Error 404: The specified blob does not exist.
[2024-08-16T23:15:02.632Z]       [end of output]
```