### PR TITLE
[rocm6.4_internal_testing] temporary skip test_RNN_dropout_state on ROCm

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4345,6 +4345,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 # Check that backward does not cause a hard error
                 outs[0].sum().backward()
 
+    @skipIfRocm("fails because ROCm doesn't support 'dropout' in RNN")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
     def test_RNN_dropout_state(self):
         for p in (0, 0.1234):


### PR DESCRIPTION
RNN dropout PR for upstream still in review pytorch/pytorch#144572

Fixes SWDEV-517343