### PR TITLE
[release/2.3] skip test_typing if numpy less then 1.21 (#1563)

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -4,6 +4,7 @@ import argparse
 import copy
 import glob
 import json
+import numpy
 import os
 import pathlib
 import re
@@ -16,6 +17,7 @@ import time
 from collections import defaultdict
 from contextlib import ExitStack
 from datetime import datetime
+from packaging.version import Version
 from typing import Any, cast, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import pkg_resources
@@ -177,6 +179,9 @@ ROCM_BLOCKLIST = [
     "test_cuda_nvml_based_avail",
     "test_jit_cuda_fuser",
 ]
+# Remove test_typing if python version is 3.9.* or less
+if Version(numpy.__version__) < Version('1.21'):
+    ROCM_BLOCKLIST.extend(["test_typing"])
 
 XPU_BLOCKLIST = [
     "test_autograd",


### PR DESCRIPTION
Skip test_typing to avoid `Error importing plugin
"numpy.typing.mypy_plugin": No module named 'numpy.typing.mypy_plugin'` It happens because we have numpy==1.20.3 in some of our images. But `mypy` can be used only witn numpy>=1.21
We have numpy==1.20.3 in our images with python3.9

Will check numpy version in run_tests.py and add test_typing to ROCM_BLOCKLIST if numpy version less then 1.21

Fix https://github.com/ROCm/frameworks-internal/issues/8497

(cherry picked from commit 3b54c4556df4682e4a7b71d1006c2984071ea212)

Fixes #ISSUE_NUMBER
