### PR TITLE
[ROCm] Inductor-gemm tuning

### DIFF
--- a/torch/_inductor/autotune_process.py
+++ b/torch/_inductor/autotune_process.py
@@ -630,6 +630,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         num_stages: int,
         num_warps: int,
         matrix_instr_nonkdim: int = 0,  # only used for hip to choose the shape of mfma instruction.
+        waves_per_eu: int = 0,  # only used on ROCm for scheduling waves per execution unit
+        kpack: int = 0,  # rocm specific gemm parameters
         workspace_arg: Optional[WorkspaceArg] = None,
     ) -> None:
         super().__init__(kernel_name, input_tensor_meta, output_tensor_meta, extra_args)
@@ -639,6 +641,8 @@ class TritonBenchmarkRequest(BenchmarkRequest):
         self.num_stages = num_stages
         self.num_warps = num_warps
         self.matrix_instr_nonkdim = matrix_instr_nonkdim
+        self.waves_per_eu = waves_per_eu
+        self.kpack = kpack
         self.workspace_arg = workspace_arg
 
     def make_run_fn(

--- a/torch/_inductor/kernel/conv.py
+++ b/torch/_inductor/kernel/conv.py
@@ -97,10 +97,11 @@ def conv_configs(m, n, k, *, device_type, **kwargs):
             n,
             k,
             configs=platform_configs,
+            extra_args={},
             scale=0.5,
             exclude=_is_large_block_for_cpu,
         )
-    return filtered_configs(m, n, k, configs=platform_configs)
+    return filtered_configs(m, n, k, configs=platform_configs, extra_args={})
 
 
 LOOP_BODY_2D = """

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -122,7 +122,7 @@ def filtered_configs(
         if extra_args is not None:
             group_m = extra_args.get("GROUP_M", 8)
             if torch.version.hip:
-                waves_per_eu = extra_args.get("waves_per_eu", 0)
+                waves_per_eu = extra_args.get("wpeu", 0)
         else:
             group_m = 8  # Default for NV
 

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -24,27 +24,25 @@ def _extract_configs(
     configs: List[Dict[str, Any]]
 ) -> Tuple[List[Tuple[int, int, int, int, int]], List[Optional[Dict[str, Any]]]]:
     """
-    Extracts platform configs and additional arguments if present, filtering by "cond".
+    Extracts triton configs and additional arguments if present filtered by a condition
 
     Args:
         configs (List[Dict[str, Any]]): List of configuration dictionaries. Each dictionary must have a "config" key
                                          and an optional "cond" key.
-
     Returns:
         Tuple[List[Tuple[int, int, int, int, int]], List[Optional[Dict[str, Any]]]]:
             A tuple containing two lists:
