### PR TITLE
use 'gfx94' to detect MI300 to adjust default workspase size

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -125,7 +125,8 @@ size_t parseChosenWorkspaceSize() {
   }
   /* 32MiB default, 128MiB for MI300 */
   cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
-  const bool gfx94 = properties != nullptr && properties->major == 9 && properties->minor == 4;
+  std::string device_arch = properties->gcnArchName;
+  const bool gfx94 = device_arch.find("gfx94") != std::string::npos;
   const size_t default_size = gfx94 ? 1024 * 128 * 1024 : 1024 * 32 * 1024;
 #else
   /* :4096:2:16:8 default, 32MiB for Hopper */

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -452,7 +452,9 @@ class TestCuda(TestCase):
         if torch.version.hip:
             default_workspace_size = 1024 * 32 * 1024  # :1024:32  32MiB
             # different size (128 MiB) expected on MI300 GPU
-            gcn_arch = str(torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0])
+            gcn_arch = str(
+                torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
+            )
             if "gfx94" in gcn_arch:
                 default_workspace_size = 1024 * 128 * 1024  # :1024:128
         else:


### PR DESCRIPTION
Detecting MI300 using "gfx94" pattern in gcnArchName
addition fix related to https://github.com/ROCm/pytorch/pull/1846
based on upstream conversation comment https://github.com/pytorch/pytorch/pull/145227#pullrequestreview-2563244274
