### PR TITLE
SWDEV-487470 : Move philox arguments to GPU and properly enable ME attention

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -208,7 +208,6 @@ bool check_flash_attention_hardware_support(sdp_params const& params, bool debug
       return false;
     }
   }
-  return true;
 #else
   return false;
 #endif
@@ -253,7 +252,6 @@ bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) 
       return false;
     }
   }
-  return true;
 #else
   return false;
 #endif
@@ -269,9 +267,8 @@ bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) 
     }
     return false;
   }
-  return true;
 #endif
-  return false;
+  return true;
 }
 
 bool check_requires_grad_and_head_dim_gt192_constraints_on_sm86_89(

--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -208,6 +208,7 @@ bool check_flash_attention_hardware_support(sdp_params const& params, bool debug
       return false;
     }
   }
+  return true;
 #else
   return false;
 #endif
@@ -252,6 +253,7 @@ bool check_mem_efficient_hardware_support(sdp_params const& params, bool debug) 
       return false;
     }
   }
+  return true;
 #else
   return false;
 #endif

--- a/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.hip
+++ b/aten/src/ATen/native/transformers/hip/flash_attn/flash_api.hip
@@ -177,8 +177,8 @@ mha_fwd(const at::Tensor &q,         // batch_size x seqlen_q x num_heads x head
     philox_state = gen->philox_cuda_state(counter_offset);
     if (at::cuda::currentStreamCaptureStatus() == at::cuda::CaptureStatus::None) {
       auto [seed, offset] = at::cuda::philox::unpack(philox_state);
-      seed_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(seed)), at::dtype(at::kLong));
-      offset_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(offset)), at::dtype(at::kLong));
+      seed_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(seed)), at::dtype(at::kLong).device(at::kCUDA));
+      offset_t = at::scalar_tensor(at::Scalar(static_cast<int64_t>(offset)), at::dtype(at::kLong).device(at::kCUDA));
     } else {
       // See Note [CUDA Graph-safe RNG states] about the design
       use_philox_state = true;


### PR DESCRIPTION
All Philox Tensors must be on the device, and `check_mem_efficient_hardware_support` should return true if test passed.

Fixes #SWDEV-487470
