### PR TITLE
[rocm6.3_internal_testing] [NO CP] Removed test skips for navi caused by is_big_gpu check

### DIFF
--- a/test/inductor/test_benchmark_fusion.py
+++ b/test/inductor/test_benchmark_fusion.py
@@ -12,8 +12,6 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     slowTest,
     TEST_WITH_ASAN,
-    skipIfRocmArch,
-    NAVI_ARCH,
 )
 from torch.testing._internal.inductor_utils import HAS_CPU, HAS_CUDA
 
@@ -246,7 +244,6 @@ if HAS_CUDA and not TEST_WITH_ASAN:
             return code, code2
 
         @fresh_inductor_cache()
-        @skipIfRocmArch(NAVI_ARCH)
         @torch._inductor.config.patch(max_autotune_gemm_backends="TRITON")
         def test_equivalent_template_code(self):
             code, code2 = self._equivalent_output_code_impl(256)

--- a/test/inductor/test_pad_mm.py
+++ b/test/inductor/test_pad_mm.py
@@ -14,10 +14,6 @@ from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_inductor_cache, is_big_gpu, run_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.inductor_utils import HAS_CUDA
-from torch.testing._internal.common_utils import (
-    NAVI_ARCH,
-    skipIfRocmArch, 
-)
 
 
 class PadMMTest(TestCase):
@@ -59,7 +55,6 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @skipIfRocmArch(NAVI_ARCH)
     @inductor_config.patch(max_autotune=True,
                            max_autotune_gemm_backends="TRITON",
                            force_shape_pad=True)
@@ -318,7 +313,6 @@ class PadMMTest(TestCase):
             FileCheck().check(f"K = {aligned_k}").run(code)
         self.assertEqual(res1, res2)
 
-    @skipIfRocmArch(NAVI_ARCH)
     @inductor_config.patch(max_autotune=True, max_autotune_gemm_backends="TRITON")
     def test_pad_addmm_dyn_mn(self):
         M = 128


### PR DESCRIPTION
Only merge if https://github.com/ROCm/pytorch/pull/1753 is merged!