### PR TITLE
[release2.4] navi4x fixes

### DIFF
--- a/aten/src/ATen/cuda/CublasHandlePool.cpp
+++ b/aten/src/ATen/cuda/CublasHandlePool.cpp
@@ -125,7 +125,8 @@ size_t parseChosenWorkspaceSize() {
   }
   /* 32MiB default, 128MiB for MI300 */
   cudaDeviceProp* properties = at::cuda::getCurrentDeviceProperties();
-  const bool gfx94 = properties != nullptr && properties->major == 9 && properties->minor == 4;
+  std::string device_arch = properties->gcnArchName;
+  const bool gfx94 = device_arch.find("gfx94") != std::string::npos;
   const size_t default_size = gfx94 ? 1024 * 128 * 1024 : 1024 * 32 * 1024;
 #else
   /* :4096:2:16:8 default, 32MiB for Hopper */

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -16,7 +16,12 @@ from functorch.compile import min_cut_rematerialization_partition
 from torch._dynamo.backends.common import aot_autograd
 from torch._dynamo.testing import CompileCounterWithBackend
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
-from torch.testing._internal.common_utils import IS_WINDOWS, NAVI_ARCH, skipIfRocm, skipIfRocmArch
+from torch.testing._internal.common_utils import (
+    IS_WINDOWS,
+    NAVI4_ARCH,
+    skipIfRocm,
+    skipIfRocmArch,
+)
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils.checkpoint import _pt2_selective_checkpoint_context_fn_gen, checkpoint
@@ -1018,7 +1023,7 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, [y, z])
         self.assertEqual(ref, res)
 
-    @skipIfRocmArch(NAVI_ARCH)
+    @skipIfRocmArch(NAVI4_ARCH)
     @requires_cuda
     def test_pattern_matcher(self):
         # Check that the sdpa op is recomputed in the backward graph

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -18,7 +18,7 @@ from torch._dynamo.testing import CompileCounterWithBackend
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
 from torch.testing._internal.common_utils import (
     IS_WINDOWS,
-    NAVI4_ARCH,
+    NAVI_ARCH,
     skipIfRocm,
     skipIfRocmArch,
 )
@@ -1023,7 +1023,7 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, [y, z])
         self.assertEqual(ref, res)
 
-    @skipIfRocmArch(NAVI4_ARCH)
+    @skipIfRocmArch(NAVI_ARCH)
     @requires_cuda
     def test_pattern_matcher(self):
         # Check that the sdpa op is recomputed in the backward graph

--- a/test/dynamo/test_activation_checkpointing.py
+++ b/test/dynamo/test_activation_checkpointing.py
@@ -16,7 +16,7 @@ from functorch.compile import min_cut_rematerialization_partition
 from torch._dynamo.backends.common import aot_autograd
 from torch._dynamo.testing import CompileCounterWithBackend
 from torch._higher_order_ops.wrap import tag_activation_checkpoint
-from torch.testing._internal.common_utils import IS_WINDOWS, skipIfRocm
+from torch.testing._internal.common_utils import IS_WINDOWS, NAVI_ARCH, skipIfRocm, skipIfRocmArch
 from torch.testing._internal.inductor_utils import HAS_CUDA
 from torch.testing._internal.two_tensor import TwoTensor
 from torch.utils.checkpoint import _pt2_selective_checkpoint_context_fn_gen, checkpoint
@@ -1018,6 +1018,7 @@ class ActivationCheckpointingViaTagsTests(torch._dynamo.test_case.TestCase):
         res = opt_fn(x, [y, z])
         self.assertEqual(ref, res)
 
+    @skipIfRocmArch(NAVI_ARCH)
     @requires_cuda
     def test_pattern_matcher(self):
         # Check that the sdpa op is recomputed in the backward graph

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -9929,10 +9929,6 @@ fn
             lambda mod: mod,
         )
 
