### PR TITLE
[release/2.5] [ROCM] Fix hipBLASLt version check in TunableOp test (#1678)

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4531,7 +4531,7 @@ class TestLinalg(TestCase):
             validators[key] = value
         if torch.version.hip:
             assert "HIPBLASLT_VERSION" in validators
-            assert re.match(r'^\d{3}-[a-z0-9]{8}$', validators["HIPBLASLT_VERSION"])
+            assert re.match(r'^\d{3,}-[a-z0-9]{8}$', validators["HIPBLASLT_VERSION"])
         assert len(torch.cuda.tunable.get_results()) > 0
 
         assert torch.cuda.tunable.write_file()  # use default filename


### PR DESCRIPTION
Allow 3 or more digits for hipBLASLt version check in TunableOp test. Needed due to upcoming ROCm 6.3 release.

Fixes
[SWDEV-493195](https://ontrack-internal.amd.com/browse/SWDEV-493195)

Same as [PR#139811](https://github.com/pytorch/pytorch/pull/139811)

