### PR TITLE
[ROCm] Add support for SymmetricMemory

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -601,10 +601,6 @@ if(USE_ROCM)
     append_filelist("libtorch_cuda_distributed_base_sources" Caffe2_HIP_SRCS)
     if(NOT WIN32)
       append_filelist("libtorch_cuda_distributed_extra_sources" Caffe2_HIP_SRCS)
-      set_source_files_properties(
-        ${TORCH_SRC_DIR}/csrc/distributed/c10d/intra_node_comm.cpp
-        PROPERTIES COMPILE_FLAGS "-DPYTORCH_C10_DRIVER_API_SUPPORTED=1"
-      )
     endif()
   endif()
   # caffe2_nvrtc's stubs to driver APIs are useful for HIP.

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -64,6 +64,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
     TEST_WITH_ROCM,
     TestCase,
+    MI300_ARCH,
+    runOnRocmArch,
 )
 
 
@@ -2727,6 +2729,7 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
+    @runOnRocmArch(MI300_ARCH)
     def test_intra_node_comm_all_reduce(self):
         from torch._C._distributed_c10d import _get_intra_node_comm_usage_counter
         from torch.testing._internal.common_cuda import SM80OrLater

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -2727,7 +2727,6 @@ class CommTest(test_c10d_common.AbstractCommTest, MultiProcessTestCase):
 
     @requires_nccl()
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm
     def test_intra_node_comm_all_reduce(self):
         from torch._C._distributed_c10d import _get_intra_node_comm_usage_counter
         from torch.testing._internal.common_cuda import SM80OrLater

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -22,6 +22,8 @@ from torch.testing._internal.common_utils import (
     run_tests,
     skip_but_pass_in_sandcastle_if,
     skipIfRocm,
+    MI300_ARCH,
+    runOnRocmArch
 )
 
 
@@ -105,6 +107,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         for row in connectivity.matrix:
             self.assertEqual(len(row), torch.cuda.device_count())
 
+    @runOnRocmArch(MI300_ARCH)
     @skip_if_lt_x_gpu(2)
     def test_empty_strided_p2p(self) -> None:
         self._init_process()
@@ -126,6 +129,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         self._verify_symmetric_memory(symm_mem)
         dist.destroy_process_group()
 
+    @runOnRocmArch(MI300_ARCH)
     @skip_if_lt_x_gpu(2)
     def test_empty_strided_p2p_persistent(self) -> None:
         self._init_process()
@@ -165,6 +169,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         self._verify_symmetric_memory(symm_mem_0)
         dist.destroy_process_group()
 
+    @runOnRocmArch(MI300_ARCH)
     @skip_if_lt_x_gpu(2)
     @parametrize("gather_dim", [0, 1])
     def test_fused_all_gather_matmul(self, gather_dim: int) -> None:
@@ -265,6 +270,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
 
         dist.destroy_process_group()
 
+    @runOnRocmArch(MI300_ARCH)
     @skip_if_lt_x_gpu(2)
     @parametrize("scatter_dim", [0, 1])
     def test_fused_matmul_reduce_scatter(self, scatter_dim: int) -> None:
@@ -340,6 +346,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
 
         dist.destroy_process_group()
 
+    @runOnRocmArch(MI300_ARCH)
     @parametrize("dim", [0, 1, 2])
     def test_optimal_layout(self, dim: int) -> None:
         t = torch.rand(8, 64, 32, 16)
@@ -352,6 +359,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         self.assertTrue(x.movedim(dim, 0).is_contiguous())
         self.assertTrue(torch.allclose(x, t))
 
+    @runOnRocmArch(MI300_ARCH)
     @skip_if_lt_x_gpu(2)
     @parametrize("symm_mem_input", [True, False])
     def test_low_contention_all_gather(self, symm_mem_input: bool) -> None:
@@ -381,6 +389,7 @@ class SymmetricMemoryTest(MultiProcessTestCase):
     @skip_if_lt_x_gpu(2)
     @parametrize("reduce_op", ["sum", "avg"])
     @parametrize("symm_mem_input", [True, False])
+    @runOnRocmArch(MI300_ARCH)
     def test_low_contention_reduce_scatter(
         self, reduce_op: str, symm_mem_input: bool
     ) -> None:

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -105,7 +105,6 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         for row in connectivity.matrix:
             self.assertEqual(len(row), torch.cuda.device_count())
 