-    # The following 2 tests fail due to https://github.com/python/cpython/issues/118013.
-    # Tracked by https://github.com/pytorch/pytorch/issues/124302.
-    # The xfails can be removed once Python 3.12 is updated on CI.
-    # @xfailIfPy312
     def test_outside_linear_module_free(self):
         # Compared to test_linear_module_free, the linear
         # layer is not the code object that is directly compiled.
@@ -9967,7 +9963,6 @@ fn
         gc.collect()
         self.assertTrue(cleared)
 
-    # @xfailIfPy312
     def test_parameter_free(self):
         def model_inp_ctr():
             param = torch.nn.Parameter(torch.randn(100, 100))

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13,7 +13,6 @@ import math
 import operator
 import os
 import random
-import re
 import sys
 import tempfile
 import threading

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -13,6 +13,7 @@ import math
 import operator
 import os
 import random
+import re
 import sys
 import tempfile
 import threading
@@ -9931,7 +9932,7 @@ fn
     # The following 2 tests fail due to https://github.com/python/cpython/issues/118013.
     # Tracked by https://github.com/pytorch/pytorch/issues/124302.
     # The xfails can be removed once Python 3.12 is updated on CI.
-    @xfailIfPy312
+    # @xfailIfPy312
     def test_outside_linear_module_free(self):
         # Compared to test_linear_module_free, the linear
         # layer is not the code object that is directly compiled.
@@ -9966,7 +9967,7 @@ fn
         gc.collect()
         self.assertTrue(cleared)
 
-    @xfailIfPy312
+    # @xfailIfPy312
     def test_parameter_free(self):
         def model_inp_ctr():
             param = torch.nn.Parameter(torch.randn(100, 100))

--- a/test/jit/test_freezing.py
+++ b/test/jit/test_freezing.py
@@ -14,9 +14,11 @@ from torch.testing._internal.common_cuda import TEST_CUDA, TEST_CUDNN
 from torch.testing._internal.common_quantization import skipIfNoFBGEMM
 from torch.testing._internal.common_quantized import override_quantized_engine
 from torch.testing._internal.common_utils import (
+    NAVI_ARCH,
     set_default_dtype,
     skipCUDAMemoryLeakCheckIf,
     skipIfRocm,
+    skipIfRocmArch,
     skipIfTorchDynamo,
     TEST_WITH_ROCM,
 )
@@ -2975,6 +2977,7 @@ class TestFrozenOptimizations(JitTestCase):
             self.assertEqual(frozen(inp), mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
     def test_freeze_conv_relu_fusion(self):
         with set_default_dtype(torch.float):
             conv_bias = [True, False]
@@ -3037,6 +3040,7 @@ class TestFrozenOptimizations(JitTestCase):
                 self.assertEqual(mod_eager(inp), frozen_mod(inp))
 
     @unittest.skipIf(not (TEST_CUDNN or TEST_WITH_ROCM), "requires CUDNN")
+    @skipIfRocmArch(NAVI_ARCH)  # not supported by MIOPEN on NAVI
     def test_freeze_conv_relu_fusion_not_forward(self):
         with set_default_dtype(torch.float):
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -373,7 +373,8 @@ class TestCuda(TestCase):
         if torch.version.hip:
             default_workspace_size = 1024 * 32 * 1024  # :1024:32  32MiB
             # different size (128 MiB) expected on MI300 GPU
-            if torch.cuda.get_device_capability() >= (9, 4):
+            gcn_arch = str(torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0])
+            if "gfx94" in gcn_arch:
                 default_workspace_size = 1024 * 128 * 1024  # :1024:128
         else:
             default_workspace_size = (

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -373,7 +373,9 @@ class TestCuda(TestCase):
         if torch.version.hip:
             default_workspace_size = 1024 * 32 * 1024  # :1024:32  32MiB
             # different size (128 MiB) expected on MI300 GPU
-            gcn_arch = str(torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0])
+            gcn_arch = str(
+                torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
+            )
             if "gfx94" in gcn_arch:
                 default_workspace_size = 1024 * 128 * 1024  # :1024:128
         else:

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -5966,7 +5966,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @onlyCUDA
-    @skipIfRocmArch(NAVI4_ARCH)
+    @skipIfRocmArch(NAVI4_ARCH)  # Flaky on Navi4
     def test_matmul_45724(self, device):
         # https://github.com/pytorch/pytorch/issues/45724
         a = torch.rand(65537, 22, 64, device=device, dtype=torch.half)

