### PR TITLE
reduce CUDA to HIP flag hipify breaking existing/valid flags

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1051,7 +1051,7 @@ class BuildExtension(build_ext):
     # Simple hipify, replace the first occurrence of CUDA with HIP
     # in flags starting with "-" and containing "CUDA", but exclude -I flags
     def _hipify_compile_flags(self, extension):
-        if isinstance(extension.extra_compile_args, dict):
+        if isinstance(extension.extra_compile_args, dict) and 'nvcc' in extension.extra_compile_args:
             modified_flags = []
             for flag in extension.extra_compile_args['nvcc']:
                 if flag.startswith("-") and "CUDA" in flag and not flag.startswith("-I"):

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1048,11 +1048,19 @@ class BuildExtension(build_ext):
         else:
             extension.extra_compile_args.append(flag)
 
+    # Simple hipify, replace the first occurrence of CUDA with HIP
+    # in flags starting with "-" and containing "CUDA", but exclude -I flags
     def _hipify_compile_flags(self, extension):
-        # Simple hipify, map CUDA->HIP
         if isinstance(extension.extra_compile_args, dict):
-            extension.extra_compile_args['nvcc'] = [
-                flag.replace("CUDA", "HIP") for flag in extension.extra_compile_args['nvcc']]
+            modified_flags = []
+            for flag in extension.extra_compile_args['nvcc']:
+                if flag.startswith("-") and "CUDA" in flag and not flag.startswith("-I"):
+                    modified_flag = flag.replace("CUDA", "HIP", 1)
+                    modified_flags.append(modified_flag)
+                    print(f'Modified flag: {flag} -> {modified_flag}', file=sys.stderr)
+                else:
+                    modified_flags.append(flag)
+            extension.extra_compile_args['nvcc'] = modified_flags
 
     def _define_torch_extension_name(self, extension):
         # pybind11 doesn't support dots in the names

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1055,7 +1055,16 @@ class BuildExtension(build_ext):
             modified_flags = []
             for flag in extension.extra_compile_args['nvcc']:
                 if flag.startswith("-") and "CUDA" in flag and not flag.startswith("-I"):
-                    modified_flag = flag.replace("CUDA", "HIP", 1)
+                    # check/split flag into flag and value
+                    parts = flag.split("=", 1)
+                    if len(parts) == 2:
+                        flag_part, value_part = parts
+                        # replace fist instance of "CUDA" with "HIP" only in the flag and not flag value
+                        modified_flag_part = flag_part.replace("CUDA", "HIP", 1)
+                        modified_flag = f"{modified_flag_part}={value_part}"
+                    else:
+                        # replace fist instance of "CUDA" with "HIP" in flag
+                        modified_flag = flag.replace("CUDA", "HIP", 1)
                     modified_flags.append(modified_flag)
                     print(f'Modified flag: {flag} -> {modified_flag}', file=sys.stderr)
                 else:


### PR DESCRIPTION
I made improvements to the exising PR to that fixes CUDA to HIP flag conversion. 

* Log: We should log this behavior since this can break hipcc down the line for all we know
* Log: Make it transparent to user what hipify actions are doing so devs are not left in the dark. 
* Fix cases where it should not touch the `-I` flags or case where CUDA appear more than once by replacing only the first instance. 
* Fix case where `nvcc` key may not exist 
* Fix case where hipify should ignore flag values and only touch the flag itself

@naromero77amd 

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @dllehr-amd @jataylo @hongxiayang

Passes the following unit test

```py
import unittest
import sys
from unittest.mock import Mock

class TestHipifyCompileFlags(unittest.TestCase):
    def test_hipify_compile_flags(self):

        class DummyClass:
            # Simple hipify, replace the first occurrence of CUDA with HIP
            # in flags starting with "-" and containing "CUDA", but exclude -I flags
            def _hipify_compile_flags(self, extension):
                if isinstance(extension.extra_compile_args, dict) and 'nvcc' in extension.extra_compile_args:
                    modified_flags = []
                    for flag in extension.extra_compile_args['nvcc']:
                        if flag.startswith("-") and "CUDA" in flag and not flag.startswith("-I"):
                            # check/split flag into flag and value
                            parts = flag.split("=", 1)
                            if len(parts) == 2:
                                flag_part, value_part = parts
                                # replace fist instance of "CUDA" with "HIP" only in the flag and not flag value
                                modified_flag_part = flag_part.replace("CUDA", "HIP", 1)
                                modified_flag = f"{modified_flag_part}={value_part}"
                            else:
                                # replace fist instance of "CUDA" with "HIP" in flag
                                modified_flag = flag.replace("CUDA", "HIP", 1)
                            modified_flags.append(modified_flag)
                            print(f'Modified flag: {flag} -> {modified_flag}', file=sys.stderr)
                        else:
                            modified_flags.append(flag)
                    extension.extra_compile_args['nvcc'] = modified_flags

        dummy = DummyClass()
        extension = Mock()

        # (tested flag, expected flag)
        test_cases = [
            ('-CUDA', '-HIP'),
            ('--CUDA', '--HIP'),
            ('--CUDA_CUDA', '--HIP_CUDA'),  # only first CUDA instance
            ('-U__CUDA', '-U__HIP'),
            ('-D__CUDA', '-D__HIP'),
            ('-I/usr/local/CUDA', '-I/usr/local/CUDA'),  # skip includes
            ('-Dmyflag=CUDA', '-Dmyflag=CUDA'),  # should not be touched
        ]

        tested_flags = [test_case[0] for test_case in test_cases]
        expected_flags = [test_case[1] for test_case in test_cases]

        # test `nvcc` key exists
        extension.extra_compile_args = {'nvcc': tested_flags}
        dummy._hipify_compile_flags(extension)
        self.assertEqual(extension.extra_compile_args['nvcc'], expected_flags)

        # test `nvcc` key does not exists
        test_cases = {'abcd': ["-DTest", "--TEST"]}
        extension.extra_compile_args = test_cases
        dummy._hipify_compile_flags(extension)
        # Assert the result
        self.assertEqual(extension.extra_compile_args['abcd'], test_cases['abcd'])

if __name__ == '__main__':
    unittest.main()
```
    
    
