### PR TITLE
[release/2.4] Use shared library tarball for aotriton for CI base docker image

### DIFF
--- a/.ci/docker/common/install_aotriton.sh
+++ b/.ci/docker/common/install_aotriton.sh
@@ -2,14 +2,12 @@
 
 set -ex
 
-source "$(dirname "${BASH_SOURCE[0]}")/common_utils.sh"
-
 TARBALL='aotriton.tar.bz2'
 # This read command alwasy returns with exit code 1
 read -d "\n" VER MANYLINUX ROCMBASE PINNED_COMMIT SHA256 < aotriton_version.txt || true
 ARCH=$(uname -m)
 AOTRITON_INSTALL_PREFIX="$1"
-AOTRITON_URL="https://github.com/ROCm/aotriton/releases/download/${VER}/aotriton-${VER}-${MANYLINUX}_${ARCH}-${ROCMBASE}.tar.bz2"
+AOTRITON_URL="https://github.com/ROCm/aotriton/releases/download/${VER}/aotriton-${VER}-${MANYLINUX}_${ARCH}-${ROCMBASE}-shared.tar.bz2"
 
 cd "${AOTRITON_INSTALL_PREFIX}"
 # Must use -L to follow redirects


### PR DESCRIPTION
Fixes sha256sum mismatch issues eg. http://rocm-ci.amd.com/blue/organizations/jenkins/framework-pytorch-2.4-ci_rel-6.2/detail/framework-pytorch-2.4-ci_rel-6.2/4/pipeline

Tested via: http://rocm-ci.amd.com/job/framework-pytorch-2.4-ci_rel-6.2/6/