### PR TITLE
[release/2.5] additional skips for distributed tests on Navi

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_training.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_training.py
@@ -40,7 +40,9 @@ from torch.testing._internal.common_fsdp import (
 )
 from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
+    NAVI_ARCH,
     run_tests,
+    skipIfRocmArch,
     wrapSwapTensorsTest,
 )
 from torch.testing._internal.distributed._tensor.common_dtensor import (
@@ -577,6 +579,7 @@ class TestFullyShard1DTrainingCompose(FSDPTest):
 
     @skip_if_lt_x_gpu(2)
     @test_compiled_fsdp(compile_compute_on_module=Transformer)
+    @skipIfRocmArch(NAVI_ARCH)
     def test_train_parity_with_activation_checkpointing(self):
         """
         Tests train parity against DDP when composing with activation

--- a/test/distributed/_composable/fully_shard/test_fully_shard_compile.py
+++ b/test/distributed/_composable/fully_shard/test_fully_shard_compile.py
@@ -17,7 +17,12 @@ from torch.testing._internal.common_fsdp import (
     FSDPTest,
     TransformerWithSharedParams,
 )
-from torch.testing._internal.common_utils import run_tests, TEST_WITH_DEV_DBG_ASAN
+from torch.testing._internal.common_utils import (
+    NAVI_ARCH, 
+    run_tests, 
+    skipIfRocmArch,
+    TEST_WITH_DEV_DBG_ASAN,
+)
 from torch.utils._triton import has_triton
 
 
@@ -40,6 +45,7 @@ class TestCompile(FSDPTest):
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
+    @skipIfRocmArch(NAVI_ARCH)
     def test_compile(self):
         self.run_subtests(
             {

--- a/test/distributed/_tensor/debug/test_comm_mode_features.py
+++ b/test/distributed/_tensor/debug/test_comm_mode_features.py
@@ -12,7 +12,7 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
-from torch.testing._internal.common_utils import run_tests
+from torch.testing._internal.common_utils import NAVI_ARCH, run_tests, skipIfRocmArch
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     DTensorTestBase,
     MLPModule,
@@ -221,6 +221,7 @@ class TestCommModeFeatures(DTensorTestBase):
 
     @skip_unless_torch_gpu
     @with_comms
+    @skipIfRocmArch(NAVI_ARCH)
     def test_transformer_module_tracing(self, is_seq_parallel=False):
         """
         tests module-level tracing for more complicated transformer module and

--- a/test/distributed/fsdp/test_fsdp_use_orig_params.py
+++ b/test/distributed/fsdp/test_fsdp_use_orig_params.py
@@ -38,8 +38,10 @@ from torch.testing._internal.common_fsdp import (
 )
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
+    NAVI_ARCH,
     parametrize,
     run_tests,
+    skipIfRocmArch,
     TEST_WITH_DEV_DBG_ASAN,
     TestCase,
 )
@@ -220,6 +222,7 @@ class TestFSDPUseOrigParamsMultipleParamGroups(FSDPTest):
 
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
+    @skipIfRocmArch(NAVI_ARCH)
     def test_fsdp_compile(self):
         self.run_subtests(
             {

--- a/test/distributed/test_inductor_collectives.py
+++ b/test/distributed/test_inductor_collectives.py
@@ -26,8 +26,10 @@ from torch.testing._internal.common_distributed import (
 )
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
+    NAVI_ARCH,
     parametrize,
     requires_cuda,
+    skipIfRocmArch
 )
 from torch.utils._triton import has_triton
 
@@ -396,6 +398,7 @@ class TestCollectivesMultiProc(DynamoDistributedMultiProcTestCase):
     @unittest.skipIf(not has_triton(), "Inductor+gpu needs triton and recent GPU arch")
     @skip_if_lt_x_gpu(2)
     @patch.object(torch._dynamo.config, "capture_scalar_outputs", True)
+    @skipIfRocmArch(NAVI_ARCH)
     def test_all_to_all_single_inductor(self):
         def example(
             inp,

--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -84,6 +84,8 @@ from torch.testing._internal.common_utils import (
     IS_FBCODE,
     NO_MULTIPROCESSING_SPAWN,
     IS_SANDCASTLE,
+    NAVI_ARCH,
+    skipIfRocmArch,
     skip_but_pass_in_sandcastle,
     skip_but_pass_in_sandcastle_if,
 )
@@ -6754,6 +6756,7 @@ class DistributedTest:
         )
         @require_backend_is_available(DistTestCases.backend_feature["gpu"])
         @with_dist_debug_levels(levels=["DETAIL", "OFF", "INFO"])
+        @skipIfRocmArch(NAVI_ARCH)
         def test_gather_object(self):
             return self._test_gather_object()
 
@@ -6762,6 +6765,7 @@ class DistributedTest:
         )
         @require_backend_is_available(DistTestCases.backend_feature["gpu"])
         @with_dist_debug_levels(levels=["DETAIL", "OFF", "INFO"])
+        @skipIfRocmArch(NAVI_ARCH)
         def test_gather_object_subgroup(self):
             default = _get_default_group()
             backend = dist.get_backend(default)


### PR DESCRIPTION
Skipped tests:
```
distributed/_composable/fsdp/test_fully_shard_training.py::TestFullyShard1DTrainingCompose::test_train_parity_with_activation_checkpointing - Expected -38340.1015625 but got -38368.55078125.	
distributed/_composable/fully_shard/test_fully_shard_compile.py::TestCompile::test_compile	
distributed/_tensor/debug/test_comm_mode_features.py::TestCommModeFeatures::test_transformer_module_tracing - RuntimeError: aten.add.Tensor: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!
distributed/fsdp/test_fsdp_use_orig_params.py::TestFSDPUseOrigParamsMultipleParamGroups::test_fsdp_compile
distributed/tensor/parallel/test_tp_examples.py::DistTensorParallelExampleTest::test_transformer_req_grad_seq_parallel_float32_thaw_*	aten.add.Tensor: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!
distributed/test_distributed_spawn.py::TestDistBackendWithSpawn::test_gather_object - AssertionError: "Can't pickle local object" does not match "Can't get local object 'DistributedTest._DistTestBase._test_gather_object.<locals>.Bar'"
distributed/test_distributed_spawn.py::TestDistBackendWithSpawn::test_gather_object_subgroup - AssertionError: "Can't pickle local object" does not match "Can't get local object 'DistributedTest._DistTestBase._test_gather_object.<locals>.Bar'"	
distributed/test_inductor_collectives.py	TestCollectivesMultiProc	test_all_to_all_single_inductor		
```