### PR TITLE
[SWDEV-480138] [SWDEV-460957] Skip flash attention inductor test on Navi

### DIFF
--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -20,7 +20,13 @@ from torch.testing._internal.common_cuda import (
     PLATFORM_SUPPORTS_CUDNN_ATTENTION,
     SM90OrLater,
 )
-from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm
+from torch.testing._internal.common_utils import (
+    IS_WINDOWS,
+    NAVI_ARCH,
+    skipIfRocm,
+    skipIfRocmArch, 
+)
+
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils.checkpoint import (
@@ -1167,6 +1173,7 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, [y, z])
         self.assertEqual(ref, res)
 
+    @skipIfRocmArch(NAVI_ARCH)
     @requires_cuda
     def test_pattern_matcher(self):
         # Check that the sdpa op is recomputed in the backward graph

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -103,6 +103,7 @@ try:
 except ImportError:
     has_pytest = False
 
+NAVI_ARCH = ("gfx1100", "gfx1101")
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -103,7 +103,7 @@ try:
 except ImportError:
     has_pytest = False
 
-NAVI_ARCH = ("gfx1100", "gfx1101")
+NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101")
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)


### PR DESCRIPTION
Flash attention not available OOB on Navi. Skipping UT which requires flash attention