### PR TITLE
[Release/2.4] Fix 493250 - Fix distributed unit tests that fail on 4 GPU NAVI machine with python12, pytorch release2.4

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -6735,7 +6735,7 @@ class DistributedTest:
 
             b = Bar()
             gather_objects = [b for _ in range(dist.get_world_size())]
-            with self.assertRaisesRegex(AttributeError, "Can't pickle local object"):
+            with self.assertRaisesRegex(AttributeError, "Can't (get|pickle) local object"):
                 dist.all_gather_object(
                     [None for _ in range(dist.get_world_size())],
                     gather_objects[self.rank],

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4107,7 +4107,7 @@ class DistributedTest:
                     self.assertGreaterAlmostEqual(
                         float(time.time()),
                         float(expected_time[0]),
-                        "destination rank: %d, my rank: %d" % (dest, rank)
+                        msg="destination rank: %d, my rank: %d" % (dest, rank)
                         + " (if you see this failure, please report in #14554)",
                     )
 

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4864,6 +4864,7 @@ class DistributedTest:
             "Failing with gloo backend + torchvision due to ongoing issue https://github.com/pytorch/pytorch/issues/111834",
         )
         @skip_if_lt_x_gpu(2)
+        @skip_if_odd_worldsize
         def test_ddp_apply_optim_in_backward(self):
             for optim_cls, init_before in itertools.product(
                 [torch.optim.SGD, torch.optim.Adam], [True, False]
@@ -4880,6 +4881,7 @@ class DistributedTest:
             "Failing with gloo backend + torchvision due to ongoing issue https://github.com/pytorch/pytorch/issues/111834",
         )
         @skip_if_lt_x_gpu(2)
+        @skip_if_odd_worldsize
         def test_ddp_apply_optim_in_backward_grad_as_bucket_view_false(self):
             for init_before in [True, False]:
                 self._test_ddp_apply_optim_in_backward(

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -7049,6 +7049,7 @@ class DistributedTest:
 
         @require_backend_is_available(DistTestCases.backend_feature["gpu"])
         @skip_if_lt_x_gpu(2)
+        @skip_if_odd_worldsize
         @skip_but_pass_in_sandcastle_if(IS_FBCODE, "Kineto in fbcode code causes hang")
         @skip_but_pass_in_sandcastle_if(
             IS_MACOS or IS_WINDOWS,


### PR DESCRIPTION
Fixes #SWDEV-493250

Solving these issues in 5 different tests.

| 1 | test_ddp_apply_optim_in_backward  distributed/test_distributed_spawn 1/7 failed!   | FAILED [9.4180s] distributed/test_distributed_spawn.py::TestDistBackendWithSpawn::test_ddp_apply_optim_in_backward - RuntimeError: Process 2 exited with error code 10 and exception:  AssertionError: Tensor-likes are not close!  Mismatched elements: 1 / 9 (11.1%) Greatest absolute difference: 0.02197265625 at index (1, 0) (up to 1e-05 allowed) Greatest relative difference: 3.0710627925145673e-06 at index (1, 0) (up to 1.3e-06 allowed) Params not equal at iteration 7                                                                                                                                                                                                                                                                                                                                                                                                         |
|---|------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| 2 | test_barrier_full_group_cuda  distributed/test_distributed_spawn 4/7 failed!       | TestDistBackendWithSpawn.test_barrier_full_group_cuda _____________     File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_internal/distributed/distributed_test.py", line 4151, in test_barrier_full_group_cuda      self._test_barrier_helper(group, group_id, rank, True, rank_to_GPU)    File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_internal/distributed/distributed_test.py", line 4107, in _test_barrier_helper      self.assertGreaterAlmostEqual(    File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 3871, in assertGreaterAlmostEqual      if round(diff, places) == 0:         ^^^^^^^^^^^^^^^^^^^  TypeError: 'str' object cannot be interpreted as an integer                                                                                                     |
| 3 | test_ddp_profiling_execution_trace  distributed/test_distributed_spawn 5/7 failed! | Process 1 exited with error code 10 and exception:   AssertionError: Scalars are not equal!  Expected 2 but got 3. Absolute difference: 1 Relative difference: 0.5                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
| 4 | test_gather_object_subgroup  distributed/test_distributed_spawn 6/7 failed!        | distributed/test_distributed_spawn.py::TestDistBackendWithSpawn::test_gather_object_subgroup - RuntimeError: Process 0 exited with error code 10 and exception:  AttributeError: Can't get local object 'DistributedTest._DistTestBase._test_gather_object.<locals>.Bar'   During handling of the above exception, another exception occurred:  AssertionError: "Can't pickle local object" does not match "Can't get local object 'DistributedTest._DistTestBase._test_gather_object.<locals>.Bar'"    File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 1095, in run_tests     assert len(failed_tests) == 0, "{} unit test(s) failed:\n\t{}".format(            ^^^^^^^^^^^^^^^^^^^^^^ AssertionError: 1 unit test(s) failed:         distributed/test_distributed_spawn.py::TestDistBackendWithSpawn::test_gather_object_subgroup |
| 5 | test_barrier_group_cuda distributed/test_distributed_spawn 7/7 failed!             | TestDistBackendWithSpawn.test_barrier_group_cuda  RuntimeError: Process 1 exited with error code 10 and exception: TypeError: 'str' object cannot be interpreted as an integer   To execute this test, run the following from the base repo dir:     PYTORCH_TEST_WITH_ROCM=1 python test/distributed/test_distributed_spawn.py -k TestDistBackendWithSpawn.test_barrier_group_cuda                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |

**Issue 1**

This test works for WORLD_SIZE is equal to number of GPUs. WORLD_SIZE is hard coded to 3, when number of GPUs is greater than 2 in test/run_test.py. So, this test has to be skipped for 4 GPU systems. Solution is to add @skip_if_odd_worldsize to the unit test. 

nn.parallel.DistributedDataParallel - To use ``DistributedDataParallel`` on a host with N GPUs, you should spawn up ``N`` processes, ensuring that each process exclusively works on a single GPU from 0 to N-1.

This change is also made to test_ddp_apply_optim_in_backward_grad_as_bucket_view_false.

**Issue 2**

The named parameter was missing in the assert statement. The solution was to explicit add the named parameter in the call. The solution is to cherry pick commit 6f32dc0c7b7688f3875f6be43e2ece8e53b0681c. 

This causes another issue of barrier synchronize call not blocking till all GPUs are finished. The solution is to add TORCH_NCCL_BLOCKING_WAIT=1 environment variable.

According to torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp - In case of blockingWait or a timeout value is specified by the user, we block the CPU thread until the work is completed or timed out.


**Issue 3**

This test runs with WORLD_SIZE 2 and checks if the pg_size NCCL metadata is equal to 2. So, we must skip this if the number of GPUs is more than 2. Solution is to add @skip_if_odd_worldsize to the unit test. 

**Issue 4**

This test had issues with pickle library in python3.12. Pickle library returns another error statement in comparison to the previous versions. The solution is to update the regular expression in the assert statement to support python3.12 and previous versions.

**Issue 5**

Similar to issue 2
