### PR TITLE
Fixed rocm skip import issue

### DIFF
--- a/torch/testing/_internal/distributed/rpc/rpc_test.py
+++ b/torch/testing/_internal/distributed/rpc/rpc_test.py
@@ -32,13 +32,13 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     captured_output,
     tp_transports,
-    skip_if_rocm,
 )
 from torch.testing._internal.common_utils import (
     IS_MACOS,
     load_tests,
     skip_but_pass_in_sandcastle_if,
     get_cycles_per_ms,
+    skipIfRocm,
 )
 
 from torch.testing._internal.dist_utils import (
@@ -5055,7 +5055,7 @@ class TensorPipeAgentRpcTest(RpcAgentTestFixture, RpcTestCommon):
 
     # Dynamic RPC existing ranks can communicate with new ranks using CUDA rpc
     @skip_if_lt_x_gpu(2)
-    @skip_if_rocm
+    @skipIfRocm
     @dist_init(setup_rpc=False)
     def test_dynamic_rpc_existing_rank_can_communicate_with_new_rank_cuda(self):
         initialize_pg(self.file_init_method, self.rank, self.world_size)


### PR DESCRIPTION
skip_if_rocm does not exist in torch/testing/_internal/common_distributed.py. Use skipIfRocm from torch/testing/_internal/common_utils.py instead.
