### PR TITLE
[NOCP][release/2.4] Skip failed unit tests in distributed/fsdp/test_fsdp_hybrid_shard

### DIFF
--- a/test/distributed/fsdp/test_fsdp_hybrid_shard.py
+++ b/test/distributed/fsdp/test_fsdp_hybrid_shard.py
@@ -35,6 +35,7 @@ from torch.testing._internal.common_fsdp import (
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     run_tests,
+    skipIfRocm,
     TEST_WITH_DEV_DBG_ASAN,
 )
 
@@ -227,6 +228,7 @@ class TestFSDPHybridShard(FSDPTest):
     # resharded after forward.
 
     @skip_if_lt_x_gpu(2)
+    @skipIfRocm # temp skip
     def test_fsdp_hybrid_shard_basic_setup(self):
         """
         Tests basic functionality of HYBRID_SHARD and _HYBRID_SHARD_ZERO2:


### PR DESCRIPTION
Skipping tests in distributed/fsdp/test_fsdp_hybrid_shard.py for release/2.4:
- test_fsdp_hybrid_shard_basic_setup
