### PR TITLE
Enabling vector length 8 for vectorized elementwise kernel

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -116,6 +116,11 @@ static inline void launch_vectorized_kernel(
   int vec_size = memory::can_vectorize_up_to<func_t>(data);
 
   switch (vec_size) {
+    case 8:
+      vectorized_elementwise_kernel<8, func_t, array_t>
+          <<<grid, num_threads(), 0, stream>>>(N, f, data);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      break;
     case 4:
       vectorized_elementwise_kernel<4, func_t, array_t>
           <<<grid, num_threads(), 0, stream>>>(N, f, data);

--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -34,7 +34,11 @@ const uint32_t block_size_bound = 256;
 const uint32_t grid_size_bound = 4;
 // number of randoms given by distributions like curand_uniform4, curand_uniform2_double
 // used in calculating philox offset.
+#if defined(USE_ROCM)
+const uint32_t curand4_engine_calls = 16;
+#else
 const uint32_t curand4_engine_calls = 4;
+#endif
 
 // utility function that calculates proper philox_offset
 // for distributions utilizing TensorIterator. For distributions using

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -350,11 +350,22 @@ inline C10_HOST_DEVICE int can_vectorize_up_to(const char *pointer) {
   uint64_t address = reinterpret_cast<uint64_t>(pointer);
   constexpr int vec2_alignment = std::alignment_of<aligned_vector<scalar_t, 2>>::value;
   constexpr int vec4_alignment = std::alignment_of<aligned_vector<scalar_t, 4>>::value;
-  if (address % vec4_alignment == 0) {
-    return 4;
-  } else if (address % vec2_alignment == 0) {
-    return 2;
-  }
+  #if defined(USE_ROCM)
+    constexpr int vec8_alignment = std::alignment_of<aligned_vector<scalar_t, 8>>::value;
+    if (address % vec8_alignment == 0) {
+      return 8;
+    } else if (address % vec4_alignment == 0) {
+      return 4;
+    } else if (address % vec2_alignment == 0) {
+      return 2;
+    }
+  #else
+    if (address % vec4_alignment == 0) {
+      return 4;
+    } else if (address % vec2_alignment == 0) {
+      return 2;
+    }
+  #endif
   return 1;
 }
 

--- a/aten/src/ATen/native/cuda/thread_constants.h
+++ b/aten/src/ATen/native/cuda/thread_constants.h
@@ -18,5 +18,9 @@ constexpr uint32_t num_threads() {
 }
 #endif
 
+#if defined(USE_ROCM)
+constexpr int thread_work_size() { return 16; }
+#else
 constexpr int thread_work_size() { return 4; }
+#endif
 constexpr int block_work_size() { return thread_work_size() * num_threads(); }


### PR DESCRIPTION
enabling use of vector length 8 on AMD GPUs for vectorized elementwise kernel and minor parameter tuning to improve perf 