### PR TITLE
[NOCP][release/2.4] Skip failed unit tests in distributed/fsdp/test_fsdp_sharded_grad_scaler.py

### DIFF
--- a/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
+++ b/test/distributed/fsdp/test_fsdp_sharded_grad_scaler.py
@@ -34,6 +34,7 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     parametrize,
     run_tests,
+    skipIfRocm,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
 )
@@ -235,6 +236,7 @@ class TestShardedGradScalerParityWithDDP(FSDPTest):
         return model, optim, ref_model, ref_optim
 
     @skip_if_lt_x_gpu(2)
+    @skipIfRocm # temp skip
     def test_sharded_grad_scaler_found_inf(self):
         self.run_subtests(
             {


### PR DESCRIPTION
Skipping tests in distributed/fsdp/test_fsdp_sharded_grad_scaler.py for release/2.4:
- test_sharded_grad_scaler_found_inf
