### PR TITLE
change torch.equal() to self.assetrEqual() while comparing NHWC and NCHW batchnorm output

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5070,7 +5070,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             inp2 = inp1.contiguous(memory_format=torch.channels_last)
             out1 = model(inp1)
             out2 = model(inp2)
-            self.assertTrue(torch.equal(out1, out2))
+            self.assertEqual(out1, out2)
 
     def test_batchnorm_load_state_dict(self):
         bn = torch.nn.BatchNorm2d(3)


### PR DESCRIPTION
`self.assertTrue(torch.equal(out1, out2))` assumes a compete match
But we have a slight difference (~1e-7) with fp32 NHWC and NCHW batchnorm output
`self.assertEqual(out1, out2)` allows for tolerance