### PR TITLE
[ROCm] Set thread work size to 8 for elementwise kernels

### DIFF
--- a/aten/src/ATen/native/cuda/thread_constants.h
+++ b/aten/src/ATen/native/cuda/thread_constants.h
@@ -18,5 +18,9 @@ constexpr uint32_t num_threads() {
 }
 #endif
 
+#ifdef USE_ROCM
+constexpr int thread_work_size() { return 8; }
+#else
 constexpr int thread_work_size() { return 4; }
+#endif
 constexpr int block_work_size() { return thread_work_size() * num_threads(); }


### PR DESCRIPTION
This improves elementwise kernel performances on MI300 gpus.

Co-author: @akadutta 
