### PR TITLE
[release/2.4] Skipped test_slice_mm_bandwidth_computation on big gpus

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -14,7 +14,7 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import expectedFailureXPU
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_BIG_GPU
 
 
 class TestKernelBenchmark(TestCase):
@@ -368,6 +368,7 @@ class TestKernelBenchmark(TestCase):
         self.check_bandwidth(compiled_module, "0.006")
 
     @expectedFailureXPU
+    @skipCUDAIf(IS_BIG_GPU, "test fails on big GPU")
     @config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     def test_slice_mm_bandwidth_computation(self):
         M, N, K = 1000, 2000, 3000


### PR DESCRIPTION
The test fails to use triton gemms because is_big_gpu returns true and thus fails to produce benchmarkable kernel.