### PR TITLE
[release/2.4] Skip failed unit tests in test_ops.py

### DIFF
--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -646,6 +646,9 @@ class TestCommon(TestCase):
     @suppress_warnings
     @ops(op_db, allowed_dtypes=(torch.float32, torch.long, torch.complex64))
     def test_noncontiguous_samples(self, device, dtype, op):
+        # temp skip
+        if 'cuda' in device and TEST_WITH_ROCM and dtype==torch.complex64 and op.name=='svd_lowrank':
+            self.skipTest(f"Failing on ROCm with complex64 for {op.name}")
         test_grad = dtype in op.supported_backward_dtypes(torch.device(device).type)
         sample_inputs = op.sample_inputs(device, dtype, requires_grad=test_grad)
         for sample_input in sample_inputs:


### PR DESCRIPTION
Skipping tests in test_ops.py for release/2.4:
- test_noncontiguous_samples_svd_lowrank_cuda_complex64
