### PR TITLE
[rocm6.3_internal_testing] [NO CP] Added ignore to cuda driver check code to disable warnings for ROCm builds

### DIFF
--- a/test/inductor/test_cpp_wrapper_hipify.py
+++ b/test/inductor/test_cpp_wrapper_hipify.py
@@ -36,16 +36,16 @@ class TestCppWrapperHipify(TestCase):
     def test_hipify_aoti_driver_header(self) -> None:
         header = cuda_kernel_driver()
         expected = """
-            #define CUDA_DRIVER_CHECK(EXPR)                    \\
-            do {                                               \\
-                hipError_t code = EXPR;                          \\
-                const char *msg;                               \\
-                hipDrvGetErrorString(code, &msg);                  \\
-                if (code != hipSuccess) {                    \\
-                    throw std::runtime_error(                  \\
-                        std::string("CUDA driver error: ") +   \\
-                        std::string(msg));                     \\
-                }                                              \\
+            #define CUDA_DRIVER_CHECK(EXPR)                     \\
+            do {                                                \\
+                hipError_t code = EXPR;                         \\
+                const char *msg;                                \\
+                std::ignore = hipDrvGetErrorString(code, &msg); \\
+                if (code != hipSuccess) {                       \\
+                    throw std::runtime_error(                   \\
+                        std::string("CUDA driver error: ") +    \\
+                        std::string(msg));                      \\
+                }                                               \\
             } while (0);
 
             namespace {

--- a/torch/_inductor/codegen/codegen_device_driver.py
+++ b/torch/_inductor/codegen/codegen_device_driver.py
@@ -10,7 +10,7 @@ def cuda_kernel_driver() -> str:
             do {                                               \\
                 CUresult code = EXPR;                          \\
                 const char *msg;                               \\
-                cuGetErrorString(code, &msg);                  \\
+                std::ignore = cuGetErrorString(code, &msg);    \\
                 if (code != CUDA_SUCCESS) {                    \\
                     throw std::runtime_error(                  \\
                         std::string("CUDA driver error: ") +   \\


### PR DESCRIPTION
Fixes #9579
