### PR TITLE
[release/2.4] skip test_pointwise_op_fusion_post_grad on Navi

### DIFF
--- a/test/inductor/test_group_batch_fusion.py
+++ b/test/inductor/test_group_batch_fusion.py
@@ -9,6 +9,7 @@ import torch._inductor
 import torch._inductor.fx_passes.group_batch_fusion
 from torch._dynamo.utils import counters, optimus_scuba_log
 from torch._inductor.test_case import run_tests, TestCase
+from torch.testing._internal.common_utils import NAVI_ARCH, skipIfRocmArch
 from torch.testing._internal.inductor_utils import HAS_CUDA
 
 try:
@@ -450,6 +451,7 @@ class TestGroupBatchFusion(TestCase):
         self.compare_gradients(module, traced, rtol=1e-8, atol=1e-8)
         counters.clear()
 
+    @skipIfRocmArch(NAVI_ARCH)  # failed on Navi when comparing ["unbind_stack_aten_pass"] with 2 (1 for Navi)
     @requires_cuda
     @torch._inductor.config.patch(
         pre_grad_fusion_options={},


### PR DESCRIPTION
Test failed only on Navi rocm6.3 release/2.4

test expects ["unbind_stack_aten_pass"] == 2 but got 1. Failed only on Navi rocm6.3 release/2.4

Fixes SWDEV-504963

Previous PR https://github.com/ROCm/pytorch/pull/1865 was closed beasuse it wlil break this test on MI 
