### PR TITLE
[rocm6.3_internal_testing] Skipped some inductor tests for no hipcc rocm environments

### DIFF
--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -90,6 +90,7 @@ from torch.testing._internal.common_utils import (
     subtest,
     TEST_WITH_ASAN,
     TEST_WITH_ROCM,
+    HAS_HIPCC,
 )
 from torch.utils import _pytree as pytree
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -126,6 +127,7 @@ _desired_test_bases = get_desired_device_type_test_bases()
 RUN_CPU = any(getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases)
 RUN_GPU = any(getattr(x, "device_type", "") == GPU_TYPE for x in _desired_test_bases)
 NAVI_ARCH = ("gfx1100", "gfx1101") # Used for navi exclusive skips on ROCm
+ROCM_WHEELS_ENV = TEST_WITH_ROCM and not HAS_HIPCC
 
 aten = torch.ops.aten
 
@@ -928,6 +930,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
+    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skipIfWindows
     def test_aoti_eager_cache_hit(self):
@@ -971,6 +974,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
+    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skipIfWindows
     def test_aoti_eager_with_persistent_cache(self):

--- a/test/inductor/test_torchinductor.py
+++ b/test/inductor/test_torchinductor.py
@@ -127,7 +127,6 @@ _desired_test_bases = get_desired_device_type_test_bases()
 RUN_CPU = any(getattr(x, "device_type", "") == "cpu" for x in _desired_test_bases)
 RUN_GPU = any(getattr(x, "device_type", "") == GPU_TYPE for x in _desired_test_bases)
 NAVI_ARCH = ("gfx1100", "gfx1101") # Used for navi exclusive skips on ROCm
-ROCM_WHEELS_ENV = TEST_WITH_ROCM and not HAS_HIPCC
 
 aten = torch.ops.aten
 
@@ -930,7 +929,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
-    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
+    @skipCUDAIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skipIfWindows
     def test_aoti_eager_cache_hit(self):
@@ -974,7 +973,7 @@ class CommonTemplate:
                 self.assertEqual(ref_value, res_value)
 
     @skipCUDAIf(not SM80OrLater, "Requires sm80")
-    @skipCUDAIf(ROCM_WHEELS_ENV, "ROCm requires hipcc compiler")
+    @skipCUDAIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     @skip_if_halide  # aoti
     @skipIfWindows
     def test_aoti_eager_with_persistent_cache(self):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -108,7 +108,7 @@ NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101")
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 
-HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None
+HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None and shutil.which('hipcc') is not None
 
 
 def freeze_rng_state(*args, **kwargs):

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -95,6 +95,7 @@ from torch.testing._comparison import (
 from torch.testing._comparison import not_close_error_metas
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.utils._import_utils import _check_module_exists
+from torch.utils.cpp_extension import ROCM_HOME
 import torch.utils._pytree as pytree
 
 try:
@@ -106,6 +107,8 @@ except ImportError:
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101")
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
+
+HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None
 
 
 def freeze_rng_state(*args, **kwargs):


### PR DESCRIPTION
Relates to https://github.com/ROCm/pytorch/pull/1679 and https://github.com/ROCm/pytorch/pull/1697