### PR TITLE
[release/2.4] Update libamd_comgr.so.3 in triton wheel build

### DIFF
--- a/.github/scripts/amd/package_triton_wheel.sh
+++ b/.github/scripts/amd/package_triton_wheel.sh
@@ -54,10 +54,15 @@ done
 ROCM_SO=(
     "libamdhip64.so.6"
     "libhsa-runtime64.so.1"
-    "libamd_comgr.so.2"
     "libdrm.so.2"
     "libdrm_amdgpu.so.1"
 )
+
+if [[ $ROCM_INT -ge 60400 ]]; then
+    ROCM_SO+=("libamd_comgr.so.3")
+else
+    ROCM_SO+=("libamd_comgr.so.2")
+fi
 
 if [[ $ROCM_INT -ge 60100 ]]; then
     ROCM_SO+=("librocprofiler-register.so.0")


### PR DESCRIPTION
libamd_comgr.so.2 is breaking rocm6.4 and newer. Breaking this build: http://rocm-ci.amd.com/job/pytorch2.4-manylinux-wheels_rel-6.4/14/

similar changes to https://github.com/ROCm/triton/pull/760

Validation
http://rocm-ci.amd.com/job/pytorch2.4-manylinux-wheels_rel-6.4/18/