--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -18,6 +18,7 @@ from torch.testing._internal.common_utils import \
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, parametrize, skipIfTorchDynamo,
+     skipIfRocmArch, NAVI4_ARCH,
      setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest,
      xfailIfTorchDynamo)
 from torch.testing._internal.common_device_type import \
@@ -5965,6 +5966,7 @@ scipy_lobpcg  | {eq_err_scipy:10.2e}  | {eq_err_general_scipy:10.2e}  | {iters2:
 
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "cublas runtime error")
     @onlyCUDA
+    @skipIfRocmArch(NAVI4_ARCH)
     def test_matmul_45724(self, device):
         # https://github.com/pytorch/pytorch/issues/45724
         a = torch.rand(65537, 22, 64, device=device, dtype=torch.half)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -30,11 +30,11 @@ from torch.nn import Parameter
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_math_dtypes, floating_types
 from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
-    TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
+    NAVI4_ARCH, TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMps, \
     IS_PPC, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
-    skipIfTorchDynamo, gcIfJetson, set_default_dtype
+    skipIfRocmArch, skipIfTorchDynamo, gcIfJetson, set_default_dtype
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, _create_basic_net, \
@@ -12209,6 +12209,7 @@ if __name__ == '__main__':
 
     @skipMeta
     @dtypes(torch.float32, torch.float64)
+    @skipIfRocmArch(NAVI4_ARCH)
     def test_module_to_empty(self, device, dtype):
         class MyModule(nn.Module):
             def __init__(self, in_features, out_features, device=None, dtype=None):

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -12209,7 +12209,7 @@ if __name__ == '__main__':
 
     @skipMeta
     @dtypes(torch.float32, torch.float64)
-    @skipIfRocmArch(NAVI4_ARCH)
+    @skipIfRocmArch(NAVI4_ARCH)  # Flaky on Navi4
     def test_module_to_empty(self, device, dtype):
         class MyModule(nn.Module):
             def __init__(self, in_features, out_features, device=None, dtype=None):

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -68,7 +68,6 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     set_default_dtype,
-    skipIfRocm,
     skipIfTorchInductor,
     slowTest,
     suppress_warnings,
@@ -1367,8 +1366,21 @@ class TestCommon(TestCase):
 
     @ops(op_db, allowed_dtypes=(torch.bool,))
     @unittest.skipIf(TEST_WITH_UBSAN, "Test uses undefined behavior")
-    @skipIfRocm
     def test_non_standard_bool_values(self, device, dtype, op):
+        if TEST_WITH_ROCM and "cuda" in device:
+            navi_blocklist = [
+                "test_non_standard_bool_values_masked_scatter_cuda_bool",
+                # "test_non_standard_bool_values_nn_functional_unfold_cuda_bool",  # only in rocm6.4_internal_testing
+                "test_non_standard_bool_values_put_cuda_bool",
+                "test_non_standard_bool_values_scatter_add_cuda_bool",
+                "test_non_standard_bool_values_scatter_cuda_bool",
+                "test_non_standard_bool_values_scatter_reduce_sum_cuda_bool",
+                "test_non_standard_bool_values_tril_cuda_bool",
+                "test_non_standard_bool_values_triu_cuda_bool",
+            ]
+            if self._testMethodName in navi_blocklist:
+                self.skipTest("Failed on ROCm")
+
         # Test boolean values other than 0x00 and 0x01 (gh-54789)
         def convert_boolean_tensors(x):
             if not isinstance(x, torch.Tensor) or x.dtype != torch.bool:

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -647,7 +647,12 @@ class TestCommon(TestCase):
     @ops(op_db, allowed_dtypes=(torch.float32, torch.long, torch.complex64))
     def test_noncontiguous_samples(self, device, dtype, op):
         # temp skip
