### PR TITLE
Diable L2_cahce_size display on ROCm platforms

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -1006,7 +1006,9 @@ static void registerCudaDeviceProperties(PyObject* module) {
 #ifndef FBCODE_CAFFE2
       .def_readonly("uuid", &cudaDeviceProp::uuid)
 #endif
+#if !USE_ROCM
       .def_readonly("L2_cache_size", &cudaDeviceProp::l2CacheSize)
+#endif
       .def("__repr__", [](const cudaDeviceProp& prop) {
         std::ostringstream stream;
         stream << "_CudaDeviceProperties(name='" << prop.name


### PR DESCRIPTION
This is not supported by clr and hsa and will return wrong results.

Fixes https://github.com/ROCm/ROCm/issues/4203
