### PR TITLE
[release/2.3] skip inductor/test_pad_mm.py::test_pad_mm_dyn_* on MI300

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -11,7 +11,9 @@ from torch._inductor.fx_passes.pad_mm import get_alignment_size, get_padded_leng
 from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.inductor_utils import HAS_CUDA
+from torch.testing._internal.common_utils import skipIfRocmArch
 
+MI300_ARCH = ("gfx940", "gfx942") # Used for MI300 exclusive skips on ROCm
 
 class PadMMTest(TestCase):
     def test_pad_preserves_output_stride(
@@ -102,6 +104,7 @@ class PadMMTest(TestCase):
                             ), "config.keep_output_stride is being violated by shape padding"
                             # ADDMM outputs are made contiguous, and therefore not aligned in preexisting impl.
 
+    @skipIfRocmArch(MI300_ARCH)
     @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     @inductor_config.patch(
         max_autotune=True,
@@ -180,6 +183,7 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
+    @skipIfRocmArch(MI300_ARCH)
     @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     @inductor_config.patch(
         max_autotune=True,
@@ -213,6 +217,7 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
+    @skipIfRocmArch(MI300_ARCH)
     @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     @inductor_config.patch(
         max_autotune=True,


### PR DESCRIPTION
skip test_pad_mm_dyn_[mnk] on MI300
https://ontrack-internal.amd.com/browse/SWDEV-462203

tests can be enabled after closing https://github.com/ROCm/frameworks-internal/issues/8803
