### PR TITLE
[rocm6.4_internal_testing] merge miopen bf16/fp16 mixed batchnorm

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -61,6 +61,7 @@
 #include <c10/core/SymIntArrayRef.h>
 #include <utility>
 #include <vector>
+#include <iostream>
 
 static const int MIOPEN_DIM_MAX = 5;
 
@@ -490,12 +491,27 @@ std::tuple<Tensor, Tensor, Tensor> batch_norm_backward_cpu_template(
   return std::make_tuple(grad_input, grad_weight, grad_bias);
 }
 
+static bool PYTORCH_MIOPEN_EXTRA_LOGGING = c10::utils::check_env("PYTORCH_MIOPEN_EXTRA_LOGGING").value_or(false);
+
 BatchNormBackend _select_batch_norm_backend(
     const Tensor& input, const Tensor& weight, const Tensor& bias, const Tensor& running_mean,
     const Tensor& running_var, bool training, double eps) {
 
   auto& ctx = at::globalContext();
   bool cudnn_enabled = ctx.userEnabledCuDNN();
+
+  if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+    std::cout
+      << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _select_batch_norm_backend"
+      << " cudnn_enabled=" << cudnn_enabled
+      << " input.dtype=" << input.scalar_type() << ":" << input.suggest_memory_format()
+      << " weight.dtype=" << (weight.defined()?"+":"-") << weight.scalar_type()
+      << " bias.dtype=" << (bias.defined()?"+":"-") << bias.scalar_type()
+      << " running_mean.dtype=" << (running_mean.defined()?"+":"-") << running_mean.scalar_type()
+      << " running_var.dtype=" << (running_mean.defined()?"+":"-") << running_mean.scalar_type()
+      << " training=" << training
+      << " input.dim=" << input.dim()
+      << std::endl;
 
   if (
       input.is_cuda()
@@ -525,8 +541,8 @@ BatchNormBackend _select_batch_norm_backend(
       input.is_cuda()
       && input.dim() <= MIOPEN_DIM_MAX
       && input.scalar_type() != at::kDouble
-      && input.scalar_type() != at::kBFloat16
       && (weight.scalar_type() != at::kHalf)
+      && (weight.scalar_type() != at::kBFloat16)
       && weight.defined() && bias.defined()
       && ((running_mean.defined() && running_var.defined())
         || (!running_mean.defined() && !running_var.defined() && training))
@@ -552,6 +568,20 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
     const Tensor& input, const std::optional<Tensor>& weight_opt /* optional */, const std::optional<Tensor>& bias_opt /* optional */, const std::optional<Tensor>& running_mean_opt /* optional */, const std::optional<Tensor>& running_var_opt /* optional */,
     bool training, double momentum, double eps, bool cudnn_enabled) {
   // See [Note: hacky wrapper removal for optional tensor]
+  if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+    std::cout
+      << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index"
+      << " input=" << input.scalar_type()
+      << " weight=" << (weight_opt.has_value() ? weight_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " bias=" << (bias_opt.has_value() ? bias_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " running_mean=" << (running_mean_opt.has_value() ? running_mean_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " running_var=" << (running_var_opt.has_value() ? running_var_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " training=" << training
+      // << " momentum=" << momentum
+      // << " eps=" << eps
+      << " cudnn_enabled=" << cudnn_enabled
+      << std::endl;
+
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
   const Tensor& bias = bias_opt.value_or(Tensor());
@@ -611,7 +641,24 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
 
   Tensor reserve = at::empty({0}, input.options().dtype(kByte));
 
+  if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+    std::cout
+            << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (use_miopen)"
+	          << " use_miopen=" << (backend == BatchNormBackend::Miopen)
+            << " cudnn_enabled=" << cudnn_enabled
+            << " dim=" << input.dim()
+            << " memory_format=" << input.suggest_memory_format()
+            << " input.dtype=" << input.scalar_type()
+            << " weight.dtype=" << (weight.defined()?"+":"-") << weight.scalar_type()
+            << " bias.dtype=" << (bias.defined()?"+":"-") << bias.scalar_type()
+            << " running_mean.dtype=" << (running_mean.defined()?"+":"-") << running_mean.scalar_type()
+            << " running_var.dtype=" << (running_mean.defined()?"+":"-") << running_mean.scalar_type()
+            << " training=" << training
+            << std::endl;
+
   if (backend == BatchNormBackend::Miopen) {
+    if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+	    std::cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (calling miopen_batch_norm)" << std::endl;
     return std::tuple_cat(
              at::miopen_batch_norm(
                input.contiguous(input.suggest_memory_format()), weight.contiguous(), bias.contiguous(),
@@ -634,6 +681,8 @@ std::tuple<Tensor, Tensor, Tensor> _batch_norm_impl_index_backward(
     const Tensor& input, const Tensor& grad_output, const std::optional<Tensor>& weight_opt /* optional */, const std::optional<Tensor>& running_mean_opt /* optional */, const std::optional<Tensor>& running_var_opt /* optional */, const std::optional<Tensor>& save_mean_opt /* optional */, const std::optional<Tensor>& save_var_transform_opt /* optional */,
     bool train, double epsilon, std::array<bool, 3> output_mask, const Tensor &reservedSpace) {
   // See [Note: hacky wrapper removal for optional tensor]
+  if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+    std :: cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index_backward" << std::endl;
   c10::MaybeOwned<Tensor> weight_maybe_owned = at::borrow_from_optional_tensor(weight_opt);
   const Tensor& weight = *weight_maybe_owned;
   const Tensor& running_mean = running_mean_opt.value_or(Tensor());
@@ -664,12 +713,16 @@ std::tuple<Tensor, Tensor, Tensor> _batch_norm_impl_index_backward(
 
   // backward in inference mode is not supported in cudnn, fallback to native
   if (impl_index == 0 || (!train)) {
+    if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+      std :: cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index_backward (calling native_batch_norm_backward)" << std::endl;
     return at::native_batch_norm_backward(grad_output, input, weight, running_mean, running_var, save_mean, save_var_transform, train, epsilon, output_mask);
   } else if (impl_index == 1) {
     // TODO: _batch_norm_impl_index_backward is only used in JIT. cudnn NHWC
     // format conversion is done inside cudnn_batch_norm_backward instead
     return at::cudnn_batch_norm_backward(input, grad_output, weight, running_mean, running_var, save_mean, save_var_transform, epsilon, reservedSpace);
   } else if (impl_index == 2) {
+    if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+      std :: cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index_backward (calling miopen_batch_norm_backward)" << std::endl;
     return at::miopen_batch_norm_backward(input, grad_output, weight, running_mean, running_var, save_mean, save_var_transform, epsilon);
   }
   TORCH_INTERNAL_ASSERT(false, "Unsupported impl_index in _batch_norm_impl_index_backward: ", impl_index);
@@ -680,10 +733,26 @@ Tensor batch_norm(
     const Tensor& input, const std::optional<Tensor>& weight_opt, const std::optional<Tensor>& bias_opt,
     const std::optional<Tensor>& running_mean_opt, const std::optional<Tensor>& running_var_opt,
     bool training, double momentum, double eps, bool cudnn_enabled) {
+
+  if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+    std :: cout
+      << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* batch_norm"
+      << " input=" << input.scalar_type()
+      << " weight=" << (weight_opt.has_value() ? weight_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " bias=" << (bias_opt.has_value() ? bias_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " running_mean=" << (running_mean_opt.has_value() ? running_mean_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " running_var=" << (running_var_opt.has_value() ? running_var_opt.value().scalar_type() : at::ScalarType::Undefined)
+      << " training=" << training
+      // << " momentum=" << momentum
+      // << " eps=" << eps
+      << " cudnn_enabled=" << cudnn_enabled
+      << std::endl;
+
   const Tensor& weight = weight_opt.value_or(Tensor());
   const Tensor& bias = bias_opt.value_or(Tensor());
   const Tensor& running_mean = running_mean_opt.value_or(Tensor());
   const Tensor& running_var = running_var_opt.value_or(Tensor());
+
   return std::get<0>(at::_batch_norm_impl_index(input, weight, bias, running_mean, running_var,
                                                 training, momentum, eps, cudnn_enabled));
   // TODO: switch to the new stack after the 2 week FC window

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -539,10 +539,9 @@ BatchNormBackend _select_batch_norm_backend(
 
   if (
       input.is_cuda()
-      && input.dim() <= MIOPEN_DIM_MAX
-      && input.scalar_type() != at::kDouble
-      && (weight.scalar_type() != at::kHalf)
-      && (weight.scalar_type() != at::kBFloat16)
+      && (input.dim() <= MIOPEN_DIM_MAX)
+      && (input.scalar_type() != at::kDouble)
+      && (weight.scalar_type() == at::kFloat)
       && weight.defined() && bias.defined()
       && ((running_mean.defined() && running_var.defined())
         || (!running_mean.defined() && !running_var.defined() && training))
@@ -668,6 +667,9 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
              std::tuple<Tensor>(reserve),
              std::make_tuple(2));
   }
+
+  if (PYTORCH_MIOPEN_EXTRA_LOGGING)
+    std::cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (calling native_batch_norm)" << std::endl;
 
   return std::tuple_cat(
            at::native_batch_norm(

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -643,7 +643,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
   if (PYTORCH_MIOPEN_EXTRA_LOGGING)
     std::cout
             << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (use_miopen)"
-	          << " use_miopen=" << (backend == BatchNormBackend::Miopen)
+            << " use_miopen=" << (backend == BatchNormBackend::Miopen)
             << " cudnn_enabled=" << cudnn_enabled
             << " dim=" << input.dim()
             << " memory_format=" << input.suggest_memory_format()
@@ -657,7 +657,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
 
   if (backend == BatchNormBackend::Miopen) {
     if (PYTORCH_MIOPEN_EXTRA_LOGGING)
-	    std::cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (calling miopen_batch_norm)" << std::endl;
+      std::cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (calling miopen_batch_norm)" << std::endl;
     return std::tuple_cat(
              at::miopen_batch_norm(
                input.contiguous(input.suggest_memory_format()), weight.contiguous(), bias.contiguous(),

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -79,7 +79,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     checkAllDefined(c, {running_mean, running_var});
   }
   checkAllSameGPU(c, {input, weight, bias, running_mean, running_var});
-  if (input->scalar_type() != ScalarType::Half) {
+  if (input->scalar_type() != ScalarType::Half && input->scalar_type() != ScalarType::BFloat16) {
     checkAllSameType(c, {input, weight});
   }
   checkAllSameType(c, {weight, bias, running_mean, running_var});
@@ -188,7 +188,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
 
   checkAllDefined(c, {input, grad_output, weight, save_mean, save_var});
   checkAllSameGPU(c, {input, grad_output, weight, save_mean, save_var});
-  if (input->scalar_type() == ScalarType::Half) {
+  if (input->scalar_type() == ScalarType::Half || input->scalar_type() == ScalarType::BFloat16) {
     checkScalarType(c, weight, ScalarType::Float);
   } else {
     checkAllSameType(c, {input, weight});

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5098,7 +5098,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
             self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
         if TEST_WITH_ROCM:
-            self.skipTest("MIOpen SolverNotFound for NCHW FP32/Fp16/BF16 NHWC batchnorm SWDEV-509640")
+            self.skipTest("MIOpen SolverNotFound for FP32/Fp16/BF16 NHWC batchnorm SWDEV-509640")
 
         (N, C, H, W) = 2, 64, 50, 50
         model = torch.nn.BatchNorm2d(C, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5142,7 +5142,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
             self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
         if TEST_WITH_ROCM and layout == "NCHW" and dtype == torch.bfloat16 and mixed:
-            self.skipTest("MIOpen tolerance issue for NCHW BF16 mixed batchnorm SWDEV-509640")
+            self.skipTest("MIOpen tolerance issue for NCHW BF16 mixed batchnorm SWDEV-507600")
 
         memory_format = torch.contiguous_format if layout == "NCHW" else torch.channels_last
         # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5145,7 +5145,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.fail(False, f"unsupported memory layout {layout}")
 
         if mixed and dtype == torch.float:
-            self.skipTest("mixed precision is usless for float32")
+            self.skipTest("mixed precision is useless for float32")
         if not mixed and dtype in (torch.half, torch.bfloat16):
             self.skipTest("pure mode not supported for bf16/fp16")
         # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4969,54 +4969,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         run_test(input, grad)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
-    def test_batchnorm_nhwc_miopen(self):
-        def run_test(input, grad_output):
-            c = input.size(1)
-            mod = nn.BatchNorm2d(c).cuda().float()
-            mod.weight.data.uniform_()
-            mod.bias.data.uniform_()
-            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
-            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
-            ref_mod = nn.BatchNorm2d(c).cuda().float()
-            ref_mod.load_state_dict(mod.state_dict())
-            out = mod(input)
-            out.backward(grad_output)
-            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm
-                ref_out = ref_mod(ref_input)
-                ref_out.backward(ref_grad)
-            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-            self.assertTrue(ref_out.is_contiguous(memory_format=torch.channels_last))
-            self.assertEqual(out, ref_out)
-            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
-            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
-            self.assertEqual(input.grad, ref_input.grad)
-
-        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
-        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
-        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
-        try:
-            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
-            input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
-
-            grad = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-            grad = grad.contiguous(memory_format=torch.channels_last)
-            run_test(input, grad)
-            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
-            # not channels_last
-            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
-            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-            grad = grad.permute(0, 2, 1, 3)
-            run_test(input, grad)
-        finally:
-            if prev_val is None:
-                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
-            else:
-                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):
         # THNN
         input = torch.randint(1, 10, (2, 3, 2, 2), dtype=torch.half, device="cuda", requires_grad=True)
@@ -5136,6 +5088,77 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             out1 = model(inp1)
             out2 = model(inp2)
             self.assertEqual(out1, out2)
+
+    def batchnorm2d_miopen(self, dtype, memory_format, mixed: bool):
+        def run_test(input, grad_output, mixed: bool):
+            c = input.size(1)
+            mod = nn.BatchNorm2d(c).cuda()
+            ref_mod = nn.BatchNorm2d(c).cuda()
+            if not mixed:
+                mod = mod.to(dtype=input.dtype)
+                ref_mod = ref_mod.to(dtype=input.dtype)
+
+            mod.weight.data.uniform_()
+            mod.bias.data.uniform_()
+
+            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
+            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
+            ref_mod.load_state_dict(mod.state_dict())
+
+            out = mod(input)
+            out.backward(grad_output)
+            with torch.backends.cudnn.flags(enabled=False):  # force to use native nhwc batchnorm
+                ref_out = ref_mod(ref_input)
+                ref_out.backward(ref_grad)
+            self.assertTrue(out.is_contiguous(memory_format=memory_format))
+            self.assertTrue(ref_out.is_contiguous(memory_format=memory_format))
+            self.assertEqual(out, ref_out)
+            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
+            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
+            self.assertEqual(mod.running_mean, ref_mod.running_mean)
+            self.assertEqual(mod.running_var, ref_mod.running_var)
+            self.assertEqual(input.grad, ref_input.grad)
+
+        size = (4, 8, 2, 2)
+        input = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
+        input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
+        grad = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
+        grad = grad.contiguous(memory_format=memory_format)
+        run_test(input, grad, mixed)
+        # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
+        # not channels_last
+        input = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
+        input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
+        grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
+        grad = grad.permute(0, 2, 1, 3)
+        run_test(input, grad, mixed)
+
+    @parametrize_test("layout", ["NCHW", "NHWC"])
+    @parametrize_test("mixed", [False, True])
+    @parametrize_test("dtype", [torch.float, torch.half, torch.bfloat16])
+    def test_batchnorm_miopen(self, layout, mixed, dtype):
+        if layout == "NCHW":
+            layout = torch.contiguous_format
+        elif layout == "NHWC":
+            layout = torch.channels_last
+        else:
+            self.fail(False, f"unsupported memory layout {layout}")
+
+        if mixed and dtype == torch.float:
+            self.skipTest("mixed precision is usless for float32")
+        if not mixed and dtype in (torch.half, torch.bfloat16):
+            self.skipTest("pure mode not supported for bf16/fp16")
+        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
+        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
+        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
+        try:
+            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
+            self.batchnorm2d_miopen(dtype, memory_format=layout, mixed=mixed)
+        finally:
+            if prev_val is None:
+                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
+            else:
+                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
 
     def test_batchnorm_load_state_dict(self):
         bn = torch.nn.BatchNorm2d(3)
@@ -8308,64 +8331,6 @@ class TestNNDeviceType(NNTestCase):
 
             self.assertEqual(scipy_ary, gridsample_ary.reshape_as(scipy_ary))
 
-    def batchnorm2d_miopen(self, dtype, memory_format):
-        def run_test(input, grad_output):
-            c = input.size(1)
-            mod = nn.BatchNorm2d(c).cuda().to(dtype=input.dtype)
-            mod.weight.data.uniform_()
-            mod.bias.data.uniform_()
-            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
-            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
-            ref_mod = nn.BatchNorm2d(c).cuda().to(dtype=input.dtype)
-            ref_mod.load_state_dict(mod.state_dict())
-            out = mod(input)
-            out.backward(grad_output)
-            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm
-                ref_out = ref_mod(ref_input)
-                ref_out.backward(ref_grad)
-            self.assertTrue(out.is_contiguous(memory_format=memory_format))
-            self.assertTrue(ref_out.is_contiguous(memory_format=memory_format))
-            self.assertEqual(out, ref_out)
-            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
-            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
-            self.assertEqual(mod.running_mean, ref_mod.running_mean)
-            self.assertEqual(mod.running_var, ref_mod.running_var)
-            self.assertEqual(input.grad, ref_input.grad)
-
-        size = (4, 8, 2, 2)
-        input = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
-        input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
-        grad = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
-        grad = grad.contiguous(memory_format=memory_format)
-        run_test(input, grad)
-        # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
-        # not channels_last
-        input = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
-        input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
-        grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
-        grad = grad.permute(0, 2, 1, 3)
-        run_test(input, grad)
-
-
-    @onlyCUDA
-    @dtypes(torch.float)
-    def test_batchnorm_nhwc_miopen(self, dtype):
-        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
-        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
-        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
-        try:
-            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
-            self.batchnorm2d_miopen(dtype, torch.channels_last)
-        finally:
-            if prev_val is None:
-                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
-            else:
-                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
-
-    @onlyCUDA
-    @dtypes(torch.float)
-    def test_batchnorm_nchw_miopen(self, dtype):
-        self.batchnorm2d_miopen(dtype, torch.contiguous_format)
 
     @onlyCUDA
     @dtypes(torch.float, torch.half)


### PR DESCRIPTION
bf16/fp16 NHWC/NCHW mixed batchnorm merged
refactoring of miopen batchnorm tests:

- `test_batchnorm_nhwc_miopen` - removed
- `test_batchnorm_layout_*_mixed_*` - added to cover all batchnorm train configs
> - `test_batchnorm_layout_NCHW_mixed_True_bfloat16` - skipped due to MIOpen tolerance issue SWDEV-507600
- `test_batchnorm_nhwc_eval_*` - added to cover all NHWC batchnorm inference configs
> - test_batchnorm_nhwc_eval_mixed_False_float32 - skipped due to SolverNotFound SWDEV-509640
> - test_batchnorm_nhwc_eval_mixed_True_bfloat16  - skipped due to SolverNotFound SWDEV-509640
> - test_batchnorm_nhwc_eval_mixed_True_float16  - skipped due to SolverNotFound SWDEV-509640

```
python test_nn.py  -v -k test_batchnorm_layout

Running tests...
----------------------------------------------------------------------
  test_batchnorm_layout_NCHW_mixed_False_bfloat16 (__main__.TestNN) ... skip: pure mode not supported for bf16/fp16 on ROCm (0.003s)
  test_batchnorm_layout_NCHW_mixed_False_float16 (__main__.TestNN) ... skip: pure mode not supported for bf16/fp16 on ROCm (0.002s)
  test_batchnorm_layout_NCHW_mixed_False_float32 (__main__.TestNN) ... ok (0.372s)
  test_batchnorm_layout_NCHW_mixed_True_bfloat16 (__main__.TestNN) ... skip: MIOpen tolerance issue for NCHW BF16 mixed batchnorm SWDEV-507600 (0.002s)
  test_batchnorm_layout_NCHW_mixed_True_float16 (__main__.TestNN) ... ok (0.113s)
  test_batchnorm_layout_NCHW_mixed_True_float32 (__main__.TestNN) ... skip: mixed precision is useless for float32 (0.002s)
  test_batchnorm_layout_NHWC_mixed_False_bfloat16 (__main__.TestNN) ... skip: pure mode not supported for bf16/fp16 on ROCm (0.002s)
  test_batchnorm_layout_NHWC_mixed_False_float16 (__main__.TestNN) ... skip: pure mode not supported for bf16/fp16 on ROCm (0.002s)
  test_batchnorm_layout_NHWC_mixed_False_float32 (__main__.TestNN) ... ok (0.105s)
  test_batchnorm_layout_NHWC_mixed_True_bfloat16 (__main__.TestNN) ... ok (0.102s)
  test_batchnorm_layout_NHWC_mixed_True_float16 (__main__.TestNN) ... ok (0.106s)
  test_batchnorm_layout_NHWC_mixed_True_float32 (__main__.TestNN) ... skip: mixed precision is useless for float32 (0.003s)
----------------------------------------------------------------------
Ran 12 tests in 0.817s

OK (skipped=7)
```

```
python test_nn.py -v -k test_batchnorm_nhwc_eval

Running tests...
----------------------------------------------------------------------
  test_batchnorm_nhwc_eval_mixed_False_bfloat16 (__main__.TestNN) ... skip: pure mode not supported for bf16/fp16 on ROCm (0.002s)
  test_batchnorm_nhwc_eval_mixed_False_float16 (__main__.TestNN) ... skip: pure mode not supported for bf16/fp16 on ROCm (0.001s)
  test_batchnorm_nhwc_eval_mixed_False_float32 (__main__.TestNN) ... skip: MIOpen SolverNotFound for FP32/Fp16/BF16 NHWC batchnorm SWDEV-509640 (0.001s)
  test_batchnorm_nhwc_eval_mixed_True_bfloat16 (__main__.TestNN) ... skip: MIOpen SolverNotFound for FP32/Fp16/BF16 NHWC batchnorm SWDEV-509640 (0.001s)
  test_batchnorm_nhwc_eval_mixed_True_float16 (__main__.TestNN) ... skip: MIOpen SolverNotFound for FP32/Fp16/BF16 NHWC batchnorm SWDEV-509640 (0.001s)
  test_batchnorm_nhwc_eval_mixed_True_float32 (__main__.TestNN) ... skip: mixed precision is useless for float32 (0.001s)
----------------------------------------------------------------------
Ran 6 tests in 0.008s

OK (skipped=6)
```

shoud I switch to MIOpen Batchnorm API v2 in this PR?
should this test be adapted for CUDA as well and replace them?
- [TestNN.test_batchnorm_cudnn_nhwc](https://github.com/ROCm/pytorch/blob/d3c942e263149b3faedb58e345472affdbc55b2b/test/test_nn.py#L4936) - train mode fp32 NHWC 
- [TestNN.test_batchnorm_nhwc_cuda](https://github.com/ROCm/pytorch/blob/d3c942e263149b3faedb58e345472affdbc55b2b/test/test_nn.py#L5129) - evaluation mode fp32 NHWC  
- [TestNNDeviceType/test_batchnorm_eval_mixed](https://github.com/ROCm/pytorch/blob/d3c942e263149b3faedb58e345472affdbc55b2b/test/test_nn.py#L11217) - evaluation mode fp16/bf16 mixed NCHW 
