### PR TITLE
[rocm6.2_internal_testing] add 'tlparse' to requirements-ci.txt for dynamo/test_structured_trace.py

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -255,6 +255,11 @@ tb-nightly==2.13.0a20230426
 #Pinned versions:
 #test that import:
 
+tlparse
+#Description: parse logs produced by torch.compile
+#Pinned versions:
+#test that import: dynamo/test_structured_trace.py
+
 # needed by torchgen utils
 typing-extensions
 #Description: type hints for python


### PR DESCRIPTION
install missed package `tlparse` for dynamo/test_structured_trace.py

Fixes: https://ontrack-internal.amd.com/browse/SWDEV-480494

