### PR TITLE
[release/2.4] [NO CP] Warp size fix for navi arch

### DIFF
--- a/torch/_C/__init__.pyi.in
+++ b/torch/_C/__init__.pyi.in
@@ -1911,6 +1911,7 @@ class _CudaDeviceProperties:
     is_multi_gpu_board: _int
     max_threads_per_multi_processor: _int
     gcnArchName: str
+    warp_size: _int
 
 # Functions related to SDPA
 class _SDPAParams:

--- a/torch/_inductor/codegen/codegen_device_driver.py
+++ b/torch/_inductor/codegen/codegen_device_driver.py
@@ -73,9 +73,11 @@ def cuda_kernel_driver() -> str:
             }
     """
     if torch.version.hip is not None:
-        # Replace the warp size from 32 (cuLaunchKernel) to 64 (hipModuleLaunchKernel)
-        # The warp size on NV GPU is 32, while the wavefront size on AMD GPU is 64
-        source_codes = source_codes.replace("32*numWarps", "64*numWarps")
+        # Adjusting the warp size to GPU supported wavefront size on AMD GPU
+        prop = torch.cuda.get_device_properties(torch.cuda.current_device())
+        source_codes = source_codes.replace(
+            "32*numWarps", str(prop.warp_size) + "*numWarps"
+        )
     return source_codes
 
 

--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -922,6 +922,7 @@ static void registerCudaDeviceProperties(PyObject* module) {
       .def_readonly(
           "max_threads_per_multi_processor",
           &cudaDeviceProp::maxThreadsPerMultiProcessor)
+      .def_readonly("warp_size", &cudaDeviceProp::warpSize)
 #if !USE_ROCM
       // NVIDA only property
       .def_readonly(


### PR DESCRIPTION
Added warp size to device properties, removed 64 warpsize hardcode in codegen
