### PR TITLE
FEAT:at least one of ROCM_HOME or CUDA_HOME must be None.

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -205,7 +205,11 @@ ROCM_VERSION = None
 if torch.version.hip is not None:
     ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
 
-CUDA_HOME = _find_cuda_home() if torch.cuda._is_compiled() else None
+CUDA_HOME = (
+    _find_cuda_home()
+    if ((not IS_HIP_EXTENSION) and (torch.cuda._is_compiled()))
+    else None
+)
 CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')
 # PyTorch releases have the version pattern major.minor.patch, whereas when
 # PyTorch is built from source, we append the git commit hash, which gives


### PR DESCRIPTION
This PR is a release/2.5-based version of https://github.com/ROCm/pytorch/pull/1809

Copied description by @hj-wei from https://github.com/ROCm/pytorch/pull/1809

> Hi all, I manually generating nvcc to bypass NVIDIA component checks(Megatron-LM),
see https://github.com/NVIDIA/Megatron-LM/blob/2da43ef4c1b9e76f03b7567360cf7390e877f1b6/megatron/legacy/fused_kernels/__init__.py#L57

> but it can lead to incorrect CUDA_HOME configurations. This can cause initialization anomalies in downstream libraries like DeepSpeed
