### PR TITLE
[rocm6.2_internal_testing] revert add tlparse in requirements-ci.txt

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -255,11 +255,6 @@ tb-nightly==2.13.0a20230426
 #Pinned versions:
 #test that import:
 
-tlparse
-#Description: parse logs produced by torch.compile
-#Pinned versions:
-#test that import: dynamo/test_structured_trace.py
-
 # needed by torchgen utils
 typing-extensions
 #Description: type hints for python


### PR DESCRIPTION
Revert PR https://github.com/ROCm/pytorch/pull/1579
remove `tlparse` from requirements-ci.txt

need to use `.ci/pytorch/test.sh` to install requirements before testing
https://ontrack-internal.amd.com/browse/SWDEV-480494