-        if 'cuda' in device and TEST_WITH_ROCM and dtype==torch.complex64 and op.name=='svd_lowrank':
+        if (
+            "cuda" in device
+            and TEST_WITH_ROCM
+            and dtype == torch.complex64
+            and op.name == "svd_lowrank"
+        ):
             self.skipTest(f"Failing on ROCm with complex64 for {op.name}")
         test_grad = dtype in op.supported_backward_dtypes(torch.device(device).type)
         sample_inputs = op.sample_inputs(device, dtype, requires_grad=test_grad)
@@ -1362,6 +1367,23 @@ class TestCommon(TestCase):
     @ops(op_db, allowed_dtypes=(torch.bool,))
     @unittest.skipIf(TEST_WITH_UBSAN, "Test uses undefined behavior")
     def test_non_standard_bool_values(self, device, dtype, op):
+        if TEST_WITH_ROCM and "cuda" in device:
+            gcn_arch = str(
+                torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
+            )
+            if "gfx12" in gcn_arch:
+                navi_blocklist = [
+                    "test_non_standard_bool_values_masked_scatter_cuda_bool",
+                    "test_non_standard_bool_values_put_cuda_bool",
+                    "test_non_standard_bool_values_scatter_add_cuda_bool",
+                    "test_non_standard_bool_values_scatter_cuda_bool",
+                    "test_non_standard_bool_values_scatter_reduce_sum_cuda_bool",
+                    "test_non_standard_bool_values_tril_cuda_bool",
+                    "test_non_standard_bool_values_triu_cuda_bool",
+                ]
+                if self._testMethodName in navi_blocklist:
+                    self.skipTest("Failed on Navi")
+
         # Test boolean values other than 0x00 and 0x01 (gh-54789)
         def convert_boolean_tensors(x):
             if not isinstance(x, torch.Tensor) or x.dtype != torch.bool:
@@ -1609,7 +1631,12 @@ class TestCompositeCompliance(TestCase):
     )
     @ops(op_db, allowed_dtypes=(torch.float,))
     def test_operator(self, device, dtype, op):
-        if 'cuda' in device and TEST_WITH_ROCM and dtype==torch.float32 and op.name=='nn.functional.scaled_dot_product_attention':
+        if (
+            "cuda" in device
+            and TEST_WITH_ROCM
+            and dtype == torch.float32
+            and op.name == "nn.functional.scaled_dot_product_attention"
+        ):
             self.skipTest(f"Failing on ROCm with float32 for {op.name}")
         samples = op.sample_inputs(device, dtype, requires_grad=False)
 

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -1368,7 +1368,7 @@ class TestCommon(TestCase):
     @unittest.skipIf(TEST_WITH_UBSAN, "Test uses undefined behavior")
     def test_non_standard_bool_values(self, device, dtype, op):
         if TEST_WITH_ROCM and "cuda" in device:
