### PR TITLE
[Release/2.4] Increase the precision from float32 to float64 for test related to linear algebra

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -1037,8 +1037,8 @@ class TestOperators(TestCase):
         xfail('as_strided', 'partial_views'),
     })
     def test_vmapvjpvjp(self, device, dtype, op):
-        if 'cuda' in device and TEST_WITH_ROCM and dtype==torch.float32 and op.name=='linalg.householder_product':
-            self.skipTest(f"Skipped on ROCm")
+        dtype = torch.float64
+
         # Since, we test `vjpvjp` independently,
         # for this test, we just verify that vmap
         # of `vjpvjp` is correct.


### PR DESCRIPTION
This is skipped on Nvidia, fails when made to force run on Nvidia.

Both amd and nvidia gpus - 
/opt/conda/lib/python3.11/site-packages/torch/autograd/graph.py:769: UserWarning: There is a performance drop because we have not yet implemented the batching rule for aten::tril_. Please file us an issue on GitHub so that we can prioritize its implementation. (Triggered internally at ../aten/src/ATen/functorch/BatchedFallback.cpp:81.)
  return Variable._execution_engine.run_backward(  # Calls into the C++ engine to run the backward pass

To make it more precise:
`dtype = torch.float64`

This is a temporary fix and the test should be revisited when batching rule is implemented for aten::tril_.

Running the computation in float64 (as NumPy does by default) improves the precision to pass the test. Reference - https://pytorch.org/docs/stable/notes/numerical_accuracy.html#linear-algebra-stability 