-    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     def test_empty_strided_p2p(self) -> None:
         self._init_process()
@@ -127,7 +126,6 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         self._verify_symmetric_memory(symm_mem)
         dist.destroy_process_group()
 
-    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     def test_empty_strided_p2p_persistent(self) -> None:
         self._init_process()
@@ -167,7 +165,6 @@ class SymmetricMemoryTest(MultiProcessTestCase):
         self._verify_symmetric_memory(symm_mem_0)
         dist.destroy_process_group()
 
-    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("gather_dim", [0, 1])
     def test_fused_all_gather_matmul(self, gather_dim: int) -> None:
@@ -268,7 +265,6 @@ class SymmetricMemoryTest(MultiProcessTestCase):
 
         dist.destroy_process_group()
 
-    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @parametrize("scatter_dim", [0, 1])
     def test_fused_matmul_reduce_scatter(self, scatter_dim: int) -> None:

--- a/torch/csrc/distributed/c10d/CUDASymmetricMemory.cu
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemory.cu
@@ -7,6 +7,8 @@
 
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 #include <c10/cuda/driver_api.h>
+#elif defined(USE_ROCM)
+#include <hip/hip_runtime_api.h>
 #endif
 
 #include <sys/socket.h>
@@ -27,6 +29,7 @@ class IpcChannel {
     struct sockaddr_un addr = {.sun_family = AF_UNIX};
     std::copy(socket_name_.begin(), socket_name_.end(), addr.sun_path);
 
+    unlink(addr.sun_path);
     TORCH_CHECK(
         bind(socket_, (struct sockaddr*)&addr, SUN_LEN(&addr)) == 0,
         "Failed to bind socket: ",
@@ -39,27 +42,34 @@ class IpcChannel {
   }
 
   void send_fd(int dst_pid, int fd) {
+    //Define destination socket address
     struct sockaddr_un addr = {.sun_family = AF_UNIX};
     auto socket_name = get_socket_name(dst_pid);
     std::copy(socket_name.begin(), socket_name.end(), addr.sun_path);
 
+    //Prepare data to send
+    //Data being sent is "fd", the value of fd will be sent as auxiliary data (control message)
     struct iovec io = {.iov_base = (void*)("fd"), .iov_len = 2};
 
+    //Prepare control message data buffer and zero it out
     char cbuf[CMSG_SPACE(sizeof(int))];
     memset(cbuf, 0, sizeof(cbuf));
 
+    //Create message header
     struct msghdr msg {
-      .msg_name = (void*)&addr, .msg_namelen = sizeof(struct sockaddr_un),
-      .msg_iov = &io, .msg_iovlen = 1, .msg_control = cbuf,
-      .msg_controllen = sizeof(cbuf)
+      .msg_name = (void*)&addr, .msg_namelen = sizeof(struct sockaddr_un), //destination socket address and size of it
+      .msg_iov = &io, .msg_iovlen = 1, //message content in msg_iov and number of such structs (1 in our case)
+      .msg_control = cbuf, .msg_controllen = sizeof(cbuf) //auxiliary data with the value of fd and size of it
     };
 
+    //Fill in auxiliary data
     auto cmsg = CMSG_FIRSTHDR(&msg);
     cmsg->cmsg_len = CMSG_LEN(sizeof(int));
-    cmsg->cmsg_level = SOL_SOCKET;
-    cmsg->cmsg_type = SCM_RIGHTS;
+    cmsg->cmsg_level = SOL_SOCKET; //Specify socket level message
+    cmsg->cmsg_type = SCM_RIGHTS;  //SCM_RIGHTS is the type used to pass file descriptors
     memcpy(CMSG_DATA(cmsg), &fd, sizeof(fd));
 
+    //Finally send the the message
     TORCH_CHECK(
         sendmsg(socket_, &msg, 0) > 0,
         "Failed to send fd: ",
@@ -67,23 +77,34 @@ class IpcChannel {
   }
 
   int recv_fd() {
+    //Prepare buffer for regular message "fd"
     char buf[2];
+    memset(&buf, 0, sizeof(buf));
     struct iovec io = {.iov_base = (void*)buf, .iov_len = sizeof(buf)};
 
+    //Prepare buffer for control message and zero it out
     char cbuf[CMSG_SPACE(sizeof(int))];
     memset(cbuf, 0, sizeof(cbuf));
 
+    struct sockaddr_un addr = {.sun_family = AF_UNIX};
+    std::copy(socket_name_.begin(), socket_name_.end(), addr.sun_path);
+
+    //Prepare message header
     struct msghdr msg = {
+        .msg_name = (void*)&addr,
+        .msg_namelen = sizeof(struct sockaddr_un),
         .msg_iov = &io,
         .msg_iovlen = 1,
         .msg_control = cbuf,
         .msg_controllen = sizeof(cbuf)};
 
+    //Recieve message on socket_
     TORCH_CHECK(
         recvmsg(socket_, &msg, 0) > 0,
         "Failed to receive fd: ",
         strerror(errno));
 
+    //Extract control message and validate its content
     auto cmsg = CMSG_FIRSTHDR(&msg);
     TORCH_CHECK(cmsg != NULL);
     TORCH_CHECK(cmsg->cmsg_len == CMSG_LEN(sizeof(int)));
@@ -197,6 +218,16 @@ void map_block(
   desc.location.id = static_cast<int>(device_idx);
   desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
   C10_CUDA_DRIVER_CHECK(driver_api->cuMemSetAccess_(*dev_ptr, size, &desc, 1));
+#elif defined(USE_ROCM)
+  C10_HIP_CHECK(hipMemAddressReserve(ptr, size, 0ULL, 0, 0ULL));
+  C10_HIP_CHECK(hipMemMap(*ptr, size, 0, reinterpret_cast<hipMemGenericAllocationHandle_t>(handle), 0ULL));
+
+  hipMemAccessDesc desc;
+  desc.location.type = hipMemLocationTypeDevice;
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+  desc.location.id = static_cast<int>(device_idx);
+  desc.flags =  hipMemAccessFlagsProtReadWrite;
+  C10_HIP_CHECK(hipMemSetAccess(*ptr, size, &desc, 1));
 #else
   TORCH_CHECK(
       false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
@@ -239,7 +270,6 @@ CUDASymmetricMemory::CUDASymmetricMemory(
 }
 
 CUDASymmetricMemory::~CUDASymmetricMemory() {
-#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
   // Leak the cuda allocations during static deinitialization
   if (is_finalizing()) {
     return;
@@ -247,18 +277,24 @@ CUDASymmetricMemory::~CUDASymmetricMemory() {
   c10::cuda::CUDAGuard guard(local_device_idx_);
   C10_CUDA_CHECK(cudaDeviceSynchronize());
 
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
   auto driver_api = c10::cuda::DriverAPI::get();
   for (int r = 0; r < world_size_; ++r) {
     C10_CUDA_DRIVER_CHECK(driver_api->cuMemUnmap_(
         reinterpret_cast<CUdeviceptr>(buffers_[r]), block_size_));
     C10_CUDA_DRIVER_CHECK(driver_api->cuMemRelease_(handles_[r]));
   }
-  c10::cuda::CUDACachingAllocator::raw_delete(buffers_dev_);
-  c10::cuda::CUDACachingAllocator::raw_delete(signal_pads_dev_);
+#elif defined(USE_ROCM)
+  for (int r = 0; r < world_size_; ++r) {
+    C10_HIP_CHECK(hipMemUnmap(buffers_[r], block_size_));
+    C10_HIP_CHECK(hipMemRelease(reinterpret_cast<hipMemGenericAllocationHandle_t>(handles_[r])));
+  }
 #else
   TORCH_CHECK(
       false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
 #endif
+  c10::cuda::CUDACachingAllocator::raw_delete(buffers_dev_);
+  c10::cuda::CUDACachingAllocator::raw_delete(signal_pads_dev_);
 }
 
 std::vector<void*> CUDASymmetricMemory::get_buffer_ptrs() {
@@ -328,7 +364,7 @@ void check_channel(int channel, int world_size) {
 }
 
 __device__ __forceinline__ void release_signal(uint32_t* addr) {
-#if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
   CUDA_KERNEL_ASSERT(false);
 #else
   volatile uint32_t* signal = addr;
@@ -340,7 +376,7 @@ __device__ __forceinline__ void release_signal(uint32_t* addr) {
 }
 
 __device__ __forceinline__ void acquire_signal(uint32_t* addr) {
-#if defined(USE_ROCM) || (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
   CUDA_KERNEL_ASSERT(false);
 #else
   volatile uint32_t* signal = addr;
@@ -433,6 +469,10 @@ void* CUDASymmetricMemoryAllocator::alloc(
     size_t size,
     int device_idx,
     const std::string& group_name) {
+  
+  size_t signal_pad_offset = at::round_up(size, 16UL);
+  size_t block_size = signal_pad_offset + signal_pad_size;
+
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
   auto driver_api = c10::cuda::DriverAPI::get();
 
@@ -443,8 +483,6 @@ void* CUDASymmetricMemoryAllocator::alloc(
   prop.location.id = device_idx;
   prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
 
-  size_t signal_pad_offset = at::round_up(size, 16UL);
-  size_t block_size = signal_pad_offset + signal_pad_size;
 
   size_t granularity;
   C10_CUDA_DRIVER_CHECK(driver_api->cuMemGetAllocationGranularity_(
@@ -455,6 +493,25 @@ void* CUDASymmetricMemoryAllocator::alloc(
   C10_CUDA_DRIVER_CHECK(
       driver_api->cuMemCreate_(&handle, block_size, &prop, 0));
 
+#elif defined(USE_ROCM)
+  hipMemAllocationProp prop = {};
+  prop.type = hipMemAllocationTypePinned;
+  prop.location.type = hipMemLocationTypeDevice;
+  // NOLINTNEXTLINE(bugprone-signed-char-misuse)
+  prop.location.id = device_idx;
+  prop.requestedHandleType = hipMemHandleTypePosixFileDescriptor;
+  size_t granularity;
+  C10_HIP_CHECK(hipMemGetAllocationGranularity(
+      &granularity, &prop, hipMemAllocationGranularityRecommended));
+  block_size = at::round_up(block_size, granularity);
+
+  HandleType handle;
+  C10_HIP_CHECK(hipMemCreate(reinterpret_cast<hipMemGenericAllocationHandle_t*>(&handle), block_size, &prop, 0));
+
+#else
+  TORCH_CHECK(
+      false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
+#endif
   void* ptr = nullptr;
   map_block(&ptr, handle, block_size, device_idx);
 
@@ -468,14 +525,9 @@ void* CUDASymmetricMemoryAllocator::alloc(
     ptr_to_block_.emplace(ptr, std::move(block));
   }
   return ptr;
-#else
-  TORCH_CHECK(
-      false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
-#endif
 }
 
 void CUDASymmetricMemoryAllocator::free(void* ptr) {
-#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
   auto block = find_block(ptr);
   // Leak the cuda allocations during static deinitialization
   if (block == nullptr || is_finalizing()) {
@@ -484,19 +536,23 @@ void CUDASymmetricMemoryAllocator::free(void* ptr) {
   // Initializing CUDASymmetricMemory with an allocation transfers its
   // ownership to the CUDASymmetricMemory object.
   if (block->symm_mem == nullptr) {
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
     auto driver_api = c10::cuda::DriverAPI::get();
     C10_CUDA_DRIVER_CHECK(driver_api->cuMemUnmap_(
         reinterpret_cast<CUdeviceptr>(ptr), block->block_size));
     C10_CUDA_DRIVER_CHECK(driver_api->cuMemRelease_(block->handle));
+#elif defined(USE_ROCM)
+    C10_HIP_CHECK(hipMemUnmap(ptr, block->block_size));
+    C10_HIP_CHECK(hipMemRelease(reinterpret_cast<hipMemGenericAllocationHandle_t>(block->handle)));
+#else
+  TORCH_CHECK(
+      false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
+#endif
   }
   {
     std::unique_lock lock(mutex_);
     ptr_to_block_.erase(ptr);
   }
-#else
-  TORCH_CHECK(
-      false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
-#endif
 }
 
 size_t CUDASymmetricMemoryAllocator::get_alloc_size(void* ptr) {
@@ -543,7 +599,6 @@ void validate_rendezvous_requests(
 
 c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
     void* ptr) {
-#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
   auto block = find_block(ptr);
   if (block == nullptr) {
     return nullptr;
@@ -558,11 +613,19 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
   auto store = group_info.store;
   int rank = group_info.rank;
   int world_size = group_info.world_size;
-
-  auto driver_api = c10::cuda::DriverAPI::get();
   int block_fd;
+
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+  auto driver_api = c10::cuda::DriverAPI::get();
   C10_CUDA_DRIVER_CHECK(driver_api->cuMemExportToShareableHandle_(
       &block_fd, block->handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0));
+#elif defined (USE_ROCM)
+  C10_HIP_CHECK(hipMemExportToShareableHandle(
+      &block_fd, reinterpret_cast<hipMemGenericAllocationHandle_t>(block->handle), hipMemHandleTypePosixFileDescriptor, 0));
+#else
+  TORCH_CHECK(
+      false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
+#endif
 
   auto local_req = RendezvousRequest{
       .device_idx = block->device_idx,
@@ -590,10 +653,20 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
       signal_pads[r] = (void*)((uintptr_t)ptr + block->signal_pad_offset);
       continue;
     }
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
     C10_CUDA_DRIVER_CHECK(driver_api->cuMemImportFromShareableHandle_(
         &handles[r],
         (void*)(uintptr_t)imported_fds[r],
         CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR));
+#elif defined (USE_ROCM)
+    C10_HIP_CHECK(hipMemImportFromShareableHandle(
+        &handles[r],
+        (void*)(uintptr_t)&(imported_fds[r]),
+        hipMemHandleTypePosixFileDescriptor));
+#else
+  TORCH_CHECK(
+      false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
+#endif
     map_block(&buffers[r], handles[r], block->block_size, block->device_idx);
     signal_pads[r] = (void*)((uintptr_t)buffers[r] + block->signal_pad_offset);
     close(imported_fds[r]);
@@ -615,10 +688,6 @@ c10::intrusive_ptr<SymmetricMemory> CUDASymmetricMemoryAllocator::rendezvous(
       group_info.rank,
       group_info.world_size);
   return block->symm_mem;
-#else
-  TORCH_CHECK(
-      false, "CUDASymmetricMemory requires PYTORCH_C10_DRIVER_API_SUPPORTED");
-#endif
 }
 
 bool CUDASymmetricMemoryAllocator::is_rendezvous_completed(void* ptr) {

--- a/torch/csrc/distributed/c10d/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemory.hpp
@@ -9,8 +9,10 @@ namespace symmetric_memory {
 
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 using HandleType = CUmemGenericAllocationHandle;
-#else
+#elif defined(USE_ROCM)
 using HandleType = hipMemGenericAllocationHandle_t;
+#else
+using HandleType = void*;
 #endif
 
 class CUDASymmetricMemory : public SymmetricMemory {

--- a/torch/csrc/distributed/c10d/CUDASymmetricMemory.hpp
+++ b/torch/csrc/distributed/c10d/CUDASymmetricMemory.hpp
@@ -10,7 +10,7 @@ namespace symmetric_memory {
 #if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
 using HandleType = CUmemGenericAllocationHandle;
 #else
-using HandleType = void*;
+using HandleType = hipMemGenericAllocationHandle_t;
 #endif
 
 class CUDASymmetricMemory : public SymmetricMemory {

--- a/torch/csrc/distributed/c10d/intra_node_comm.cpp
+++ b/torch/csrc/distributed/c10d/intra_node_comm.cpp
@@ -312,7 +312,7 @@ bool IntraNodeComm::rendezvous() {
   DevInfo devInfo{};
   gethostname(devInfo.hostname, sizeof(devInfo.hostname));
 
-#if defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
+#if defined(USE_ROCM)
   auto ret = rsmi_init(0);
   if (ret != RSMI_STATUS_SUCCESS) {
     LOG(ERROR) << "IntraNodeComm:: rendezvous failed in rsmi_init, ret=" << ret;
@@ -323,10 +323,10 @@ bool IntraNodeComm::rendezvous() {
   cudaDeviceProp prop{};
   AT_CUDA_CHECK(cudaGetDeviceProperties(&prop, deviceIdx_));
 
-#if defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
-  auto pci_format = "%08X:%02X:%02X.0";
-#else
+#if !defined(USE_ROCM) && defined(PYTORCH_C10_DRIVER_API_SUPPORTED)
   auto pci_format = NVML_DEVICE_PCI_BUS_ID_FMT;
+#else
+  auto pci_format = "%08X:%02X:%02X.0";
 #endif
 
   snprintf(


### PR DESCRIPTION
With the latest IFU into rocm6.3_internal_testing branch, we pulled in SymmetricMemory code which is being used by intra node communication also. SymmetricMemory also introduces a new memory allocator called CUDASymmetricMemoryAllocator. intra_node_comm is now using this new allocator to manage memory. 