### PR TITLE
[release/2.4] [NO CP] Added missing library paths for aot_mode

### DIFF
--- a/torch/_inductor/codecache.py
+++ b/torch/_inductor/codecache.py
@@ -1816,6 +1816,7 @@ def get_include_and_linking_paths(
         # like aoti_torch_grad_mode_set_enabled
         if aot_mode and sys.platform == "linux" and not config.is_fbcode():
             libs += ["torch", "torch_cpu"]
+            lpaths += [cpp_extension.TORCH_LIB_PATH]
 
     # Unconditionally import c10 for non-abi-compatible mode to use TORCH_CHECK - See PyTorch #108690
     if not config.abi_compatible:


### PR DESCRIPTION
PR for reference: https://github.com/pytorch/pytorch/pull/131791