### PR TITLE
Updated test_flex_decoding.py

### DIFF
--- a/test/inductor/test_flex_decoding.py
+++ b/test/inductor/test_flex_decoding.py
@@ -1383,7 +1383,6 @@ def forward(self, arg0_1, arg1_1, arg2_1, arg3_1, arg4_1):
         loss.backward()
         self.assertEqual(query.grad[:, :, M:, :].sum(), 0)
 
-    @skipIfRocm
     @supported_platform
     def test_windowed_no_mask_vs_sdpa(self):
         score_mod = _generate_windowed(1000)


### PR DESCRIPTION
Fixes [SWDEV-480212](https://ontrack-internal.amd.com/browse/SWDEV-480212)

test/inductor/test_flex_decoding.py runs fine and re-enable test/inductor/test_flex_decoding.py::TestFlexDecoding::test_windowed_no_mask_vs_sdpa (verified this unit test runs fine on NAVI3x and MI300)