-            navi_blocklist = [
+            rocm_blocklist = [
                 "test_non_standard_bool_values_masked_scatter_cuda_bool",
                 # "test_non_standard_bool_values_nn_functional_unfold_cuda_bool",  # only in rocm6.4_internal_testing
                 "test_non_standard_bool_values_put_cuda_bool",
@@ -1378,7 +1378,7 @@ class TestCommon(TestCase):
                 "test_non_standard_bool_values_tril_cuda_bool",
                 "test_non_standard_bool_values_triu_cuda_bool",
             ]
-            if self._testMethodName in navi_blocklist:
+            if self._testMethodName in rocm_blocklist:
                 self.skipTest("Failed on ROCm")
 
         # Test boolean values other than 0x00 and 0x01 (gh-54789)

--- a/test/test_ops.py
+++ b/test/test_ops.py
@@ -68,6 +68,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     set_default_dtype,
+    skipIfRocm,
     skipIfTorchInductor,
     slowTest,
     suppress_warnings,
@@ -1366,24 +1367,8 @@ class TestCommon(TestCase):
 
     @ops(op_db, allowed_dtypes=(torch.bool,))
     @unittest.skipIf(TEST_WITH_UBSAN, "Test uses undefined behavior")
+    @skipIfRocm
     def test_non_standard_bool_values(self, device, dtype, op):
-        if TEST_WITH_ROCM and "cuda" in device:
-            gcn_arch = str(
-                torch.cuda.get_device_properties(0).gcnArchName.split(":", 1)[0]
-            )
-            if "gfx12" in gcn_arch:
-                navi_blocklist = [
-                    "test_non_standard_bool_values_masked_scatter_cuda_bool",
-                    "test_non_standard_bool_values_put_cuda_bool",
-                    "test_non_standard_bool_values_scatter_add_cuda_bool",
-                    "test_non_standard_bool_values_scatter_cuda_bool",
-                    "test_non_standard_bool_values_scatter_reduce_sum_cuda_bool",
-                    "test_non_standard_bool_values_tril_cuda_bool",
-                    "test_non_standard_bool_values_triu_cuda_bool",
-                ]
-                if self._testMethodName in navi_blocklist:
-                    self.skipTest("Failed on Navi")
-
         # Test boolean values other than 0x00 and 0x01 (gh-54789)
         def convert_boolean_tensors(x):
             if not isinstance(x, torch.Tensor) or x.dtype != torch.bool:

--- a/test/test_sparse_csr.py
+++ b/test/test_sparse_csr.py
@@ -9,7 +9,8 @@ from torch.testing import make_tensor
 from torch.testing._internal.common_cuda import SM53OrLater, SM80OrLater, TEST_CUSPARSE_GENERIC
 from torch.testing._internal.common_utils import \
     (TEST_WITH_TORCHINDUCTOR, TEST_WITH_ROCM, TEST_SCIPY, TEST_NUMPY, TEST_MKL, IS_WINDOWS, TestCase, run_tests,
-     load_tests, coalescedonoff, parametrize, subtest, skipIfTorchDynamo, skipIfRocm, IS_FBCODE, IS_REMOTE_GPU)
+     load_tests, coalescedonoff, parametrize, subtest, skipIfTorchDynamo, skipIfRocm, skipIfRocmArch, NAVI4_ARCH,
+     IS_FBCODE, IS_REMOTE_GPU)
 from torch.testing._internal.common_device_type import \
     (ops, instantiate_device_type_tests, dtypes, OpDTypes, dtypesIfCUDA, onlyCPU, onlyCUDA, skipCUDAIfNoSparseGeneric,
      precisionOverride, skipMeta, skipCUDAIf, skipCPUIfNoMklSparse, skipCUDAIfRocmVersionLessThan,
@@ -3848,6 +3849,7 @@ class TestSparseCompressedTritonKernels(TestCase):
     @dtypes(torch.half, torch.bfloat16, torch.float)
     @dtypesIfCUDA(torch.half, *[torch.bfloat16] if SM80OrLater else [], torch.float)
     @unittest.skipIf(IS_FBCODE and IS_REMOTE_GPU, "Test requires Triton")
+    @skipIfRocmArch(NAVI4_ARCH)
     def test_triton_bsr_scatter_mm(self, device, dtype, blocksize):
         import triton
         from torch.sparse._triton_ops import bsr_scatter_mm, bsr_scatter_mm_indices_data

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -104,6 +104,7 @@ except ImportError:
     has_pytest = False
 
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
+NAVI4_ARCH = ("gfx1200", "gfx1201")
 
 HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None and shutil.which('hipcc') is not None
 
@@ -1597,7 +1598,7 @@ def skipIfRocmArch(arch: Tuple[str, ...]):
     def dec_fn(fn):
         @wraps(fn)
         def wrap_fn(self, *args, **kwargs):
-            if TEST_WITH_ROCM:
+            if TEST_WITH_ROCM:  # noqa: F821
                 prop = torch.cuda.get_device_properties(0)
                 if prop.gcnArchName.split(":")[0] in arch:
                     reason = f"skipIfRocm: test skipped on {arch}"

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -103,7 +103,7 @@ try:
 except ImportError:
     has_pytest = False
 
-NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101")
+NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
 
 HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None and shutil.which('hipcc') is not None
 


### PR DESCRIPTION
Several inductor test files are added to ROCM_BLOCKLIST on Navi4x
```python
if "gfx12" in gcn_arch:
    NAVI_BLOCKLIST = [
        "inductor/test_aot_inductor.py",
        "inductor/test_compiled_optimizers.py",
        "inductor/test_control_flow.py",
        "inductor/test_cuda_cpp_wrapper.py",
        "inductor/test_cuda_repro.py",
        "inductor/test_multi_kernel.py",
        "inductor/test_padding.py",
        "inductor/test_pattern_matcher.py",
        "inductor/test_torchinductor_codegen_dynamic_shapes.py",
        "inductor/test_torchinductor_dynamic_shapes.py",
        "inductor/test_torchinductor_opinfo.py",
        "inductor/test_torchinductor.py",
        "inductor/test_unbacked_symints.py",
    ]
    ROCM_BLOCKLIST.extend(NAVI_BLOCKLIST)
```
Skipped several `test_ops.py` tests on Navi4 by exact name matchng (to avoid missing many tests) 
```python
if "gfx12" in gcn_arch:
  navi_blocklist = [
    "test_non_standard_bool_values_masked_scatter_cuda_bool",
    "test_non_standard_bool_values_put_cuda_bool",
    "test_non_standard_bool_values_scatter_add_cuda_bool",
    "test_non_standard_bool_values_scatter_cuda_bool",
    "test_non_standard_bool_values_scatter_reduce_sum_cuda_bool",
    "test_non_standard_bool_values_tril_cuda_bool",
    "test_non_standard_bool_values_triu_cuda_bool",
  ]
  if self._testMethodName in navi_blocklist:
    self.skipTest("Failed on Navi")
```
skipped on Navi4:
```
test_sparse_csr.py::TestSparseCompressedTritonKernelsCUDA::test_triton_bsr_scatter_mm_blocksize_*
nn/test_convolution.py::TestConvolutionNNDeviceTypeCUDA::test_cudnn_convolution_relu_cuda_float32
test_jit.py::TestFrozenOptimizations::test_freeze_conv_relu_fusion
test_jit.py::TestFrozenOptimizations::test_freeze_conv_relu_fusion_not_forward
```
Flaky tests skipped on Navi4
```
test_linalg.py::TestLinalgCUDA::test_matmul_45724_cuda
test_nn.py::TestNNDeviceTypeCUDA::test_module_to_empty_cuda_float32
test_nn.py::TestNNDeviceTypeCUDA::test_module_to_empty_cuda_float64
```
skipped on Navi
```
dynamo/test_activation_checkpointing.py::ActivationCheckpointingViaTagsTests::test_pattern_matcher
```
fixed:
```
dynamo/test_misc.py::MiscTests::test_parameter_free
dynamo/test_misc.py::MiscTests::test_outside_linear_module_free
dynamo/test_dynamic_shapes.py::DynamicShapesMiscTests::test_outside_linear_module_free_dynamic_shapes
test_cuda_expandable_segments.py::TestCuda::test_cublas_workspace_explicit_allocation
test_cuda.py::TestCuda::test_cublas_workspace_explicit_allocation
```
