### PR TITLE
[release/2.6] [ROCm] Improvements for vectorized elementwise kernels (#143269)

### DIFF
--- a/aten/src/ATen/cuda/jiterator.cu
+++ b/aten/src/ATen/cuda/jiterator.cu
@@ -16,10 +16,18 @@ static inline void launch_jitted_vectorized_kernel_dynamic(
   DeviceIndex dev_idx, int64_t N, const std::string& f, void* data_ptr,
   const c10::SmallVector<at::Scalar>& extra_args, bool return_by_ref) {
   TORCH_INTERNAL_ASSERT(N > 0 && N <= std::numeric_limits<int32_t>::max());
-  // N is still int64_t for the computation, but it's always safe to cast result to int
-  const uint32_t grid = (N + block_work_size() - 1) / block_work_size();
 
-  const int vec_size = jitted_can_vectorize_up_to(iter);
+  int nInputs = iter.ninputs();
+  int nOutputs = iter.noutputs();
+  const at::ScalarType common_dtype = iter.common_dtype();
+
+  int tws = at::cuda::jit::calc_thread_work_size(nInputs, nOutputs, common_dtype, common_dtype);
+  int vec_size = jitted_can_vectorize_up_to(iter);
+
+  int bws = tws * num_threads();
+  // N is still int64_t for the computation, but it's always safe to cast result to int
+  const uint32_t grid = (N + bws - 1) / bws;
+
   bool vectorized = vec_size > 1;
 
   // Different kernels are compiled depending on what we're vectorizing up to (1, 2 or 4 elements)
@@ -27,9 +35,6 @@ static inline void launch_jitted_vectorized_kernel_dynamic(
   // TODO: Memory use can probably be optimized by re-using kernels across GPUs with
   //   the same compute capability
 
-  int nInputs = iter.ninputs();
-  int nOutputs = iter.noutputs();
-  const at::ScalarType common_dtype = iter.common_dtype();
   std::string f_inputs_type_str = at::cuda::jit::typeName(common_dtype);
   std::string compute_type_str = at::cuda::jit::typeName(toOpMathType(common_dtype));
   std::string result_type_str = at::cuda::jit::typeName(common_dtype);
@@ -59,6 +64,7 @@ static inline void launch_jitted_vectorized_kernel_dynamic(
                                                /*contiguous=*/true, /*dynamic_casting=*/false,
                                                at::cuda::jit::BinaryFuncVariant::NoScalar,
                                                extra_args_types,
+                                               tws,
                                                vectorized, vec_size,
                                                return_by_ref);
       std::string kernel_name = vectorized ? name + "_vectorized" + std::to_string(vec_size) : name;
@@ -121,12 +127,16 @@ static inline void launch_jitted_unrolled_kernel_dynamic(
   const c10::SmallVector<at::Scalar>& extra_args, bool return_by_ref) {
 
   TORCH_INTERNAL_ASSERT(N > 0 && N <= std::numeric_limits<int32_t>::max());
-  //casting result to int is always safe, intermediate is int64 and won't overflow
-  const uint32_t grid = (N + block_work_size() - 1) / block_work_size();
 
   int nInputs = iter.ninputs();
   int nOutputs = iter.noutputs();
   const at::ScalarType common_dtype = iter.common_dtype();
+
+  int tws = at::cuda::jit::calc_thread_work_size(nInputs, nOutputs, common_dtype, common_dtype);
+  int bws = tws * num_threads();
+  //casting result to int is always safe, intermediate is int64 and won't overflow
+  const uint32_t grid = (N + bws - 1) / bws;
+
   std::string f_inputs_type_str = at::cuda::jit::typeName(common_dtype);
   std::string compute_type_str = at::cuda::jit::typeName(toOpMathType(common_dtype));
   std::string result_type_str = at::cuda::jit::typeName(common_dtype);
@@ -153,7 +163,7 @@ static inline void launch_jitted_unrolled_kernel_dynamic(
                                                f_inputs_type_str, compute_type_str, result_type_str,
                                                contiguous, dynamic_casting,
                                                at::cuda::jit::BinaryFuncVariant::NoScalar,
-                                               extra_args_types, /*vectorized*/false, /*vec_size*/0, return_by_ref);
+                                               extra_args_types, tws, /*vectorized*/false, /*vec_size*/0, return_by_ref);
       *fn_ptr = at::cuda::jit::jit_pwise_function(code, name);
     }
   }

--- a/aten/src/ATen/native/cuda/CUDAJitLoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDAJitLoops.cuh
@@ -50,6 +50,11 @@ struct JittedVecKernelCache {
   at::cuda::jit::NvrtcFunction vec1;
   at::cuda::jit::NvrtcFunction vec2;
   at::cuda::jit::NvrtcFunction vec4;
+#ifdef USE_ROCM
+  at::cuda::jit::NvrtcFunction vec8;
+  at::cuda::jit::NvrtcFunction vec16;
+#endif
+
 };
 
 struct JittedKernelVariantCache {
@@ -89,8 +94,11 @@ void launch_jitted_unrolled_kernel(
     c10::ArrayRef<void*> extra_args) {
 
   TORCH_INTERNAL_ASSERT(N > 0 && N <= std::numeric_limits<int32_t>::max());
+
+  int tws = at::cuda::jit::calc_thread_work_size(desc.nInputs, desc.nOutputs, desc.f_inputs_type, desc.result_type);
+  int bws = tws * num_threads();
   //casting result to int is always safe, intermediate is int64 and won't overflow
-  const uint32_t grid = (N + block_work_size() - 1) / block_work_size();
+  const uint32_t grid = (N + bws - 1) / bws;
 
   if (!fn_cache.function) {
     const std::lock_guard<std::mutex> lock{jiterator_mutex};
@@ -98,7 +106,7 @@ void launch_jitted_unrolled_kernel(
       constexpr bool dynamic_casting = !std::is_same<decltype(l), memory::LoadWithoutCast>() ||
                                        !std::is_same<decltype(s), memory::StoreWithoutCast>();
       auto code = at::cuda::jit::generate_code(
-          desc, contiguous, dynamic_casting, scalar_pos);
+          desc, contiguous, dynamic_casting, scalar_pos, tws);
       fn_cache = at::cuda::jit::jit_pwise_function(code, desc.name);
     }
   }
@@ -115,14 +123,26 @@ void launch_jitted_vectorized_kernel(
     at::cuda::jit::BinaryFuncVariant scalar_pos,
     void *scalar_val, c10::ArrayRef<void*> extra_args) {
   TORCH_INTERNAL_ASSERT(N > 0 && N <= std::numeric_limits<int32_t>::max());
+
+  int tws = at::cuda::jit::calc_thread_work_size(desc.nInputs, desc.nOutputs, desc.f_inputs_type, desc.result_type);
+  int bws = tws * num_threads();
   // N is still int64_t for the computation, but it's always safe to cast result to int
-  const uint32_t grid = (N + block_work_size() - 1) / block_work_size();
-  const int vec_size = at::cuda::jit::can_vectorize_up_to(
+  const uint32_t grid = (N + bws - 1) / bws;
+
+  int vec_size = at::cuda::jit::can_vectorize_up_to(
       desc, c10::ArrayRef<char*>(data.data(), data.size()));
 
   // Different kernels are compiled depending on what we're vectorizing up to (1, 2 or 4 elements)
   //   fn_ptr is set to the appropriate function based on the vec size and GPU used
-  at::cuda::jit::NvrtcFunction* fn_ptr;
+  at::cuda::jit::NvrtcFunction* fn_ptr = nullptr;
+
+#ifdef USE_ROCM
+  if (vec_size == 16) {
+    fn_ptr = &fn_cache.vec16;
+  } else if (vec_size == 8) {
+    fn_ptr = &fn_cache.vec8;
+  } else
+#endif
   if (vec_size == 4) {
     fn_ptr = &fn_cache.vec4;
   } else if (vec_size == 2) {
@@ -142,7 +162,7 @@ void launch_jitted_vectorized_kernel(
       // Generates program
       auto code = at::cuda::jit::generate_code(
           desc, /*contiguous=*/true, /*dynamic_casting=*/false,
-          scalar_pos, vectorized, vec_size);
+          scalar_pos, tws, vectorized, vec_size);
       std::string kernel_name = vectorized ? desc.name + "_vectorized" + std::to_string(vec_size) : desc.name;
 
       // Acquires the program

--- a/aten/src/ATen/native/cuda/CUDALoops.cuh
+++ b/aten/src/ATen/native/cuda/CUDALoops.cuh
@@ -78,13 +78,49 @@ constexpr auto io_block_work_size() {
   return num_threads() * elems_per_thread<io_sizes>();
 }
 
+#ifdef USE_ROCM
+template <typename args_t, size_t... Is>
+constexpr auto input_size(args_t args, std::index_sequence<Is...>) {
+  if constexpr (sizeof...(Is) == 0) {
+    return 0;
+  } else {
+    return sizeof(std::tuple_element_t<0, args_t>);
+  }
+}
+
+template <int vec_size, int io_size>
+constexpr auto calc_optimal_vec_size() {
+  static_assert(vec_size != 0);
+  static_assert(io_size != 0);
+  if constexpr (io_size == 1 && vec_size >= 16) {
+    return 16;
+  } else if constexpr (io_size <= 2 && vec_size >= 8) {
+    return 8;
+  } else if constexpr (io_size <= 4 && vec_size >= 4) {
+    return 4;
+  } else if constexpr (vec_size >= 4) {
+    return 4;
+  } else if constexpr (vec_size >= 2) {
+    return 2;
+  } else {
+    return 1;
+  }
+}
+#endif
+
 template <typename func_t>
 constexpr auto calc_io_size(){
   using traits = function_traits<func_t>;
   using args_t = typename traits::ArgsTuple;
+#ifdef USE_ROCM
+  constexpr auto input_size = at::native::input_size(args_t{}, std::make_index_sequence<std::tuple_size_v<args_t>>{});
+  constexpr auto output_size = sizeof(typename traits::result_type);
+  return (input_size > 0) ? ((input_size < output_size) ? input_size : output_size) : output_size;
+#else
   constexpr auto input_size = at::native::sum_of_sizes(args_t{}, std::make_index_sequence<std::tuple_size_v<args_t>>{});
   constexpr auto output_size = sizeof(typename traits::result_type);
   return input_size + output_size;
+#endif
 }
 
 template <int vec_size, typename func_t, typename array_t>
@@ -111,8 +147,13 @@ __global__ void vectorized_elementwise_kernel(int N, func_t f, array_t data) {
     elementwise_kernel_helper(f, policy);
   } else { // if this block has a full `block_work_size` data to handle, use
            // vectorized memory access
+#ifdef USE_ROCM
+    constexpr auto optimal_vec_size = calc_optimal_vec_size<vec_size, io_size>();
+#else
+    constexpr auto optimal_vec_size = vec_size;
+#endif
     elementwise_kernel_helper(
-        f, memory::policies::vectorized<vec_size, array_t, elems_per_thread<io_size>()>(data));
+        f, memory::policies::vectorized<optimal_vec_size, array_t, elems_per_thread<io_size>()>(data));
   }
 }
 
@@ -154,6 +195,18 @@ static inline void launch_vectorized_kernel(
   int vec_size = memory::can_vectorize_up_to<func_t>(data);
 
   switch (vec_size) {
+#ifdef USE_ROCM
+    case 16:
+      vectorized_elementwise_kernel<16, func_t, array_t>
+          <<<grid, num_threads(), 0, stream>>>(N, f, data);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      break;
+    case 8:
+      vectorized_elementwise_kernel<8, func_t, array_t>
+          <<<grid, num_threads(), 0, stream>>>(N, f, data);
+      C10_CUDA_KERNEL_LAUNCH_CHECK();
+      break;
+#endif
     case 4:
       vectorized_elementwise_kernel<4, func_t, array_t>
           <<<grid, num_threads(), 0, stream>>>(N, f, data);

--- a/aten/src/ATen/native/cuda/MemoryAccess.cuh
+++ b/aten/src/ATen/native/cuda/MemoryAccess.cuh
@@ -351,6 +351,16 @@ inline C10_HOST_DEVICE int can_vectorize_up_to(const char *pointer) {
   uint64_t address = reinterpret_cast<uint64_t>(pointer);
   constexpr int vec2_alignment = std::alignment_of_v<aligned_vector<scalar_t, 2>>;
   constexpr int vec4_alignment = std::alignment_of_v<aligned_vector<scalar_t, 4>>;
+#ifdef USE_ROCM
+  constexpr int vec8_alignment = std::alignment_of_v<aligned_vector<scalar_t, 8>>;
+  constexpr int vec16_alignment = std::alignment_of_v<aligned_vector<scalar_t, 16>>;
+  constexpr int type_size = sizeof(scalar_t);
+  if (type_size == 1 && (address % vec16_alignment == 0)) {
+    return 16;
+  } else if (type_size <= 2 && (address % vec8_alignment == 0)) {
+    return 8;
+  } else
+#endif
   if (address % vec4_alignment == 0) {
     return 4;
   } else if (address % vec2_alignment == 0) {

--- a/aten/src/ATen/native/cuda/jit_utils.cpp
+++ b/aten/src/ATen/native/cuda/jit_utils.cpp
@@ -196,7 +196,7 @@ const std::string jit_common_types = R"ESCAPE(
   static_assert(sizeof(uint32_t) == 4, "expected size does not match");
   static_assert(sizeof(int8_t) == 1, "expected size does not match");
   constexpr int num_threads = CUDA_OR_ROCM_NUM_THREADS;
-  constexpr int thread_work_size = 4; // TODO: make template substitution once we decide where those vars live
+  constexpr int thread_work_size = ${thread_work_size}; // TODO: make template substitution once we decide where those vars live
   constexpr int block_work_size = thread_work_size * num_threads;
 
   ${traits_string}
@@ -933,11 +933,55 @@ void initializeCudaContext() {
   }
 }
 
+#ifdef USE_ROCM
+int calc_io_size(
+    const int nInputs,
+    const int nOutputs,
+    const c10::ScalarType& inputs_type,
+    const c10::ScalarType& result_type) {
+    if (nInputs > 0 && nOutputs > 0) {
+        return std::min(c10::elementSize(inputs_type), c10::elementSize(result_type));
+    }
+
+    if (nInputs > 0) {
+        return c10::elementSize(inputs_type);
+    }
+
+    if (nOutputs > 0) {
+        return c10::elementSize(result_type);
+    }
+
+    return 0;
+}
+#endif
+
+int calc_thread_work_size(
+    const int nInputs,
+    const int nOutputs,
+    const c10::ScalarType& inputs_type,
+    const c10::ScalarType& result_type) {
+#ifdef USE_ROCM
+    auto io_size = at::cuda::jit::calc_io_size(nInputs, nOutputs, inputs_type, result_type);
+    TORCH_INTERNAL_ASSERT(io_size > 0);
+    if (io_size == 1) {
+        return 16;
+    } else if (io_size < 4) {
+        return 8;
+    } else {
+        return 4;
+    }
+    return io_size;
+#else
+    return JIT_THREAD_WORK_SIZE;
+#endif
+}
+
 std::string generate_code(
     const KernelDescriptor &desc,
     bool contiguous,
     bool dynamic_casting,
     BinaryFuncVariant scalar_pos,
+    int thread_work_size,
     bool vectorized,
     int vec_size,
     bool return_by_ref) {
@@ -958,14 +1002,11 @@ std::string generate_code(
       dynamic_casting,
       scalar_pos,
       extra_args_typenames,
+      thread_work_size,
       vectorized,
       vec_size,
       return_by_ref);
 }
-
-//FIXME - this are defined in Loops.cuh, but including Loops.cuh here would lead to circular includes Loops.cuh -> CUDALoops.cuh -> jit_utils.h -> Loops.cuh
-#define THREAD_WORK_SIZE 4
-constexpr int thread_work_size = THREAD_WORK_SIZE;
 
 std::string generate_code(
     int nInputs,
@@ -979,6 +1020,7 @@ std::string generate_code(
     bool dynamic_casting,
     BinaryFuncVariant scalar_pos,
     c10::SmallVector<std::string>& extra_args_typenames,
+    int thread_work_size,
     bool vectorized,
     int vec_size,
     bool return_by_ref) {
@@ -993,6 +1035,7 @@ std::string generate_code(
   env.s("functor", func);
   env.s("name", name);
   env.s("cmath_string", get_cmath_string());
+  env.s("thread_work_size", std::to_string(thread_work_size));
 
   // Generate `extra_params` for function signature
   // and `extra_args` for computation call if
@@ -1340,6 +1383,7 @@ std::string generate_reduction_code(
     int max_threads_codegen) {
       std::string func = func_;
       at::jit::TemplateEnv env;
+      constexpr int thread_work_size = JIT_THREAD_WORK_SIZE;
       env.s("index_type", "unsigned int");
       env.s("scalar_type", f_inputs_type);
       env.s("result_type", result_type);
@@ -1347,6 +1391,7 @@ std::string generate_reduction_code(
       env.s("vt0", std::to_string(vt0));
       env.s("name", name);
       env.s("max_threads_lb", std::to_string(max_threads_codegen));
+      env.s("thread_work_size", std::to_string(thread_work_size));
       // reductions don't support dynamic casting, so the only way to get nonstandard types
       // is through input
       if (f_inputs_type == "at::Half" || f_inputs_type == "std::complex<at::Half>") {

--- a/aten/src/ATen/native/cuda/jit_utils.h
+++ b/aten/src/ATen/native/cuda/jit_utils.h
@@ -56,6 +56,14 @@ KernelDescriptor make_kernel_descriptor(
 
 inline int can_vectorize_up_to(size_t default_alignment, void *pointer) {
   auto ip = reinterpret_cast<uintptr_t>(pointer);
+#ifdef USE_ROCM
+  if ((default_alignment == 1) && (ip % (16 * default_alignment) == 0)) {
+    return 16;
+  }
+  if ((default_alignment <= 2) && (ip % (8 * default_alignment) == 0)) {
+    return 8;
+  }
+#endif
   if (ip % (4 * default_alignment) == 0) {
     return 4;
   }
@@ -82,18 +90,36 @@ inline int can_vectorize_up_to(const KernelDescriptor &desc, c10::ArrayRef<char*
   return result;
 }
 
+//FIXME - this are defined in Loops.cuh, but including Loops.cuh here would lead to circular includes Loops.cuh -> CUDALoops.cuh -> jit_utils.h -> Loops.cuh
+#define JIT_THREAD_WORK_SIZE 4
+
+#ifdef USE_ROCM
+int calc_io_size(
+    const int nInputs,
+    const int nOutputs,
+    const c10::ScalarType& inputs_type,
+    const c10::ScalarType& result_type);
+#endif
+
+int calc_thread_work_size(
+    const int nInputs,
+    const int nOutputs,
+    const c10::ScalarType& inputs_type,
+    const c10::ScalarType& result_type);
+
 std::string generate_code(
     int nInputs,
     int nOutputs,
     const std::string& func,
     const std::string& name,
-    const std::string& f_input_type,
+    const std::string& f_inputs_type,
     const std::string& compute_type,
     const std::string& result_type,
     bool contiguous,
     bool dynamic_casting,
     BinaryFuncVariant scalar_pos,
     c10::SmallVector<std::string>& extra_args_typenames,
+    int thread_work_size=JIT_THREAD_WORK_SIZE,
     bool vectorized=false,
     int vec_size=0,
     bool return_by_ref=false);
@@ -103,6 +129,7 @@ std::string generate_code(
     bool contiguous,
     bool dynamic_casting,
     BinaryFuncVariant scalar_pos,
+    int thread_work_size=JIT_THREAD_WORK_SIZE,
     bool vectorized=false,
     int vec_size=0,
     bool return_by_ref=false);


### PR DESCRIPTION
*  Make io_size calculation as minimum of size of input and output size, rather than the summation of all sizes
   * for e.g, for torch.add() on half dtypes (bfloat16/float16), calc_io_size() returns 6 causing elems_per_thread to be 4
   * But elems_per_thread = 8 works better on half datypes for AMD gpus
* Enable *_load_dwordx4 ISA for 16-bit and 8-bit dtypes on AMD gpus by using vector size of 8 and 16 respectively

Co-author: @akadutta

Pull Request resolved: https://github.com/pytorch/pytorch/pull/143269
Approved by: https://github.com/jeffdaily, https://github.com/pruthvistony

Fixes #ISSUE_NUMBER
