### PR TITLE
[Release/2.1] triton git commit

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -97,7 +97,7 @@ def build_triton(
         # Nightly binaries include the triton commit hash, i.e. 2.1.0+e6216047b8
         # while release build should only include the version, i.e. 2.1.0
         rocm_version = get_rocm_version()
-        version = f"{version}+rocm{rocm_version}.{commit_hash[:10]}"
+        version = f"{version}+rocm{rocm_version}.git{commit_hash[:8]}"
 
     with TemporaryDirectory() as tmpdir:
         triton_basedir = Path(tmpdir) / "triton"

--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.1.0|5e08b50e55f472db9a59364f6bbf77c2524af173|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.1.0|5e08b50e55f472db9a59364f6bbf77c2524af173|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.1.0|22fea09ed9ba89a60d1813d88099deb3a826f925|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.1.0|22fea09ed9ba89a60d1813d88099deb3a826f925|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.16|8c34ea8a172336567050a73dc7fffa8689a6ae11|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.16|8c34ea8a172336567050a73dc7fffa8689a6ae11|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.16|66671007c84e07386da3c04e5ca403b8a417c8e5|https://github.com/pytorch/text


### PR DESCRIPTION
Relates to:
https://github.com/ROCm/builder/pull/68

Validation:
http://ml-ci-internal.amd.com:8080/job/pytorch/job/manylinux_rocm_wheels/519/
