### PR TITLE
[release/2.4] fix test_pointwise_op_fusion_post_grad

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -471,7 +471,7 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(counters["inductor"]["batch_aten_tanh"], 1)
         self.assertEqual(counters["inductor"]["batch_aten_relu"], 1)
         self.assertEqual(counters["inductor"]["batch_aten_sigmoid"], 1)
-        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 1)
+        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 2)
         ref.sum().backward()
         res.sum().backward()
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
rocm6.2_internal_testing and upstream compare `counters["inductor"]["unbind_stack_aten_pass"]` with `2`
https://github.com/ROCm/pytorch/blob/89f9b8db7b67cab32eeb1a00494397505c51ef39/test/inductor/test_group_batch_fusion.py#L476

