### PR TITLE
[Release/2.5] triton git commit

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -98,7 +98,7 @@ def get_rocm_version() -> str:
 def build_triton(
     *,
     version: str,
-    commit_hash: str,
+    : str,
     build_conda: bool = False,
     device: str = "cuda",
     py_version: Optional[str] = None,
@@ -114,7 +114,7 @@ def build_triton(
         # Nightly binaries include the triton commit hash, i.e. 2.1.0+e6216047b8
         # while release build should only include the version, i.e. 2.1.0
         rocm_version = get_rocm_version()
-        version_suffix = f"+rocm{rocm_version}_{commit_hash[:10]}"
+        version_suffix = f"+rocm{rocm_version}.git{commit_hash[:8]}"
         version += version_suffix
 
     with TemporaryDirectory() as tmpdir:

--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -98,7 +98,7 @@ def get_rocm_version() -> str:
 def build_triton(
     *,
     version: str,
-    : str,
+    commit_hash: str,
     build_conda: bool = False,
     device: str = "cuda",
     py_version: Optional[str] = None,


### PR DESCRIPTION
Relates to:
https://github.com/ROCm/builder/pull/68

Validation:
http://ml-ci-internal.amd.com:8080/job/pytorch/job/manylinux_rocm_wheels/530/