### PR TITLE
[release/2.5] [ROCm][TunableOp] Future proof TunableOp unit test.

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4531,7 +4531,7 @@ class TestLinalg(TestCase):
             validators[key] = value
         if torch.version.hip:
             assert "HIPBLASLT_VERSION" in validators
-            assert re.match(r'^\d{3,}-[a-z0-9]{8}$', validators["HIPBLASLT_VERSION"])
+            assert re.match(r'^\d+-[a-z0-9]+$', validators["HIPBLASLT_VERSION"])
         assert len(torch.cuda.tunable.get_results()) > 0
 
         assert torch.cuda.tunable.write_file()  # use default filename


### PR DESCRIPTION
Note that I had to copy and paste this one line change because the file has changed so much that the cherry-pick command fails.

TunableOp UT will fail because the regular expression in the test will not work for future versions of ROCm.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/146548
Approved by: https://github.com/jeffdaily
