### PR TITLE
[ROCm] Set thread work size to 8 for elementwise kernels

### DIFF
--- a/aten/src/ATen/native/cuda/DistributionTemplates.h
+++ b/aten/src/ATen/native/cuda/DistributionTemplates.h
@@ -35,7 +35,7 @@ const uint32_t grid_size_bound = 4;
 // number of randoms given by distributions like curand_uniform4, curand_uniform2_double
 // used in calculating philox offset.
 #if defined(USE_ROCM)
-const uint32_t curand4_engine_calls = 16;
+const uint32_t curand4_engine_calls = 8;
 #else
 const uint32_t curand4_engine_calls = 4;
 #endif

--- a/aten/src/ATen/native/cuda/thread_constants.h
+++ b/aten/src/ATen/native/cuda/thread_constants.h
@@ -19,7 +19,7 @@ constexpr uint32_t num_threads() {
 #endif
 
 #if defined(USE_ROCM)
-constexpr int thread_work_size() { return 16; }
+constexpr int thread_work_size() { return 8; }
 #else
 constexpr int thread_work_size() { return 4; }
 #endif


### PR DESCRIPTION
thread work size = 8 performs better than 16 for 1D tensors. 
For 2D tensors, both 8 and 16 gives similar performance.
