### PR TITLE
[rocm6.4_internal_testing] [ROCm][TunableOp] Close offline tuning results file when offline tuning is disabled.

### DIFF
--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -459,6 +459,8 @@ void TuningContext::EnableRecordUntuned(bool value) {
     TUNABLE_LOG1("Enable Record Untuned for TunableOp");
   } else {
     TUNABLE_LOG1("Disable Record Untuned for TunableOp");
+    TUNABLE_LOG1("Writing untuned gemm results to file.");
+    untuned_file_.close();
   }
 }
 

--- a/aten/src/ATen/cuda/tunable/Tunable.cpp
+++ b/aten/src/ATen/cuda/tunable/Tunable.cpp
@@ -459,7 +459,7 @@ void TuningContext::EnableRecordUntuned(bool value) {
     TUNABLE_LOG1("Enable Record Untuned for TunableOp");
   } else {
     TUNABLE_LOG1("Disable Record Untuned for TunableOp");
-    TUNABLE_LOG1("Writing untuned gemm results to file.");
+    TUNABLE_LOG1("Closing Untuned GEMM Results File");
     untuned_file_.close();
   }
 }


### PR DESCRIPTION
This is cherry-pick of an upstream PR that has been approved but is unmerged (due to CI delays). The PR did previously pass ROCm tests.
https://github.com/pytorch/pytorch/pull/146574

This PR is to fix UT breakage that has been reported internally and is considered high priority. When tunable.record_untuned_enable(False) is invoked, we flush the results of the untuned gemm file.

Offline tuning I/O currently doesn't have a set untuned results filename member function or untuned results write to file member function. When performing back-to-back unit tests, the same ofstream ends up getting reused between UTs. Due to the way the UT are executed, this can lead to unexpected failures.

