### PR TITLE
[release/2.5] Remove sanitized rocm path in install_miopen.sh

### DIFF
--- a/.ci/docker/common/install_miopen.sh
+++ b/.ci/docker/common/install_miopen.sh
@@ -55,7 +55,7 @@ retry () {
 }
 
 # Build custom MIOpen to use comgr for offline compilation.
-ROCM_INSTALL_PATH="/opt/rocm-${ROCM_VERSION}"
+ROCM_INSTALL_PATH="/opt/rocm"
 
 
 # MIOPEN_USE_HIP_KERNELS is a Workaround for COMgr issues

--- a/.ci/docker/common/install_miopen.sh
+++ b/.ci/docker/common/install_miopen.sh
@@ -55,16 +55,8 @@ retry () {
 }
 
 # Build custom MIOpen to use comgr for offline compilation.
+ROCM_INSTALL_PATH="/opt/rocm-${ROCM_VERSION}"
 
-## Need a sanitized ROCM_VERSION without patchlevel; patchlevel version 0 must be added to paths.
-ROCM_DOTS=$(echo ${ROCM_VERSION} | tr -d -c '.' | wc -c)
-if [[ ${ROCM_DOTS} == 1 ]]; then
-    ROCM_VERSION_NOPATCH="${ROCM_VERSION}"
-    ROCM_INSTALL_PATH="/opt/rocm-${ROCM_VERSION}.0"
-else
-    ROCM_VERSION_NOPATCH="${ROCM_VERSION%.*}"
-    ROCM_INSTALL_PATH="/opt/rocm-${ROCM_VERSION}"
-fi
 
 # MIOPEN_USE_HIP_KERNELS is a Workaround for COMgr issues
 MIOPEN_CMAKE_COMMON_FLAGS="


### PR DESCRIPTION
Issue origin: [SWDEV-500540](https://ontrack-internal.amd.com/browse/SWDEV-500540?focusedId=17699571&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17699571)
Fixes http://rocm-ci.amd.com/job/framework-pytorch-2.5-ci_rel-6.2/3/

With http://rocm-ci.amd.com/job/framework-pytorch-2.5-ci_rel-6.2/6/

