### PR TITLE
[NOCP][release/2.4] Skip failed unit tests in distributed/test_c10d_nccl

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -4045,6 +4045,8 @@ class NCCLTraceTestDumpOnTimeout(NCCLTraceTestDumpOnTimeoutBase):
     @skip_but_pass_in_sandcastle_if(not TEST_MULTIGPU, "NCCL test requires 2+ GPUs")
     @parametrize("timing_enabled", [True, False])
     def test_timeout_dumps(self, timing_enabled):
+        if TEST_WITH_ROCM and timing_enabled == False:
+            self.skipTest(f"Skipped on ROCm")
         # dump on heartbeatmonitor thread
         os.environ["TORCH_NCCL_COORD_CHECK_MILSEC"] = "1000"
         # need rank0 to crash before looking for its output file


### PR DESCRIPTION
Skipping tests in distributed/test_c10d_nccl.py for release/2.4:
- test_timeout_dumps_timing_enabled_False
