### PR TITLE
Skip failing unit test / test_unbacked_symints.py::TestUnbackedSymintsCUDA::test_vertical_pointwise_reduction_fusion_cuda

### DIFF
--- a/test/inductor/test_unbacked_symints.py
+++ b/test/inductor/test_unbacked_symints.py
@@ -10,7 +10,7 @@ from torch._inductor.test_case import TestCase as InductorTestCase
 from torch._inductor.utils import is_big_gpu
 from torch.testing import make_tensor
 from torch.testing._internal.common_device_type import instantiate_device_type_tests
-from torch.testing._internal.common_utils import IS_LINUX, parametrize
+from torch.testing._internal.common_utils import IS_LINUX, parametrize, skipIfRocm
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_CUDA, skipCUDAIf
 
 
@@ -188,6 +188,7 @@ class TestUnbackedSymints(InductorTestCase):
         expected = fn(*example_inputs)
         torch.testing.assert_close(actual, expected)
 
+    @skipIfRocm # Will work again on torch 2.6.0 with up-to-date triton
     @skipCUDAIf(not HAS_CUDA, "requires cuda")
     @dynamo_config.patch({"capture_scalar_outputs": True})
     def test_vertical_pointwise_reduction_fusion(self, device):


### PR DESCRIPTION

Applied skipIfRocm on a failing unit test - this was tested to work on future torch 2.6.0 with latest triton so untill then..

Fixes https://github.com/ROCm/frameworks-internal/issues/10079
