### PR TITLE
[release/2.4] skip failed tests in test_nn.py

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3083,6 +3083,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                                                 [2.42240309, 0.0354595, -0.60659063, -0.05378816]]]))
             torch.testing.assert_close(result, ref_output, rtol=1e-5, atol=0)
 
+    @skipIfRocm
     def test_transformerdecoder(self):
         def get_a_test_layer(use_cuda, activation, batch_first=False):
             d_model = 4
@@ -3849,6 +3850,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         hidden_c_shape = update_shape(correct_hidden_c_shape, 0, bad_size)
         test(input_shape, hidden_h_shape, hidden_c_shape)
 
+    @skipIfRocm
     @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_rnn_check_device(self):
         import copy
@@ -8246,6 +8248,7 @@ class TestNNDeviceType(NNTestCase):
         if self.device_type == 'cuda':
             self._test_InstanceNorm_cuda_half(nn.InstanceNorm2d, input, device)
 
+    @skipIfRocm
     def test_InstanceNorm3d_general(self, device):
         b = random.randint(3, 5)
         c = random.randint(3, 5)
@@ -11791,6 +11794,9 @@ if __name__ == '__main__':
     @largeTensorTest("70GB", "cuda")
     @parametrize_test("reduction", ("none", "mean", "sum"))
     def test_cross_entropy_large_tensor(self, device, reduction):
+        if TEST_WITH_ROCM and 'cuda' in device and reduction == 'none':
+            # Skip this test for ROCm 
+            self.skipTest("Test failed on ROCm with reduction='none'")
         logits = torch.randn(int(2 ** 16), int(2 ** 16) + 1, dtype=torch.float32, device='cuda', requires_grad=True)
         labels = torch.zeros(logits.size(0), dtype=torch.long, device='cuda')
         loss = F.cross_entropy(logits, labels, reduction=reduction)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -11794,9 +11794,6 @@ if __name__ == '__main__':
     @largeTensorTest("70GB", "cuda")
     @parametrize_test("reduction", ("none", "mean", "sum"))
     def test_cross_entropy_large_tensor(self, device, reduction):
-        if TEST_WITH_ROCM and 'cuda' in device and reduction == 'none':
-            # Skip this test for ROCm 
-            self.skipTest("Test failed on ROCm with reduction='none'")
         logits = torch.randn(int(2 ** 16), int(2 ** 16) + 1, dtype=torch.float32, device='cuda', requires_grad=True)
         labels = torch.zeros(logits.size(0), dtype=torch.long, device='cuda')
         loss = F.cross_entropy(logits, labels, reduction=reduction)


### PR DESCRIPTION
skipping tests in test_nn.py for release/2.4:

- test_rnn_check_device
- test_transformerdecoder
- test_InstanceNorm3d_general_cuda
- <s>test_cross_entropy_large_tensor_reduction_none_cuda</s>
