### PR TITLE
skip all *_stress_cuda UT

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -51,6 +51,7 @@ from torch.testing._internal.common_utils import (
     retry_on_connect_failures,
     run_tests,
     skip_but_pass_in_sandcastle,
+    skipIfRocm,
     TestCase,
 )
 
@@ -1095,6 +1096,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_gather_stress(inputs, lambda t: t.clone())
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_gather_stress_cuda(self):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -919,6 +919,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         ]
         self._test_scatter_stress(inputs, lambda t: t.clone())
 
+    @skipIfRocm
     @skip_but_pass_in_sandcastle(
         "Test is flaky, see https://github.com/pytorch/pytorch/issues/15963"
     )

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -490,6 +490,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_allreduce_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_allreduce_stress_cuda(self):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -385,6 +385,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i * self.world_size + self.rank]) for i in range(1000)]
         self._test_broadcast_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_broadcast_stress_cuda(self):
@@ -1229,6 +1230,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_allgather_stress(inputs, lambda t: t.clone())
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_allgather_stress_cuda(self):
@@ -1415,6 +1417,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_reduce_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_reduce_stress_cuda(self):


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
I am skipping test_gather_stress_cuda for rocm6.2 due to getting time out.