### PR TITLE
[Release/2.4] Use deterministic backends of scaled dot product attention for batched testing

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2339,7 +2339,6 @@ class TestOperators(TestCase):
             skip("sparse.sampled_addmm", ""),
             skip("sparse.mm", "reduce"),
             skip("native_layer_norm", "", device_type="cpu"),
-            skip("nn.functional.scaled_dot_product_attention", "", device_type="cuda"), # temp skip
             # RuntimeError: Expected contiguous tensor, but got
             # non-contiguous tensor for argument #2 'grad_output'
             decorate(
@@ -2402,6 +2401,9 @@ class TestOperators(TestCase):
         if not op.supports_autograd:
             self.skipTest("Skipped! Autograd not supported.")
             return
+
+        torch.backends.cuda.enable_flash_sdp(False)
+        torch.backends.cuda.enable_mem_efficient_sdp(False)
 
         sample_inputs = op.sample_inputs(device, dtype, requires_grad=True)
 


### PR DESCRIPTION
Use deterministic version of scaled_dot_product_attention for better comparison of outputs. It is mentioned in scaled_dot_product_attention documentation - Due to the nature of fusing floating point operations, the output of this function may be different depending on what backend kernel is chosen. The c++ implementation supports torch.float64 and can be used when higher precision is required. So, we disable the other two backends - FlashAttention and Memory-Efficient Attention.

```
torch.backends.cuda.enable_flash_sdp(False)
torch.backends.cuda.enable_mem_efficient_sdp(False)
```
