### PR TITLE
[rocm6.3_internal_testing] Fixed error string assertion in test_invalid_devices

### DIFF
--- a/torch/testing/_internal/distributed/nn/api/remote_module_test.py
+++ b/torch/testing/_internal/distributed/nn/api/remote_module_test.py
@@ -616,7 +616,7 @@ class CudaRemoteModuleTest(CommonRemoteModuleTest):
         if TEST_WITH_ROCM:
             errorString = (r"HIP error: invalid device ordinal\n"
                           r"HIP kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.\n"
-                          r"For debugging consider passing AMD_SERIALIZE_KERNEL=3.")
+                          r"For debugging consider passing AMD_SERIALIZE_KERNEL=3")
         else:
             errorString = r"CUDA error: invalid device ordinal"
         with self.assertRaisesRegex(


### PR DESCRIPTION
Fixes #8974
