### PR TITLE
[release/2.4] Enabled forced padding for multiple tests in test_pad_mm

### DIFF
--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -50,7 +50,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_cat_pad_mm_dyn_m(self):
         M1 = 128
         M2 = 40
@@ -85,7 +87,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_mm_dyn_n(self):
         M = 20
         K = 81
@@ -112,7 +116,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_mm_dyn_k(self):
         M = 21
         K = 80
@@ -179,7 +185,9 @@ class PadMMTest(TestCase):
         b = torch.randn(10, 100).cuda()
         self.assertEqual(torch.compile(addmm)(x, a, b), addmm(x, a, b))
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_bmm_dyn_b(self):
         B = 10
         M = 128
@@ -208,7 +216,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_bmm_dyn_k(self):
         B = 10
         M = 128
@@ -237,7 +247,9 @@ class PadMMTest(TestCase):
             FileCheck().check(f"N = {aligned_n}").run(code)
         self.assertEqual(res1, res2)
 
-    @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
+    @inductor_config.patch(max_autotune=True,
+                           max_autotune_gemm_backends="TRITON",
+                           force_shape_pad=True)
     def test_pad_bmm_dyn_bm(self):
         B = 10
         M = 128


### PR DESCRIPTION
This affects:
-test_cat_pad_mm_dyn_m
-test_pad_bmm_dyn_b
-test_pad_bmm_dyn_bm
-test_pad_bmm_dyn_k
-test_pad_mm_dyn_k
-test_pad_mm_dyn_n