### PR TITLE
Adjust max values per thread for AMDGPU.

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -1092,7 +1092,7 @@ ReduceConfig setReduceConfig(const TensorIterator& iter){
   }
 
   constexpr int min_values_per_thread = 16;
-  constexpr int max_values_per_thread = 256;
+  constexpr int max_values_per_thread = 1024;
 
   if (config.values_per_thread() >= block_height * 16 || config.values_per_thread() >= max_values_per_thread) {
     // Divide the input across warps in a thread-block, if that leaves at least


### PR DESCRIPTION
Benchmark results shows that with max_values_per_thread set to 1024, we reach 98% of NVIDIA H100 performance for reductions.

Fixes SWDEV-478485
