### PR TITLE
[NOCP][release/2.4] Skip failed unit tests in distributed/_composable/fully_shard/test_fully_shard_compile

### DIFF
--- a/test/distributed/_composable/fully_shard/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fully_shard/test_fully_shard_compile.py
@@ -17,7 +17,7 @@ from torch.testing._internal.common_fsdp import (
     FSDPTest,
     TransformerWithSharedParams,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN, skipIfRocm
 from torch.utils._triton import has_triton
 
 if not dist.is_available():
@@ -39,6 +39,7 @@ class TestCompile(FSDPTest):
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
+    @skipIfRocm # temp skip
     def test_compile(self):
         self.run_subtests(
             {


### PR DESCRIPTION
Skipping tests in distributed/_composable/fully_shard/test_fully_shard_compile.py for release/2.4:
- test_compile
