### PR TITLE
[release/2.4] Skipped some inductor tests for no hipcc rocm environments

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -94,8 +94,6 @@ from torch.utils.weak import WeakTensorKeyDictionary
 
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
 
-ROCM_WHEELS_ENV = TEST_WITH_ROCM and not HAS_HIPCC
-
 if IS_WINDOWS and IS_CI:
     sys.stderr.write(
         "Windows CI does not have necessary dependencies for test_torchinductor yet\n"
@@ -754,7 +752,7 @@ class CommonTemplate:
         )
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
-    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
+    @skipCUDAIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     def test_eager_aoti_cache_hit(self):
         ns = "aten"
         op_name = "abs"
@@ -807,7 +805,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
-    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
+    @skipCUDAIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     def test_aoti_compile_with_persistent_cache(self):
         def fn(a):
             return torch.abs(a)
@@ -6666,7 +6664,7 @@ class CommonTemplate:
 
         self.common(fn, [torch.randn(64, 64)])
 
-    @unittest.skipIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
+    @unittest.skipIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     def test_new_cpp_build_logical(self):
         from torch._inductor.codecache import validate_new_cpp_commands
 

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -85,6 +85,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
+    HAS_HIPCC,
 )
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -92,6 +93,8 @@ from torch.utils._pytree import tree_flatten, tree_unflatten
 from torch.utils.weak import WeakTensorKeyDictionary
 
 DO_PERF_TEST = os.environ.get("DO_PERF_TEST") == "1"
+
+ROCM_WHEELS_ENV = TEST_WITH_ROCM and not HAS_HIPCC
 
 if IS_WINDOWS and IS_CI:
     sys.stderr.write(
@@ -751,6 +754,7 @@ class CommonTemplate:
         )
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
+    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
     def test_eager_aoti_cache_hit(self):
         ns = "aten"
         op_name = "abs"
@@ -803,6 +807,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
+    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
     def test_aoti_compile_with_persistent_cache(self):
         def fn(a):
             return torch.abs(a)
@@ -6661,6 +6666,7 @@ class CommonTemplate:
 
         self.common(fn, [torch.randn(64, 64)])
 
+    @unittest.skipIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
     def test_new_cpp_build_logical(self):
         from torch._inductor.codecache import validate_new_cpp_commands
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -105,7 +105,7 @@ except ImportError:
 
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101")
 
-HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None
+HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None and shutil.which('hipcc') is not None
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -94,6 +94,7 @@ from torch.testing._comparison import (
 from torch.testing._comparison import not_close_error_metas
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.utils._import_utils import _check_module_exists
+from torch.utils.cpp_extension import ROCM_HOME
 import torch.utils._pytree as pytree
 
 try:
@@ -102,8 +103,9 @@ try:
 except ImportError:
     has_pytest = False
 
-
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101")
+
+HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)


### PR DESCRIPTION
Skipped some tests for wheels builds with a check for ROCM_HOME.