### PR TITLE
[release/2.6] Fix sort for non-standard bool

### DIFF
--- a/aten/src/ATen/native/cuda/Sort.cpp
+++ b/aten/src/ATen/native/cuda/Sort.cpp
@@ -65,6 +65,19 @@ void sort_cuda_kernel(
   const auto self_dtype = self.dtype();
   TORCH_CHECK(self_dtype != ScalarType::ComplexFloat && self_dtype != ScalarType::ComplexDouble,
     "Sort currently does not support complex dtypes on CUDA.");
+#if defined(USE_ROCM)
+  // ROCm has undefined behavior for non-standard bools. Here we are converting bool to uint8 which will
+  // convert false to 0 and true or any non-zero value to a 1. copy_ on const Tensors only changes the
+  // data in the tensor and not the metadata.
+  // That's why, tensor's dtype stays as bool. It just becomes a standard bool.
+  if (self_dtype == ScalarType::Bool) {
+      self.copy_(self.to(at::kByte));
+  }
+#else
+  // FIXME: remove this check once cub sort supports bool
+  TORCH_CHECK(self_dtype != ScalarType::Bool,
+    "Sort currently does not support bool dtype on CUDA.");
+#endif
 
   // use inplace algorithm for smaller input sizes without stable=True
   if (should_use_small_sort(self, dim)) {

--- a/torch/testing/_internal/common_methods_invocations.py
+++ b/torch/testing/_internal/common_methods_invocations.py
@@ -18528,8 +18528,6 @@ op_db: List[OpInfo] = [
            supports_forward_ad=True,
            supports_fwgrad_bwgrad=True,
            skips=(
-               DecorateInfo(unittest.expectedFailure, 'TestCommon', 'test_non_standard_bool_values',
-                            dtypes=[torch.bool], device_type='cuda'),
            )),
     OpInfo('unique',
            dtypes=all_types_and(torch.bool, torch.float16, torch.bfloat16, torch.uint16, torch.uint32, torch.uint64),
@@ -21382,13 +21380,6 @@ op_db: List[OpInfo] = [
                 "TestJit",
                 "test_variant_consistency_jit",
                 dtypes=(torch.float32,),
-            ),
-            DecorateInfo(
-                unittest.expectedFailure,
-                "TestCommon",
-                "test_non_standard_bool_values",
-                dtypes=[torch.bool],
-                device_type='cuda',
             ),
         ),
     ),


### PR DESCRIPTION
When converting rom uint8 to bool using `view` op, we get a bool that has 0 for false and a non-zero value for true. However, these kinds of bool have undefined behavior. We only read the last bit as 0 or 1 to convert to false or true.

In this fix, we convert bools to uint8, which will convert false to 0 and non-zero value to 1. Essentially, converting non-standard bool to a standard bool and fixing the sort op for non-standard bool.

(cherry picked from commit dda599d938c39f14dbd5416ce4e89a6dbcd6bc03)

Fixes #ISSUE_NUMBER
