### PR TITLE
[AUTOGENERATED] [release/2.4] FEAT:at least one of ROCM_HOME or CUDA_HOME must be None.

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -205,7 +205,11 @@ ROCM_VERSION = None
 if torch.version.hip is not None:
     ROCM_VERSION = tuple(int(v) for v in torch.version.hip.split('.')[:2])
 
-CUDA_HOME = _find_cuda_home() if torch.cuda._is_compiled() else None
+CUDA_HOME = (
+    _find_cuda_home()
+    if ((not IS_HIP_EXTENSION) and (torch.cuda._is_compiled()))
+    else None
+)
 CUDNN_HOME = os.environ.get('CUDNN_HOME') or os.environ.get('CUDNN_PATH')
 # PyTorch releases have the version pattern major.minor.patch, whereas when
 # PyTorch is built from source, we append the git commit hash, which gives


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/1814 