### PR TITLE
[rocm6.3_internal_testing] add tlparse into requirements-ci.txt

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -253,6 +253,11 @@ tb-nightly==2.13.0a20230426
 #Pinned versions:
 #test that import:
 
+tlparse==0.3.25
+#Description: parse logs produced by torch.compile
+#Pinned versions:
+#test that import: dynamo/test_structured_trace.py
+
 # needed by torchgen utils
 typing-extensions
 #Description: type hints for python


### PR DESCRIPTION
this PR add tlparse==0.3.25 into requirementss-ci.txt

fix dynamo/test_structured_trace.py
Error message: FileNotFoundError: [Errno 2] No such file or directory: 'tlparse'

Fixes: https://ontrack-internal.amd.com/browse/SWDEV-480494 (cherry picked from commit 70fdaed1278eb4be695f2f583796454d592d1dbc)
