### PR TITLE
skip test_reduce_stress_cuda on ROCm as it fails on MI300

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -50,6 +50,7 @@ from torch.testing._internal.common_utils import (
     retry_on_connect_failures,
     run_tests,
     skip_but_pass_in_sandcastle,
+    skipIfRocm,
     TestCase,
 )
 
@@ -1340,6 +1341,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_reduce_stress(inputs)
 
+    @skipIfRocm()
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_reduce_stress_cuda(self):


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-469119

@pruthvistony this test pass on MI200 and fail on MI300 in several branches. 
Do I need to introduce skipIfRocmArch decorator?