### PR TITLE
[Release/2.4] Fixes 10211 - Deselecting the efficient attention backend for scaled dot product function in ROCm

### DIFF
--- a/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
+++ b/aten/src/ATen/native/transformers/cuda/sdp_utils.cpp
@@ -644,6 +644,11 @@ bool can_use_mem_efficient_attention(sdp_params const& params, bool debug) {
   constexpr auto less_than_sm80_mem_efficient_dtypes =
       array_of<at::ScalarType>(at::kHalf, at::kFloat);
 #ifdef USE_ROCM
+ if (params.is_causal){
+     return false ;
+ }
+
+
   constexpr auto aotriton_mem_efficient_dtypes =
       array_of<at::ScalarType>(at::kHalf, at::kFloat, at::kBFloat16);
 #endif

--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -2339,7 +2339,6 @@ class TestOperators(TestCase):
             skip("sparse.sampled_addmm", ""),
             skip("sparse.mm", "reduce"),
             skip("native_layer_norm", "", device_type="cpu"),
-            skip("nn.functional.scaled_dot_product_attention", "", device_type="cuda"), # temp skip
             # RuntimeError: Expected contiguous tensor, but got
             # non-contiguous tensor for argument #2 'grad_output'
             decorate(


### PR DESCRIPTION
Fixes [10211](https://github.com/ROCm/frameworks-internal/issues/10211) 

Deselecting the efficient attention backend for scaled dot product function for ROCm architecture when casual parameter is True.
Reference - https://github.com/ROCm/aotriton/issues/25 
We are aware of this issue but the precise ETA has not been determined at the moment due to various missing functionalities in AOTriton, (varlen, MQA, causal variants, etc.)


