### PR TITLE
[Release/2..4] Fix 493250 tests - make barrier() block cpu and pass two unit tests

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -4135,6 +4135,7 @@ class DistributedTest:
         @skip_but_pass_in_sandcastle_if(
             BACKEND == "mpi", "MPI doesn't supports GPU barrier"
         )
+        @with_nccl_blocking_wait
         def test_barrier_group_cuda(self):
             group, group_id, rank = self._init_group_test()
             rank_to_GPU = init_multigpu_helper(dist.get_world_size(), BACKEND)
@@ -4145,6 +4146,7 @@ class DistributedTest:
         @skip_but_pass_in_sandcastle_if(
             BACKEND == "mpi", "MPI doesn't supports GPU barrier"
         )
+        @with_nccl_blocking_wait
         def test_barrier_full_group_cuda(self):
             group, group_id, rank = self._init_full_group_test()
             rank_to_GPU = init_multigpu_helper(dist.get_world_size(), BACKEND)


### PR DESCRIPTION
Fixes #[SWDEV-493250](https://ontrack-internal.amd.com/browse/SWDEV-493250)

Added @with_nccl_blocking_wait decorator to tests test_barrier_full_group_cuda and test_barrier_group_cuda so that the CPU blocks until the GPU streams are synchronized in the barrier call and the assertion check is made after the GPU streams are synchronized. barrier() call is made to block CPU in the upstream after release2.4, but this functionality is not present in the upstream release2.4. This decorator helps to make barrier() block the CPU and pass these unit tests for rocm/pytorch release2.4.