### PR TITLE
SWDEV-486396 : Import numpy after torch

### DIFF
--- a/test/run_test.py
+++ b/test/run_test.py
@@ -4,7 +4,6 @@ import argparse
 import copy
 import glob
 import json
-import numpy
 import os
 import pathlib
 import re
@@ -37,6 +36,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_ROCM,
     TEST_WITH_SLOW_GRADCHECK,
 )
+
+import numpy
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
Fixes error introduced by https://github.com/ROCm/pytorch/commit/995edef06cb695bbf52f6ebd3e2eca7efe2101a8 when running unit tests using `run_test.py`:
```
Error: mkl-service + Intel(R) MKL: MKL_THREADING_LAYER=INTEL is incompatible with libgomp.so.1 library.
	Try to import numpy first or set the threading layer accordingly. Set MKL_SERVICE_FORCE_INTEL to force it.
```

Refer solution suggested in: https://github.com/pytorch/pytorch/issues/37377#issuecomment-629610327

Need to cherry-pick this change to release/2.3 and release/2.4 branches as well.
