### PR TITLE
[CUDA][AMP] Speed up fp16/bf16 casts on H100+ (#137053)

### DIFF
--- a/aten/src/ATen/native/cuda/Copy.cu
+++ b/aten/src/ATen/native/cuda/Copy.cu
@@ -30,6 +30,18 @@ namespace at::native {
 void neg_kernel_cuda(TensorIteratorBase &iter);
 void conj_kernel_cuda(TensorIteratorBase &iter);
 
+void float16_copy_kernel_cuda(TensorIteratorBase &iter) {
+    gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
+        return static_cast<at::Half>(value);
+    });
+}
+
+void bfloat16_copy_kernel_cuda(TensorIteratorBase &iter) {
+    gpu_kernel_nocast(iter, [] GPU_LAMBDA(float value) {
+        return static_cast<at::BFloat16>(value);
+    });
+}
+
 void float8_copy_kernel_cuda(TensorIteratorBase &iter) {
   ScalarType dtype = iter.dtype(0);
   ScalarType other_dtype = iter.dtype(1);
@@ -147,6 +159,12 @@ void direct_copy_kernel_cuda(TensorIteratorBase &iter) {
     });
   } else if (dtype == kFloat8_e5m2 || dtype == kFloat8_e4m3fn || dtype == kFloat8_e5m2fnuz || dtype == kFloat8_e4m3fnuz) {
      float8_copy_kernel_cuda(iter);
+  } else if (iter.dtype(1) == kFloat && (dtype == kBFloat16 || dtype == kHalf)) {
+     if (dtype == kBFloat16) {
+       bfloat16_copy_kernel_cuda(iter);
+     } else {
+       float16_copy_kernel_cuda(iter);
+     }
   } else if (isBitsType(dtype)) {
     TORCH_CHECK(dtype == iter.dtype(1), "copy_() does not support casting "
       "bits types to different bits types. Source dtype is ", iter.dtype(1), "target dtype is ", dtype);


### PR DESCRIPTION
Similar to #110251 we're seeing cases where vectorization can benefit casts to fp16/bf16

Pull Request resolved: https://github.com/pytorch/pytorch/pull/137053
Approved by: https://github.com/drisspg

