### PR TITLE
[rocm6.4_internal_testing] fix test_cublas_workspace_explicit_allocation for navi

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -452,7 +452,8 @@ class TestCuda(TestCase):
         if torch.version.hip:
             default_workspace_size = 1024 * 32 * 1024  # :1024:32  32MiB
             # different size (128 MiB) expected on MI300 GPU
-            if torch.cuda.get_device_capability() >= (9, 4):
+            gcn_arch = str(torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0])
+            if "gfx94" in gcn_arch:
                 default_workspace_size = 1024 * 128 * 1024  # :1024:128
         else:
             default_workspace_size = (


### PR DESCRIPTION
Navi passes condition `torch.cuda.get_device_capability() >= (9, 4)` and  uses `default_workspace_size=128MB`, but it required only for MI300
Fix condition to use `("gfx94" in gcn_arch)` instead of  `torch.cuda.get_device_properties()` to detect MI300
Fixes https://ontrack-internal.amd.com/browse/SWDEV-507235
