### PR TITLE
[release/2.6] Update libamd_comgr.so.3 in triton wheel build (#1963)

### DIFF
--- a/.github/scripts/amd/package_triton_wheel.sh
+++ b/.github/scripts/amd/package_triton_wheel.sh
@@ -61,10 +61,15 @@ fi
 ROCM_SO=(
     "${libamdhip}"
     "libhsa-runtime64.so.1"
-    "libamd_comgr.so.2"
     "libdrm.so.2"
     "libdrm_amdgpu.so.1"
 )
+
+if [[ $ROCM_INT -ge 60400 ]]; then
+    ROCM_SO+=("libamd_comgr.so.3")
+else
+    ROCM_SO+=("libamd_comgr.so.2")
+fi
 
 if [[ $ROCM_INT -ge 60100 ]]; then
     ROCM_SO+=("librocprofiler-register.so.0")


### PR DESCRIPTION
libamd_comgr.so.2 is breaking rocm6.4 and newer. Breaking this build:http://rocm-ci.amd.com/job/pytorch2.5-manylinux-wheels_rel-6.4/25/

similar changes to https://github.com/ROCm/triton/pull/760

Validation:
http://rocm-ci.amd.com/job/pytorch2.5-manylinux-wheels_rel-6.4/29/


THIS CAN BE CLOSED AS COMMIT WAS CHERRY PICKED HERE:https://github.com/ROCm/pytorch/commit/13339bf6e263690a3972ad67473862b8fee0385a
