### PR TITLE
Copy trans fixl2 miss

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -142,138 +142,153 @@ void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
 bool is_permute_021(TensorIteratorBase &iter) {
   const auto& input = iter.tensor(1);
   const auto& output = iter.tensor(0);
-
   bool is_permute = false;
   if (input.dim() == 3) {
     is_permute = true;
     is_permute &= input.dim() == output.dim();
-    is_permute &= input.stride(0) == input.size(1) * input.size(2);
+
+    is_permute &= input.stride(0) == input.size(2) * input.stride(2);
     is_permute &= input.stride(1) == 1;
-    is_permute &= input.stride(2) == input.size(1);
+    is_permute &= input.stride(2) >= input.size(1);
     is_permute &= output.is_contiguous();
   }
   return is_permute;
 }
 
-template<class _T, int _WG>
-__global__ void transpose_tile_big_kernel(const void* __restrict a, void* __restrict c, const int N, const int K)
+template<class _T, int _WG, int BIG_TILE_SIZE_N, int BIG_TILE_SIZE_K>
+__global__ void transpose_tile_big_kernel(const void* __restrict a, void* __restrict c, const int N, const int K, const int STRIDE_N_ELE)
 {
-  constexpr uint32_t BIG_TILE_SIZE = 64;
-  // pad LDS row by dword
-  constexpr uint32_t LDS_PAD = (4 / sizeof(_T));
-  constexpr uint32_t element_size = sizeof(_T);  // in bytes
-  constexpr uint32_t elements_in_16B = 16 / element_size;
-
-  union BLOCK_16B
-  {
-      _T e[elements_in_16B];
-      __uint128_t ow;
-  };
-  // Round up processing to next full tile
-  const uint32_t n_tiles = (N + BIG_TILE_SIZE - 1) / BIG_TILE_SIZE;
-  const uint32_t k_tiles = (K + BIG_TILE_SIZE - 1) / BIG_TILE_SIZE;
-  const uint32_t nk_tiles = n_tiles * k_tiles;
-  const uint32_t m = blockIdx.x / nk_tiles;
-  const uint64_t stride_n = N * sizeof(_T);
-  const uint64_t stride_k = K * sizeof(_T);
-  const uint64_t stride_nk = N * K * sizeof(_T);
-
-  // Walk destination tiles continuously for cache coherency
-  constexpr uint32_t XCD = 8;
-  constexpr uint32_t SEQ = 8;
-  constexpr uint32_t sblk = XCD * SEQ;
-  const uint32_t max_swizzle = (nk_tiles / sblk) * sblk;
-  uint32_t tIdx = blockIdx.x % nk_tiles;
-  tIdx = tIdx > max_swizzle ? tIdx :
-      (tIdx / sblk) * sblk + (tIdx % sblk) / SEQ + (tIdx % SEQ) * XCD;
-  uint32_t ti = tIdx / k_tiles;
-  uint32_t tj = tIdx % k_tiles;
-
-   __shared__ _T sa[BIG_TILE_SIZE][BIG_TILE_SIZE + LDS_PAD];
-
-  // Detect partial tiles
-  uint32_t max_part_n = (ti == (n_tiles - 1) && (N % BIG_TILE_SIZE) != 0) ? (N % BIG_TILE_SIZE) : BIG_TILE_SIZE;
-  uint32_t max_part_k = (tj == (k_tiles - 1) && (K % BIG_TILE_SIZE) != 0) ? (K % BIG_TILE_SIZE) : BIG_TILE_SIZE;
-
-  if (max_part_n == BIG_TILE_SIZE && max_part_k == BIG_TILE_SIZE) {
-    // Copy full tile with large loads
-    constexpr uint32_t row_bytes = BIG_TILE_SIZE * sizeof(_T);
-    constexpr uint32_t vmem_per_row = row_bytes / sizeof(__uint128_t);
-    constexpr uint32_t rows_per_wg = _WG / vmem_per_row;
-    constexpr uint32_t vmem_per_thread = BIG_TILE_SIZE / rows_per_wg;
-    // Make sure WG isn't too large
-    static_assert(vmem_per_thread >= 1);
-
-    const uint8_t* pat = (const uint8_t*)a + tj * BIG_TILE_SIZE * stride_n + ti * row_bytes + m * stride_nk;
-    #pragma unroll
-    for (uint32_t t = 0; t < vmem_per_thread; t++)
+    constexpr uint32_t elements_in_16B = 8;
+    union BLOCK_16B
     {
-        uint32_t col = threadIdx.x % vmem_per_row;
-        uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
-        uint64_t offset = row * stride_n + col * sizeof(__uint128_t);
-        const __uint128_t* pfa = (const __uint128_t*)(pat + offset);
-        BLOCK_16B d;
-        d.ow = *pfa;
+        _T e[elements_in_16B];
+        __uint128_t ow;
+    };
+
+
+    constexpr int LDS_PAD = (4 / sizeof(_T));
+    // Round up processing to next full tile
+    const uint32_t n_tiles = (N + BIG_TILE_SIZE_N - 1) / BIG_TILE_SIZE_N;
+    const uint32_t k_tiles = (K + BIG_TILE_SIZE_K - 1) / BIG_TILE_SIZE_K;
+    const uint32_t nk_tiles = n_tiles * k_tiles;
+    const uint32_t m = blockIdx.x / 8 / nk_tiles * 8 + blockIdx.x % 8;
+    const uint64_t stride_n = STRIDE_N_ELE * sizeof(_T);
+    const uint64_t stride_k = N * sizeof(_T);
+    const uint64_t out_stride_nk = N * K * sizeof(_T);
+    const uint64_t in_stride_nk = N * STRIDE_N_ELE * sizeof(_T);
+
+    // Walk destination tiles continuously for cache coherency
+    constexpr uint32_t XCD = 8;
+    constexpr uint32_t SEQ = 8;
+    constexpr uint32_t sblk = XCD * SEQ;
+    const uint32_t max_swizzle = (nk_tiles / sblk) * sblk;
+    uint32_t tIdx = blockIdx.x / 8 % nk_tiles;
+    tIdx = tIdx > max_swizzle ? tIdx :
+        (tIdx / sblk) * sblk + (tIdx % sblk) / SEQ + (tIdx % SEQ) * XCD;
+    uint32_t ti = tIdx / k_tiles;
+    uint32_t tj = tIdx % k_tiles;
+
+    __shared__ _T sa[BIG_TILE_SIZE_N][BIG_TILE_SIZE_K + LDS_PAD];
+
+    // Detect partial tiles
+    uint32_t max_part_n = (ti == (n_tiles - 1) && (N % BIG_TILE_SIZE_N) != 0) ? (N % BIG_TILE_SIZE_N) : BIG_TILE_SIZE_N;
+    uint32_t max_part_k = (tj == (k_tiles - 1) && (K % BIG_TILE_SIZE_K) != 0) ? (K % BIG_TILE_SIZE_K) : BIG_TILE_SIZE_K;
+    if (max_part_n % 8 == 0 && max_part_k % 8 == 0)
+    {
+        // Copy full tile with large loads
+        constexpr uint32_t row_bytes = BIG_TILE_SIZE_K * sizeof(_T);
+        constexpr uint32_t vmem_per_row = row_bytes / sizeof(__uint128_t);
+        constexpr uint32_t rows_per_wg = _WG / vmem_per_row;
+        constexpr uint32_t vmem_per_thread = BIG_TILE_SIZE_N / rows_per_wg;
+        // Make sure WG isn't too large
+        static_assert(vmem_per_thread >= 1);
+
+        const uint8_t* pat = (const uint8_t*)a + tj * row_bytes + ti * BIG_TILE_SIZE_N * stride_n + m * in_stride_nk;
         #pragma unroll
-        for (uint32_t i = 0; i < elements_in_16B; i++)
+        for (uint32_t t = 0; t < vmem_per_thread; t++)
         {
-            sa[row][col * elements_in_16B + i] = d.e[i];
+            uint32_t col = threadIdx.x % vmem_per_row;
+            uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
+            uint64_t offset = (col * 8 < max_part_k && row < max_part_n) ?
+                    row * stride_n + col * sizeof(__uint128_t) : 0;
+            const __uint128_t* pfa = (const __uint128_t*)(pat + offset);
+            BLOCK_16B d;
+            d.ow = *pfa;
+            #pragma unroll
+            for (uint32_t i = 0; i < elements_in_16B; i++)
+            {
+                sa[row][col * elements_in_16B + i] = d.e[i];
+            }
+        }
+        __syncthreads();
+        // Copy full tile with large loads
+        constexpr uint32_t row_bytes_out = BIG_TILE_SIZE_N * sizeof(_T);
+        constexpr uint32_t vmem_per_row_out = row_bytes_out / sizeof(__uint128_t);
+        constexpr uint32_t rows_per_wg_out = _WG / vmem_per_row_out; 
+        constexpr uint32_t vmem_per_thread_out = BIG_TILE_SIZE_K / rows_per_wg_out; 
+        // Make sure WG isn't too large
+        static_assert(vmem_per_thread_out >= 1);
+        const uint8_t* pc = (const uint8_t*)c + tj * BIG_TILE_SIZE_K * stride_k + ti * row_bytes_out + m * out_stride_nk;
+        #pragma unroll
+        for (uint32_t t = 0; t < vmem_per_thread_out; t++)
+        {
+            uint32_t col = threadIdx.x % vmem_per_row_out;
+            uint32_t row = threadIdx.x / vmem_per_row_out + t * rows_per_wg_out;
+            if (col * 8 < max_part_n && row < max_part_k)
+            {
+                uint64_t offset = row * stride_k + col * sizeof(__uint128_t);
+                BLOCK_16B d;
+                // Transpose tile on read from LDS
+                #pragma unroll
+                for (uint32_t i = 0; i < elements_in_16B; i++)
+                {
+                    d.e[i] = sa[col * elements_in_16B + i][row];
+                }
+                __uint128_t* pfc = (__uint128_t*)(pc + offset);
+                *pfc = d.ow;
+            }
         }
     }
-    __syncthreads();
-
-    const uint8_t* pc = (const uint8_t*)c + ti * BIG_TILE_SIZE * stride_k + tj * row_bytes + m * stride_nk;
-    #pragma unroll
-    for (uint32_t t = 0; t < vmem_per_thread; t++)
+    else
     {
-        uint32_t col = threadIdx.x % vmem_per_row;
-        uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
-        uint64_t offset = row * stride_k + col * sizeof(__uint128_t);
-        BLOCK_16B d;
-        // Transpose tile on read from LDS
+        // Copy partial tiles with element accesses
+        constexpr uint32_t row_bytes = BIG_TILE_SIZE_K * sizeof(_T);
+        constexpr uint32_t vmem_per_row = BIG_TILE_SIZE_K;
+        constexpr uint32_t rows_per_wg = _WG / vmem_per_row;
+        constexpr uint32_t vmem_per_thread = BIG_TILE_SIZE_N / rows_per_wg;
+        // Make sure WG isn't too large
+        static_assert(vmem_per_thread >= 1);
+
+        const uint8_t* pat = (const uint8_t*)a + tj * row_bytes + ti * BIG_TILE_SIZE_N * stride_n + m * in_stride_nk;
         #pragma unroll
-        for (uint32_t i = 0; i < elements_in_16B; i++)
+        for (uint32_t t = 0; t < vmem_per_thread; t++)
         {
-            d.e[i] = sa[col * elements_in_16B + i][row];
+            uint32_t col = threadIdx.x % vmem_per_row;
+            uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
+            uint64_t offset = (col < max_part_k && row < max_part_n) ? row * stride_n + col * 2 : 0;
+            const uint16_t* pfa = (const uint16_t*)(pat + offset);
+            sa[row][col] = *pfa;
         }
-        __uint128_t* pfc = (__uint128_t*)(pc + offset);
-        *pfc = d.ow;
+        __syncthreads();
+        // Copy full tile with large loads
+        constexpr uint32_t row_bytes_out = BIG_TILE_SIZE_N * sizeof(_T);
+        constexpr uint32_t vmem_per_row_out = BIG_TILE_SIZE_N;
+        constexpr uint32_t rows_per_wg_out = _WG / vmem_per_row_out;
+        constexpr uint32_t vmem_per_thread_out = BIG_TILE_SIZE_K / rows_per_wg_out;
+        const uint8_t* pc = (const uint8_t*)c + tj * BIG_TILE_SIZE_K * stride_k + ti * row_bytes_out + m * out_stride_nk;
+        #pragma unroll
+        for (uint32_t t = 0; t < vmem_per_thread_out; t++)
+        {
+            uint32_t col = threadIdx.x % vmem_per_row_out;
+            uint32_t row = threadIdx.x / vmem_per_row_out + t * rows_per_wg_out;
+            if (col < max_part_n && row < max_part_k)
+            {
+                uint64_t offset = row * stride_k + col * 2;
+                uint16_t* pfc = (uint16_t*)(pc + offset);
+                *pfc = sa[col][row];
+            }
+        }
     }
-  } else {
-      // Copy partial tiles with element accesses
-      constexpr uint32_t row_bytes = BIG_TILE_SIZE * sizeof(_T);
-      constexpr uint32_t vmem_per_row = BIG_TILE_SIZE;
-      constexpr uint32_t rows_per_wg = _WG / vmem_per_row;
-      constexpr uint32_t vmem_per_thread = BIG_TILE_SIZE / rows_per_wg;
-      // Make sure WG isn't too large
-      static_assert(vmem_per_thread >= 1);
-
-      const uint8_t* pat = (const uint8_t*)a + tj * BIG_TILE_SIZE * stride_n + ti * row_bytes + m * stride_nk;
-      #pragma unroll
-      for (uint32_t t = 0; t < vmem_per_thread; t++)
-      {
-          uint32_t col = threadIdx.x % vmem_per_row;
-          uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
-          uint64_t offset = (col < max_part_n && row < max_part_k) ? row * stride_n + col * 2 : 0;
-          const uint16_t* pfa = (const uint16_t*)(pat + offset);
-          sa[row][col] = *pfa;
-      }
-      __syncthreads();
-
-      const uint8_t* pc = (const uint8_t*)c + ti * BIG_TILE_SIZE * stride_k + tj * row_bytes + m * stride_nk;
-      #pragma unroll
-      for (uint32_t t = 0; t < vmem_per_thread; t++)
-      {
-          uint32_t col = threadIdx.x % vmem_per_row;
-          uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
-          if (col < max_part_k && row < max_part_n)
-          {
-              uint64_t offset = row * stride_k + col * 2;
-              uint16_t* pfc = (uint16_t*)(pc + offset);
-              *pfc = sa[col][row];
-          }
-      }
-  }
 }
 
 void transpose_last2dim(TensorIteratorBase &iter) {
@@ -286,11 +301,12 @@ void transpose_last2dim(TensorIteratorBase &iter) {
   int K = input.size(2);
 
   auto stream = c10::cuda::getCurrentCUDAStream();
-  constexpr uint32_t BIG_TILE_SIZE = 64;
-  int big_tile_wg = M * ((N + BIG_TILE_SIZE - 1) / BIG_TILE_SIZE) * ((K + BIG_TILE_SIZE - 1) / BIG_TILE_SIZE);
+  constexpr uint32_t BIG_TILE_SIZE_N = 64;
+  constexpr uint32_t BIG_TILE_SIZE_K = 64;
+  int big_tile_wg = M * ((N + BIG_TILE_SIZE_N - 1) / BIG_TILE_SIZE_N) * ((K + BIG_TILE_SIZE_K - 1) / BIG_TILE_SIZE_K);
   const dim3 grid_dim(big_tile_wg, 1, 1);
   const dim3 block_dim(256, 1, 1);
-  transpose_tile_big_kernel<uint16_t, 256><<<grid_dim, block_dim, 0, stream>>>(src, dst, N, K);
+  transpose_tile_big_kernel<uint16_t, 256, BIG_TILE_SIZE_N, BIG_TILE_SIZE_K><<<grid_dim, block_dim, 0, stream>>>(src, dst, K, N, input.stride(2));
 }
 
 // TODO: We probably can use the opaque type trick to avoid creating duplicate
@@ -303,6 +319,8 @@ void direct_copy_kernel_cuda(TensorIteratorBase &iter) {
     });
   } else if (dtype == kFloat8_e5m2 || dtype == kFloat8_e4m3fn || dtype == kFloat8_e5m2fnuz || dtype == kFloat8_e4m3fnuz) {
      float8_copy_kernel_cuda(iter);
+  } else if (is_permute_021(iter) && (dtype == kBFloat16 || dtype == kHalf)) {
+      transpose_last2dim(iter);
   } else if (isBitsType(dtype)) {
     TORCH_CHECK(dtype == iter.dtype(1), "copy_() does not support casting "
       "bits types to different bits types. Source dtype is ", iter.dtype(1), "target dtype is ", dtype);

--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -155,94 +155,91 @@ bool is_permute_021(TensorIteratorBase &iter) {
   return is_permute;
 }
 
-template<class _T, int _WG, int BIG_TILE_SIZE_N, int BIG_TILE_SIZE_K>
+template<typename T, int BLOCK_SIZE, int BIG_TILE_SIZE_N, int BIG_TILE_SIZE_K, int M_SWIZZLE>
 __global__ void transpose_tile_big_kernel(const void* __restrict a, void* __restrict c, const int N, const int K, const int STRIDE_N_ELE)
 {
-    constexpr uint32_t elements_in_16B = 8;
+    constexpr uint32_t elements_in_128b = 16 / sizeof(T);
     union BLOCK_16B
     {
-        _T e[elements_in_16B];
+        T e[elements_in_128b];
         __uint128_t ow;
     };
 
-
-    constexpr int LDS_PAD = (4 / sizeof(_T));
+    constexpr int LDS_PAD = (4 / sizeof(T));
     // Round up processing to next full tile
     const uint32_t n_tiles = (N + BIG_TILE_SIZE_N - 1) / BIG_TILE_SIZE_N;
     const uint32_t k_tiles = (K + BIG_TILE_SIZE_K - 1) / BIG_TILE_SIZE_K;
     const uint32_t nk_tiles = n_tiles * k_tiles;
-    const uint32_t m = blockIdx.x / 8 / nk_tiles * 8 + blockIdx.x % 8;
-    const uint64_t stride_n = STRIDE_N_ELE * sizeof(_T);
-    const uint64_t stride_k = N * sizeof(_T);
-    const uint64_t out_stride_nk = N * K * sizeof(_T);
-    const uint64_t in_stride_nk = N * STRIDE_N_ELE * sizeof(_T);
+    const uint32_t m_tiles = gridDim.x / nk_tiles;
+    const uint32_t m_tile_swizzle = blockIdx.x / nk_tiles / M_SWIZZLE * M_SWIZZLE;
+    /// do m_swizzle when there are enough m_tiles
+    const bool swizzle_m = m_tile_swizzle + M_SWIZZLE <= m_tiles;
+    const uint32_t current_m = swizzle_m ? m_tile_swizzle + blockIdx.x % M_SWIZZLE : blockIdx.x / nk_tiles;
+    const uint64_t stride_n = STRIDE_N_ELE * sizeof(T);
+    const uint64_t stride_k = N * sizeof(T);
+    const uint64_t out_stride_nk = N * K * sizeof(T);
+    const uint64_t in_stride_nk = N * STRIDE_N_ELE * sizeof(T);
 
-    // Walk destination tiles continuously for cache coherency
-    constexpr uint32_t XCD = 8;
-    constexpr uint32_t SEQ = 8;
-    constexpr uint32_t sblk = XCD * SEQ;
-    const uint32_t max_swizzle = (nk_tiles / sblk) * sblk;
-    uint32_t tIdx = blockIdx.x / 8 % nk_tiles;
-    tIdx = tIdx > max_swizzle ? tIdx :
-        (tIdx / sblk) * sblk + (tIdx % sblk) / SEQ + (tIdx % SEQ) * XCD;
-    uint32_t ti = tIdx / k_tiles;
-    uint32_t tj = tIdx % k_tiles;
+    const uint32_t current_nk = swizzle_m ? blockIdx.x / M_SWIZZLE % nk_tiles : blockIdx.x % nk_tiles;
+    const uint32_t ti = current_nk / k_tiles;
+    const uint32_t tj = current_nk % k_tiles;
 
-    __shared__ _T sa[BIG_TILE_SIZE_N][BIG_TILE_SIZE_K + LDS_PAD];
+    __shared__ T smem[BIG_TILE_SIZE_N][BIG_TILE_SIZE_K + LDS_PAD];
 
     // Detect partial tiles
-    uint32_t max_part_n = (ti == (n_tiles - 1) && (N % BIG_TILE_SIZE_N) != 0) ? (N % BIG_TILE_SIZE_N) : BIG_TILE_SIZE_N;
-    uint32_t max_part_k = (tj == (k_tiles - 1) && (K % BIG_TILE_SIZE_K) != 0) ? (K % BIG_TILE_SIZE_K) : BIG_TILE_SIZE_K;
-    if (max_part_n % 8 == 0 && max_part_k % 8 == 0)
+    const uint32_t current_n_size = (ti == (n_tiles - 1) && (N % BIG_TILE_SIZE_N) != 0) ? (N % BIG_TILE_SIZE_N) : BIG_TILE_SIZE_N;
+    const uint32_t current_k_size = (tj == (k_tiles - 1) && (K % BIG_TILE_SIZE_K) != 0) ? (K % BIG_TILE_SIZE_K) : BIG_TILE_SIZE_K;
+    //use 128bit load&store whenever possible
+    if (current_n_size % 8 == 0 && current_k_size % 8 == 0)
     {
         // Copy full tile with large loads
-        constexpr uint32_t row_bytes = BIG_TILE_SIZE_K * sizeof(_T);
-        constexpr uint32_t vmem_per_row = row_bytes / sizeof(__uint128_t);
-        constexpr uint32_t rows_per_wg = _WG / vmem_per_row;
+        constexpr uint32_t row_bytes = BIG_TILE_SIZE_K * sizeof(T);
+        constexpr uint32_t ld_per_row = row_bytes / sizeof(__uint128_t);
+        constexpr uint32_t rows_per_wg = BLOCK_SIZE / ld_per_row;
         constexpr uint32_t vmem_per_thread = BIG_TILE_SIZE_N / rows_per_wg;
         // Make sure WG isn't too large
         static_assert(vmem_per_thread >= 1);
 
-        const uint8_t* pat = (const uint8_t*)a + tj * row_bytes + ti * BIG_TILE_SIZE_N * stride_n + m * in_stride_nk;
+        const uint8_t* pat = (const uint8_t*)a + tj * row_bytes + ti * BIG_TILE_SIZE_N * stride_n + current_m * in_stride_nk;
         #pragma unroll
         for (uint32_t t = 0; t < vmem_per_thread; t++)
         {
-            uint32_t col = threadIdx.x % vmem_per_row;
-            uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
-            uint64_t offset = (col * 8 < max_part_k && row < max_part_n) ?
+            uint32_t col = threadIdx.x % ld_per_row;
+            uint32_t row = threadIdx.x / ld_per_row + t * rows_per_wg;
+            uint64_t offset = (col * 8 < current_k_size && row < current_n_size) ?
                     row * stride_n + col * sizeof(__uint128_t) : 0;
             const __uint128_t* pfa = (const __uint128_t*)(pat + offset);
             BLOCK_16B d;
             d.ow = *pfa;
             #pragma unroll
-            for (uint32_t i = 0; i < elements_in_16B; i++)
+            for (uint32_t i = 0; i < elements_in_128b; i++)
             {
-                sa[row][col * elements_in_16B + i] = d.e[i];
+                smem[row][col * elements_in_128b + i] = d.e[i];
             }
         }
         __syncthreads();
         // Copy full tile with large loads
-        constexpr uint32_t row_bytes_out = BIG_TILE_SIZE_N * sizeof(_T);
-        constexpr uint32_t vmem_per_row_out = row_bytes_out / sizeof(__uint128_t);
-        constexpr uint32_t rows_per_wg_out = _WG / vmem_per_row_out; 
-        constexpr uint32_t vmem_per_thread_out = BIG_TILE_SIZE_K / rows_per_wg_out; 
+        constexpr uint32_t row_bytes_wr = BIG_TILE_SIZE_N * sizeof(T);
+        constexpr uint32_t vmem_per_row_wr = row_bytes_wr / sizeof(__uint128_t);
+        constexpr uint32_t rows_per_wg_wr = BLOCK_SIZE / vmem_per_row_wr; 
+        constexpr uint32_t wr_per_row = BIG_TILE_SIZE_K / rows_per_wg_wr; 
         // Make sure WG isn't too large
-        static_assert(vmem_per_thread_out >= 1);
-        const uint8_t* pc = (const uint8_t*)c + tj * BIG_TILE_SIZE_K * stride_k + ti * row_bytes_out + m * out_stride_nk;
+        static_assert(wr_per_row >= 1);
+        const uint8_t* pc = (const uint8_t*)c + tj * BIG_TILE_SIZE_K * stride_k + ti * row_bytes_wr + current_m * out_stride_nk;
         #pragma unroll
-        for (uint32_t t = 0; t < vmem_per_thread_out; t++)
+        for (uint32_t t = 0; t < wr_per_row; t++)
         {
-            uint32_t col = threadIdx.x % vmem_per_row_out;
-            uint32_t row = threadIdx.x / vmem_per_row_out + t * rows_per_wg_out;
-            if (col * 8 < max_part_n && row < max_part_k)
+            uint32_t col = threadIdx.x % vmem_per_row_wr;
+            uint32_t row = threadIdx.x / vmem_per_row_wr + t * rows_per_wg_wr;
+            if (col * 8 < current_n_size && row < current_k_size)
             {
                 uint64_t offset = row * stride_k + col * sizeof(__uint128_t);
                 BLOCK_16B d;
                 // Transpose tile on read from LDS
                 #pragma unroll
-                for (uint32_t i = 0; i < elements_in_16B; i++)
+                for (uint32_t i = 0; i < elements_in_128b; i++)
                 {
-                    d.e[i] = sa[col * elements_in_16B + i][row];
+                    d.e[i] = smem[col * elements_in_128b + i][row];
                 }
                 __uint128_t* pfc = (__uint128_t*)(pc + offset);
                 *pfc = d.ow;
@@ -252,40 +249,40 @@ __global__ void transpose_tile_big_kernel(const void* __restrict a, void* __rest
     else
     {
         // Copy partial tiles with element accesses
-        constexpr uint32_t row_bytes = BIG_TILE_SIZE_K * sizeof(_T);
-        constexpr uint32_t vmem_per_row = BIG_TILE_SIZE_K;
-        constexpr uint32_t rows_per_wg = _WG / vmem_per_row;
+        constexpr uint32_t row_bytes = BIG_TILE_SIZE_K * sizeof(T);
+        constexpr uint32_t ld_per_row = BIG_TILE_SIZE_K;
+        constexpr uint32_t rows_per_wg = BLOCK_SIZE / ld_per_row;
         constexpr uint32_t vmem_per_thread = BIG_TILE_SIZE_N / rows_per_wg;
         // Make sure WG isn't too large
         static_assert(vmem_per_thread >= 1);
 
-        const uint8_t* pat = (const uint8_t*)a + tj * row_bytes + ti * BIG_TILE_SIZE_N * stride_n + m * in_stride_nk;
+        const uint8_t* pat = (const uint8_t*)a + tj * row_bytes + ti * BIG_TILE_SIZE_N * stride_n + current_m * in_stride_nk;
         #pragma unroll
         for (uint32_t t = 0; t < vmem_per_thread; t++)
         {
-            uint32_t col = threadIdx.x % vmem_per_row;
-            uint32_t row = threadIdx.x / vmem_per_row + t * rows_per_wg;
-            uint64_t offset = (col < max_part_k && row < max_part_n) ? row * stride_n + col * 2 : 0;
+            uint32_t col = threadIdx.x % ld_per_row;
+            uint32_t row = threadIdx.x / ld_per_row + t * rows_per_wg;
+            uint64_t offset = (col < current_k_size && row < current_n_size) ? row * stride_n + col * 2 : 0;
             const uint16_t* pfa = (const uint16_t*)(pat + offset);
-            sa[row][col] = *pfa;
+            smem[row][col] = *pfa;
         }
         __syncthreads();
         // Copy full tile with large loads
-        constexpr uint32_t row_bytes_out = BIG_TILE_SIZE_N * sizeof(_T);
-        constexpr uint32_t vmem_per_row_out = BIG_TILE_SIZE_N;
-        constexpr uint32_t rows_per_wg_out = _WG / vmem_per_row_out;
-        constexpr uint32_t vmem_per_thread_out = BIG_TILE_SIZE_K / rows_per_wg_out;
-        const uint8_t* pc = (const uint8_t*)c + tj * BIG_TILE_SIZE_K * stride_k + ti * row_bytes_out + m * out_stride_nk;
+        constexpr uint32_t row_bytes_wr = BIG_TILE_SIZE_N * sizeof(T);
+        constexpr uint32_t vmem_per_row_wr = BIG_TILE_SIZE_N;
+        constexpr uint32_t rows_per_wg_wr = BLOCK_SIZE / vmem_per_row_wr;
+        constexpr uint32_t wr_per_row = BIG_TILE_SIZE_K / rows_per_wg_wr;
+        const uint8_t* pc = (const uint8_t*)c + tj * BIG_TILE_SIZE_K * stride_k + ti * row_bytes_wr + current_m * out_stride_nk;
         #pragma unroll
-        for (uint32_t t = 0; t < vmem_per_thread_out; t++)
+        for (uint32_t t = 0; t < wr_per_row; t++)
         {
-            uint32_t col = threadIdx.x % vmem_per_row_out;
-            uint32_t row = threadIdx.x / vmem_per_row_out + t * rows_per_wg_out;
-            if (col < max_part_n && row < max_part_k)
+            uint32_t col = threadIdx.x % vmem_per_row_wr;
+            uint32_t row = threadIdx.x / vmem_per_row_wr + t * rows_per_wg_wr;
+            if (col < current_n_size && row < current_k_size)
             {
                 uint64_t offset = row * stride_k + col * 2;
                 uint16_t* pfc = (uint16_t*)(pc + offset);
-                *pfc = sa[col][row];
+                *pfc = smem[col][row];
             }
         }
     }
@@ -303,10 +300,11 @@ void transpose_last2dim(TensorIteratorBase &iter) {
   auto stream = c10::cuda::getCurrentCUDAStream();
   constexpr uint32_t BIG_TILE_SIZE_N = 64;
   constexpr uint32_t BIG_TILE_SIZE_K = 64;
-  int big_tile_wg = M * ((N + BIG_TILE_SIZE_N - 1) / BIG_TILE_SIZE_N) * ((K + BIG_TILE_SIZE_K - 1) / BIG_TILE_SIZE_K);
-  const dim3 grid_dim(big_tile_wg, 1, 1);
+  constexpr uint32_t M_SWIZZLE = 8;
+  const int grid_x = M * ((N + BIG_TILE_SIZE_N - 1) / BIG_TILE_SIZE_N) * ((K + BIG_TILE_SIZE_K - 1) / BIG_TILE_SIZE_K);
+  const dim3 grid_dim(grid_x, 1, 1);
   const dim3 block_dim(256, 1, 1);
-  transpose_tile_big_kernel<uint16_t, 256, BIG_TILE_SIZE_N, BIG_TILE_SIZE_K><<<grid_dim, block_dim, 0, stream>>>(src, dst, K, N, input.stride(2));
+  transpose_tile_big_kernel<uint16_t, 256, BIG_TILE_SIZE_N, BIG_TILE_SIZE_K, M_SWIZZLE><<<grid_dim, block_dim, 0, stream>>>(src, dst, K, N, input.stride(2));
 }
 
 // TODO: We probably can use the opaque type trick to avoid creating duplicate

--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -565,14 +565,11 @@ struct ReduceOp {
     using load_t = at::native::memory::aligned_vector<scalar_t, output_vec_size>;
 
     // Multiple accumulators to remove dependency between unrolled loops.
-    arg_vec_t value_list[vt0];
+    arg_vec_t value_list;
 
     #pragma unroll
-    for (int i = 0; i < vt0; i++) {
-      #pragma unroll
-      for (int j = 0; j < output_vec_size; j++) {
-        value_list[i][j] = ident;
-      }
+    for (int j = 0; j < output_vec_size; j++) {
+      value_list[j] = ident;
     }
 
     load_t values[vt0];
@@ -587,7 +584,7 @@ struct ReduceOp {
       for (index_t i = 0; i < vt0; i++) {
         #pragma unroll
         for (index_t j = 0; j < output_vec_size; j++) {
-          value_list[i][j] = ops.reduce(value_list[i][j], values[i].val[j], idx + i * stride);
+          value_list[j] = ops.reduce(value_list[j], values[i].val[j], idx + i * stride);
         }
       }
       idx += stride * vt0;
@@ -612,20 +609,12 @@ struct ReduceOp {
       }
       #pragma unroll
       for (index_t j = 0; j < output_vec_size; j++) {
-        value_list[i][j] = ops.reduce(value_list[i][j], values[i].val[j], idx);
+        value_list[j] = ops.reduce(value_list[j], values[i].val[j], idx);
       }
       idx += stride;
     }
 
-    // combine accumulators
-    #pragma unroll
-    for (int i = 1; i < vt0; i++) {
-      #pragma unroll
-      for (index_t j = 0; j < output_vec_size; j++) {
-        value_list[0][j] = ops.combine(value_list[0][j], value_list[i][j]);
-      }
-    }
-    return value_list[0];
+    return value_list;
   }
 
   template <int output_vec_size>


### PR DESCRIPTION
- optimize copy transpose op:
-   fix cacheline miss in L2
-   performance 2x for large shapes lastdim % 64 != 0
-   reach 4TB/s for typical cases 