### PR TITLE
[AUTOGENERATED] [release/2.5] [ROCm] Enable vector size for 8 for half precision types in elementwise kernels

### DIFF
--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -116,6 +116,11 @@ static inline void launch_vectorized_kernel(
   int vec_size = memory::can_vectorize_up_to<func_t>(data);
 
   switch (vec_size) {
+    case 8:
+      vectorized_elementwise_kernel<8, func_t, array_t>
+          <<<grid, num_threads(), 0, stream>>>(N, f, data);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      break;
     case 4:
       vectorized_elementwise_kernel<4, func_t, array_t>
           <<<grid, num_threads(), 0, stream>>>(N, f, data);

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -350,11 +350,23 @@ inline C10_HOST_DEVICE int can_vectorize_up_to(const char *pointer) {
   uint64_t address = reinterpret_cast<uint64_t>(pointer);
   constexpr int vec2_alignment = std::alignment_of<aligned_vector<scalar_t, 2>>::value;
   constexpr int vec4_alignment = std::alignment_of<aligned_vector<scalar_t, 4>>::value;
+#if defined(USE_ROCM)
+  constexpr int vec8_alignment = std::alignment_of<aligned_vector<scalar_t, 8>>::value;
+  constexpr bool half_dtype = std::is_same_v<c10::BFloat16, scalar_t> || std::is_same_v<c10::Half, scalar_t>;
+  if (half_dtype && (address % vec8_alignment == 0)) {
+    return 8;
+  } else if (address % vec4_alignment == 0) {
+    return 4;
+  } else if (address % vec2_alignment == 0) {
+    return 2;
+  }
+#else
   if (address % vec4_alignment == 0) {
     return 4;
   } else if (address % vec2_alignment == 0) {
     return 2;
   }
+#endif
   return 1;
 }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/1738 