### PR TITLE
[release/2.4] Skipped test_slice_mm_bandwidth_computation and test_pad_addmm_dyn_mn on navi

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -14,7 +14,11 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache
 from torch.testing import FileCheck
 from torch.testing._internal.common_device_type import expectedFailureXPU
-from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_BIG_GPU
+from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
+from torch.testing._internal.common_utils import (
+    NAVI_ARCH,
+    skipIfRocmArch, 
+)
 
 
 class TestKernelBenchmark(TestCase):
@@ -368,7 +372,7 @@ class TestKernelBenchmark(TestCase):
         self.check_bandwidth(compiled_module, "0.006")
 
     @expectedFailureXPU
-    @skipCUDAIf(IS_BIG_GPU, "test fails on big GPU")
+    @skipIfRocmArch(NAVI_ARCH)
     @config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     def test_slice_mm_bandwidth_computation(self):
         M, N, K = 1000, 2000, 3000

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -21,6 +21,7 @@ from torch.testing._internal.common_utils import (
     skipIfRocmArch, 
 )
 
+
 class PadMMTest(TestCase):
     @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     def test_pad_mm_dyn_m(self):

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -16,7 +16,10 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache, run_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.inductor_utils import HAS_CUDA
-
+from torch.testing._internal.common_utils import (
+    NAVI_ARCH,
+    skipIfRocmArch, 
+)
 
 class PadMMTest(TestCase):
     @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
@@ -308,6 +311,7 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
+    @skipIfRocmArch(NAVI_ARCH)
     @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     def test_pad_addmm_dyn_mn(self):
         M = 128

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -103,6 +103,8 @@ except ImportError:
     has_pytest = False
 
 
+NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101")
+
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)
 


### PR DESCRIPTION
The tests fail because is_big_gpu for navi returns false and GEMMs backend fails to produce any kernels going back to ATen. The tests fail to check to valid metadate for kernels and thus fail. Decided to skip the for navi currently and not rely on is_big_gpu check.