### PR TITLE
Revert "[release/2.4] fix test_pointwise_op_fusion_post_grad (#1763)"

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -471,7 +471,7 @@ class TestGroupBatchFusion(TestCase):
         self.assertEqual(counters["inductor"]["batch_aten_tanh"], 1)
         self.assertEqual(counters["inductor"]["batch_aten_relu"], 1)
         self.assertEqual(counters["inductor"]["batch_aten_sigmoid"], 1)
-        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 2)
+        self.assertEqual(counters["inductor"]["unbind_stack_aten_pass"], 1)
         ref.sum().backward()
         res.sum().backward()
         self.compare_parameters(module, traced, rtol=1e-8, atol=1e-8)


### PR DESCRIPTION
the value was reverted back from 2 to 1 in upstream/main also

This reverts commit 95a4c16a6697f8e4039f41a28ab25ce24a850d85.

Fixes https://ontrack-internal.amd.com/browse/SWDEV-504963
