### PR TITLE
[NOCP][release/2.4] skip failed tests in test_torch.py

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -6866,6 +6866,7 @@ class TestTorch(TestCase):
                     added = zeros.index_add(0, torch.arange(0, size[0], dtype=idx_dtype, device=device), tensor, alpha=-1)
                     self.assertEqual(added, -tensor)
 
+    @skipIfRocm
     @unittest.mock.patch.object(torch._dynamo.config, "suppress_errors", False)
     @set_default_dtype(torch.double)
     def test_index_add_correctness(self):


### PR DESCRIPTION
skip for test_index_add_correctness on ROCm