### PR TITLE
[release/2.4] Newer conda versions require --update-deps to update dependencies such as libgcc-ng

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -74,7 +74,7 @@ fi
 
   # libstdcxx from conda default channels are too old, we need GLIBCXX_3.4.30
   # which is provided in libstdcxx 12 and up.
-  conda_install libstdcxx-ng=12.3.0 -c conda-forge
+  conda_install --update-deps libstdcxx-ng=12.3.0 -c conda-forge
 
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   if [[ $(uname -m) == "aarch64" ]]; then

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -74,7 +74,7 @@ fi
 
   # libstdcxx from conda default channels are too old, we need GLIBCXX_3.4.30
   # which is provided in libstdcxx 12 and up.
-  conda_install --update-deps libstdcxx-ng=12.3.0 -c conda-forge
+  conda_install libstdcxx-ng=12.3.0 --update-deps -c conda-forge
 
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   if [[ $(uname -m) == "aarch64" ]]; then


### PR DESCRIPTION
Fixes SWDEV-516667

* conda installs the same libgcc-ng package from "defaults" conda channel: `libgcc-ng pkgs/main/linux-64::libgcc-ng-11.2.0-h1234567_1`
* However, at a later point, when we try to [install libstdcxx-ng 12.3.0 from conda-forge](https://github.com/ROCm/pytorch/blob/7cecbf6d33d6567b6ef3aab0b3d6bc5e63478e81/.ci/docker/common/install_conda.sh#L77), conda 24.7.1 updates the dependencies of that package, including libgcc-ng package to the following: 
libgcc-ng-14.2.0 | h69a702a_2 52 KB conda-forge
* On the contrary, conda 25.1.1 does *not* update any dependencies, and hence the same installation of libgcc-ng is present in DOCKER_F after this step.
* The older libgcc-ng from the "defaults" conda channel contains a problematic RPATH setting: 
0x000000000000000f (RPATH) Library rpath: [/opt/conda/conda-bld/gcc-compiler_1654084175708/_h_env_placehold_placehold_placehold_placehold_placehold_placeho
ld_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_/lib]
* The newer libgcc-ng from the "conda-forge" conda channel contains the proper RPATH setting: 
0x000000000000000f (RPATH) Library rpath: [$ORIGIN/.]
* Adding the "--update-deps" flags to the conda install command installs the newer libgcc-ng package from the "conda-forge" conda channel: 
libgcc-ng-12.3.0 | h77fa898_13 762 KB conda-forge
* While this is not the exact same version of libgcc-ng as installed by conda 24.7.1, it does seem to be the more compatible version, as it matches the version of libstdcxx-ng package being installed (12.3.0)
* So maybe conda actually fixed a bug in their dependency resolution/installation code to update the dependencies only if the --update-deps flag is specified.


Validation: http://rocm-ci.amd.com/job/mainline-framework-pytorch-2.4-ub22-py3.10-ci/189/