### PR TITLE
Sync requirements-ci.txt optree versions with requirements.txt for py3.12

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -140,7 +140,8 @@ opt-einsum==3.3
 #Pinned versions: 3.3
 #test that import: test_linalg.py
 
-optree==0.9.1
+optree==0.9.1 ; python_version < "3.12"
+optree==0.10.0 ; python_version >= "3.12"
 #Description: A library for tree manipulation
 #Pinned versions: 0.9.1
 #test that import: test_vmap.py, test_aotdispatch.py, test_dynamic_shapes.py,


### PR DESCRIPTION
Follow-up to https://github.com/ROCm/pytorch/pull/1544

Fixes issues seen with optree installation when QA installs `requirements-ci.txt` for testing py3.12 PyTorch wheels, since version 0.9.1 didn't have a py3.12 wheel, so it tries to build from source and fails:
[pytorch_wheel_hw_33.txt](https://github.com/user-attachments/files/16935708/pytorch_wheel_hw_33.txt)

```
Building wheels for collected packages: optree, scikit-image
  Building wheel for optree (pyproject.toml) ... error
  error: subprocess-exited-with-error

  � Building wheel for optree (pyproject.toml) did not run successfully.
  � exit code: 1
  ?-> [84 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build
      creating build/lib.linux-x86_64-cpython-312
      creating build/lib.linux-x86_64-cpython-312/optree
      copying optree/utils.py -> build/lib.linux-x86_64-cpython-312/optree
      copying optree/registry.py -> build/lib.linux-x86_64-cpython-312/optree
      copying optree/version.py -> build/lib.linux-x86_64-cpython-312/optree
      copying optree/typing.py -> build/lib.linux-x86_64-cpython-312/optree
      copying optree/__init__.py -> build/lib.linux-x86_64-cpython-312/optree
      copying optree/ops.py -> build/lib.linux-x86_64-cpython-312/optree
      running egg_info
      writing optree.egg-info/PKG-INFO
      writing dependency_links to optree.egg-info/dependency_links.txt
      writing requirements to optree.egg-info/requires.txt
      writing top-level names to optree.egg-info/top_level.txt
      reading manifest file 'optree.egg-info/SOURCES.txt'
      reading manifest template 'MANIFEST.in'
      adding license file 'LICENSE'
      writing manifest file 'optree.egg-info/SOURCES.txt'
      copying optree/_C.pyi -> build/lib.linux-x86_64-cpython-312/optree
      copying optree/py.typed -> build/lib.linux-x86_64-cpython-312/optree
      running build_ext
      x86_64-linux-gnu-g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O2 -Wall -fPIC -I/usr/include/python3.12 -c flagcheck.cpp -o flagcheck.o -std=c++17
      Traceback (most recent call last):
        File "/usr/lib/python3/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/usr/lib/python3/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/lib/python3/dist-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 251, in build_wheel
          return _build_backend().build_wheel(wheel_directory, config_settings,
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 421, in build_wheel
          return self._build_with_temp_dir(
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 403, in _build_with_temp_dir
          self.run_setup()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/build_meta.py", line 318, in run_setup
          exec(code, locals())
        File "<string>", line 107, in <module>
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/__init__.py", line 117, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/core.py", line 184, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/core.py", line 200, in run_commands
          dist.run_commands()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 954, in run_commands
          self.run_command(cmd)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/dist.py", line 950, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/command/bdist_wheel.py", line 384, in run
          self.run_command("build")
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/cmd.py", line 316, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/dist.py", line 950, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/command/build.py", line 135, in run
          self.run_command(cmd_name)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/cmd.py", line 316, in run_command
          self.distribution.run_command(command)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/dist.py", line 950, in run_command
          super().run_command(command)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/dist.py", line 973, in run_command
          cmd_obj.run()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/command/build_ext.py", line 98, in run
          _build_ext.run(self)
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/command/build_ext.py", line 359, in run
          self.build_extensions()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/pybind11/setup_helpers.py", line 287, in build_extensions
          super().build_extensions()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/command/build_ext.py", line 476, in build_extensions
          self._build_extensions_serial()
        File "/tmp/pip-build-env-1v06_758/overlay/local/lib/python3.12/dist-packages/setuptools/_distutils/command/build_ext.py", line 502, in _build_extensions_serial
          self.build_extension(ext)
        File "<string>", line 41, in build_extension
      RuntimeError: Cannot find CMake executable.
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for optree
  Building wheel for scikit-image (pyproject.toml) ... done
  Created wheel for scikit-image: filename=scikit_image-0.20.0-cp312-cp312-linux_x86_64.whl size=15059688 sha256=befd4df370d4e441f8af6fb2783f81aaffefe4de91f59343d13bf741706a08c8
  Stored in directory: /root/.cache/pip/wheels/05/07/6a/2459449b1daba6959acab22a4601aaceeb0903bf8b4c26b257
Successfully built scikit-image
Failed to build optree
```