-              - base_configs: List of base configurations as tuples.
-              - extra_args: List of extra arguments (or None if no extra args exist).
+              - trion_configs: List of base configurations as tuples.
+              - extra_args: List of extra arguments supplied with the triton config.
     """
-    base_configs = []
+    triton_configs = []
     extra_args = []
     for config in configs:
         if config.get("cond", False):
-            base_configs.append(cast(Tuple[int, int, int, int, int], config["config"]))
-            extra_args.append(
-                {k: v for k, v in config.items() if k not in {"config", "cond"}} or None
-            )
-    return base_configs, extra_args
+            triton_configs.append(cast(Tuple[int, int, int, int, int], config["config"]))
+            filtered_args = {k: v for k, v in config.items() if k not in {"config", "cond"}}
+            extra_args.append(filtered_args)
+    return triton_configs, extra_args
 
 
 def triton_config(num_stages, num_warps, **kwargs):
@@ -63,7 +61,7 @@ def filtered_configs(
     n: int,
     k: int,
     configs: Sequence[Tuple[int, int, int, int, int]],
-    extra_args: Sequence[Optional[Dict[str, Any]]] = None,
+    extra_args: Sequence[Optional[Dict[str, Any]]],
     has_int8_tensor=False,
     scale=1,
     exclude=lambda m, n, k: False,

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -219,259 +219,265 @@ if torch.version.hip is None:
             for num_warps in [2, 4, 8]
         ]
     )
-
 else:
     rocm_num_stages = get_backend_num_stages()
-    if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE":
-        mm_kernel_configs = [
-            {
-                "config": (128, 128, 32, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 32, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 32, rocm_num_stages, 8),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 64, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 64, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 64, rocm_num_stages, 8),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 256, 32, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (128, 64, 16, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 64, 32, rocm_num_stages, 8),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 64, 32, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (128, 64, 64, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 64, 64, rocm_num_stages, 8),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (16, 16, 256, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (256, 128, 32, rocm_num_stages, 8),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (256, 128, 32, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (32, 16, 256, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (32, 32, 128, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (32, 64, 128, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (32, 64, 64, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (64, 128, 32, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (64, 128, 32, rocm_num_stages, 8),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (64, 128, 64, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (64, 16, 128, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (64, 16, 64, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 2,
-                "cond": True,
-            },
-            {
-                "config": (64, 64, 64, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (64, 64, 128, rocm_num_stages, 4),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (64, 128, 64, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 128, rocm_num_stages, 8),
-                "GROUP_M": 16,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (64, 128, 128, rocm_num_stages, 4),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 64, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 128, 64, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 0,
-                "mfma_size": 0,
-                "cond": True,
-            },
+    if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE"
+        mm_kernel_configs = (
+            [
+                {
+                    "config": (128, 128, 32, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 32, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 32, rocm_num_stages, 8),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 64, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 64, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 64, rocm_num_stages, 8),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 256, 32, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 64, 16, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 64, 32, rocm_num_stages, 8),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 64, 32, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 64, 64, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 64, 64, rocm_num_stages, 8),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (16, 16, 256, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (256, 128, 32, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (256, 128, 32, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (32, 16, 256, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (32, 32, 128, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (32, 64, 128, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (32, 64, 64, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 128, 32, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 128, 32, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 128, 64, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 16, 128, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 16, 64, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 64, 64, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 64, 128, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 128, 64, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 128, rocm_num_stages, 8),
+                    "GROUP_M": 16,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 128, 128, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 64, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 64, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 0,
+                    "mfma_size": 0,
+                    "kpack": 1,
+                    "cond": True,
+                },
 
-            {
-                "config": (64, 64, 32, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (256, 256, 64, rocm_num_stages, 8),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (256, 128, 64, rocm_num_stages, 8),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 256, 64, rocm_num_stages, 8),
-                "GROUP_M": 4,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 64, 128, rocm_num_stages, 8),
-                "GROUP_M": 8,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (32, 16, 128, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 0,
-                "cond": True,
-            },
-            {
-                "config": (128, 32, 32, rocm_num_stages, 4),
-                "GROUP_M": 8,
-                "wpeu": 2,
-                "cond": True,
-            },
-
-        ]
-    else:
-        [
-            {
-                "config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps),
-                "GROUP_M": GROUP_M,
-                "wpeu": waves_per_eu,
-                "cond": True,
-            }
-            for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
-                [16, 32, 64, 128, 256], repeat=3
+                {
+                    "config": (64, 64, 32, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (256, 256, 64, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (256, 128, 64, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 256, 64, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 64, 128, rocm_num_stages, 8),
+                    "GROUP_M": 8,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (32, 16, 128, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 32, 32, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+            ]
+        else: 
+            mm_kernel_configs = (
+                [
+                    {
+                        "config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps),
+                        "GROUP_M": GROUP_M,
+                        "wpeu": waves_per_eu,
+                        "mfma_size": matrix_instr_nonkdim,
+                        "kpack": kpack,
+                        "cond": True,
+                    }
+                    for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
+                        [16, 32, 64, 128, 256], repeat=3
+                    )
+                    for num_stages in [2]
+                    for num_warps in [4, 8]
+                    for waves_per_eu in [0, 2]
+                    for GROUP_M in [4, 8, 16]
+                    for matrix_instr_nonkdim in [0, 16]
+                    for kpack in [1, 2]
+                ]
             )
-            for num_stages in [2]
-            for num_warps in [4, 8]
-            for waves_per_eu in [0, 2]
-            for GROUP_M in [4, 8, 16]
-        ]
 
 
 # these are only used in tuned_mm when AutoHeuristic is enabled
@@ -517,8 +523,8 @@ mixed_mm_kernel_configs_small_m = [
 
 mixed_mm_kernel_configs = (
     mm_kernel_configs + mixed_mm_kernel_configs_small_m
-    if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE"
-    else mm_kernel_configs
+    #if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE"
+    #else mm_kernel_configs
 )
 
 scaled_mm_kernel_configs = [

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -438,6 +438,13 @@ else:
                 "wpeu": 0,
                 "cond": True,
             },
+            {
+                "config": (32, 16, 128, rocm_num_stages, 4),
+                "GROUP_M": 8,
+                "wpeu": 0,
+                "cond": True,
+            },
+
         ]
     else:
         [

--- a/torch/_inductor/kernel/mm_common.py
+++ b/torch/_inductor/kernel/mm_common.py
@@ -221,7 +221,7 @@ if torch.version.hip is None:
     )
 else:
     rocm_num_stages = get_backend_num_stages()
-    if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE"
+    if inductor_config.max_autotune_gemm_search_space != "EXHAUSTIVE":
         mm_kernel_configs = (
             [
                 {
@@ -455,29 +455,96 @@ else:
                     "wpeu": 2,
                     "cond": True,
                 },
+                {
+                    "config": (32, 256, 64, rocm_num_stages, 8),
+                    "GROUP_M": 8,
+                    "kpack": 1,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 128, 64, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "kpack": 1,
+                    "cond": True,
+                },
+                {
+                    "config": (16, 64, 128, rocm_num_stages, 8),
+                    "GROUP_M": 8,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 32, 16, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "kpack": 1,
+                    "wpeu": 2,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 64, 128, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "kpack": 1,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 32, 16, rocm_num_stages, 4),
+                    "GROUP_M": 16,
+                    "kpack": 1,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 256, 64, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "kpack": 1,
+                    "mfma_size": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 256, 16, rocm_num_stages, 4),
+                    "GROUP_M": 4,
+                    "kpack": 1,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 32, 32, rocm_num_stages, 4),
+                    "GROUP_M": 8,
+                    "kpack": 2,
+                    "mfma_size": 0,
+                    "cond": True,
+                },
+                {
+                    "config": (128, 128, 128, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "cond": True,
+                },
+                {
+                    "config": (64, 256, 32, rocm_num_stages, 8),
+                    "GROUP_M": 4,
+                    "cond": True,
+                },
             ]
-        else: 
-            mm_kernel_configs = (
-                [
-                    {
-                        "config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps),
-                        "GROUP_M": GROUP_M,
-                        "wpeu": waves_per_eu,
-                        "mfma_size": matrix_instr_nonkdim,
-                        "kpack": kpack,
-                        "cond": True,
-                    }
-                    for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
-                        [16, 32, 64, 128, 256], repeat=3
-                    )
-                    for num_stages in [2]
-                    for num_warps in [4, 8]
-                    for waves_per_eu in [0, 2]
-                    for GROUP_M in [4, 8, 16]
-                    for matrix_instr_nonkdim in [0, 16]
-                    for kpack in [1, 2]
-                ]
-            )
+        )
+    else: 
+        mm_kernel_configs = (
+            [
+                {
+                    "config": (BLOCK_M, BLOCK_N, BLOCK_K, num_stages, num_warps),
+                    "GROUP_M": GROUP_M,
+                    "wpeu": waves_per_eu,
+                    "mfma_size": matrix_instr_nonkdim,
+                    "kpack": kpack,
+                    "cond": True,
+                }
+                for BLOCK_M, BLOCK_N, BLOCK_K in itertools.product(
+                    [16, 32, 64, 128, 256], repeat=3
+                )
+                for num_stages in [2]
+                for num_warps in [4, 8]
+                for waves_per_eu in [0, 2]
+                for GROUP_M in [4, 8, 16]
+                for matrix_instr_nonkdim in [0, 16]
+                for kpack in [1, 2]
+            ]
+        )
 
 
 # these are only used in tuned_mm when AutoHeuristic is enabled

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -481,6 +481,10 @@ class CachingAutotuner(KernelInterface):
                     options["matrix_instr_nonkdim"] = compile_meta[
                         "matrix_instr_nonkdim"
                     ]
+                if "kpack" in compile_meta:
+                    options["kpack" = compile_meta[
+                        "kpack"
+                    ]
             compile_kwargs = {
                 "target": target,
                 "options": options,

--- a/torch/_inductor/runtime/triton_heuristics.py
+++ b/torch/_inductor/runtime/triton_heuristics.py
@@ -482,7 +482,7 @@ class CachingAutotuner(KernelInterface):
                         "matrix_instr_nonkdim"
                     ]
                 if "kpack" in compile_meta:
-                    options["kpack" = compile_meta[
+                    options["kpack"] = compile_meta[
                         "kpack"
                     ]
             compile_kwargs = {

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -340,15 +340,13 @@ class TritonTemplateKernel(TritonKernel):
         triton_meta["configs"] = [config_of(signature)]
         for arg_num in triton_meta["configs"][0].equal_to_1:  # type: ignore[index]
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index]
-        matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", 0)
-        waves_per_eu = self.meta.get("waves_per_eu", 0)
-        kpack = self.meta.get("kpack", 1)
-
-        if matrix_instr_nonkdim != 0:
+        
+        if torch.version.hip:
+            matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", 0)
+            waves_per_eu = self.meta.get("waves_per_eu", 0)
+            kpack = self.meta.get("kpack", 1) 
             triton_meta["matrix_instr_nonkdim"] = matrix_instr_nonkdim
-        if waves_per_eu != 0:
             triton_meta["waves_per_eu"] = waves_per_eu
-        if kpack != 0:
             triton_meta["kpack"] = kpack
 
         self.triton_meta = triton_meta
@@ -927,7 +925,7 @@ class TritonTemplate(KernelTemplate):
                 ),
                 "num_stages": num_stages,
                 "num_warps": num_warps,
-                "GROUP_M": kwargs.get("GROUP_M", -1)
+                "GROUP_M": kwargs.get("GROUP_M", -1),
                 "allow_tf32": str(kwargs.get("ALLOW_TF32", None)),
                 "acc_type": str(kwargs.get("ACC_TYPE", None)),
             },

--- a/torch/_inductor/select_algorithm.py
+++ b/torch/_inductor/select_algorithm.py
@@ -340,11 +340,11 @@ class TritonTemplateKernel(TritonKernel):
         triton_meta["configs"] = [config_of(signature)]
         for arg_num in triton_meta["configs"][0].equal_to_1:  # type: ignore[index]
             triton_meta["constants"][signature[arg_num].name] = 1  # type: ignore[index]
-        
+
         if torch.version.hip:
             matrix_instr_nonkdim = self.meta.get("matrix_instr_nonkdim", 0)
             waves_per_eu = self.meta.get("waves_per_eu", 0)
-            kpack = self.meta.get("kpack", 1) 
+            kpack = self.meta.get("kpack", 1)
             triton_meta["matrix_instr_nonkdim"] = matrix_instr_nonkdim
             triton_meta["waves_per_eu"] = waves_per_eu
             triton_meta["kpack"] = kpack


### PR DESCRIPTION
Adds tuning options for extra_args in mm_common.py on ROCm side we can supply specific triton tuning args such as waves_per_eu, kpack, matrix_instr_nonkdim. This PR also introduces behavior to allow tuning for GROUP_M in triton gemm case.

Also brings in specific tuning for general ROCm gemm case.