### PR TITLE
[release/2.6] Add gfx120x in supported archs for hipBLASLt

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -320,7 +320,7 @@ at::BlasBackend Context::blasPreferredBackend() {
       static const std::vector<std::string> archs = {
           "gfx90a", "gfx940", "gfx941", "gfx942",
 #if ROCM_VERSION >= 60300
-          "gfx1100", "gfx1101"
+          "gfx1100", "gfx1101", "gfx1200", "gfx1201"
 #endif
       };
       for (auto index: c10::irange(getNumGPUs())) {


### PR DESCRIPTION
Add gfx120x to supported architectures for hipBLASLt so it does not fall back to rocBLAS.