### PR TITLE
[release/2.5] Enable tf32 testing on test_nn

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -233,7 +233,7 @@ void Context::setBenchmarkLimitCuDNN(int b) {
 
 bool Context::allowTF32CuBLAS() const {
 #ifdef USE_ROCM
-    const static auto allow_tf32 = c10::utils::check_env(hipblaslt_allow_tf32);
+    auto allow_tf32 = c10::utils::check_env(hipblaslt_allow_tf32);
     if (allow_tf32 != true) {
       return false;
     }
@@ -243,7 +243,7 @@ bool Context::allowTF32CuBLAS() const {
 
 void Context::setAllowTF32CuBLAS(bool b) {
 #ifdef USE_ROCM
-  const static auto allow_tf32 = c10::utils::check_env(hipblaslt_allow_tf32);
+  auto allow_tf32 = c10::utils::check_env(hipblaslt_allow_tf32);
   if (allow_tf32 != true) {
     LOG(INFO) << "torch.backends.cuda.matmul.allow_tf32 is not supported on ROCm by default. "
               << "Please set environment variable HIPBLASLT_ALLOW_TF32=1 to enable it.";


### PR DESCRIPTION
1. In Context.cpp, for the variable allow_tf32 remove static const variable type to non const variable. This allows us to capture the env variable HIPBLASLT_ALLOW_TF32 changes.
2. Add ROCm arch support to tf32_is_not_fp32()

Fixes #ISSUE_NUMBER
