### PR TITLE
[Release/2.4] Update related_commits for vision

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release0.19_lddtree|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release0.19_lddtree|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.19|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.19|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.7|5e6f7b7dc5f8c8409a6a140f520a045da8700451|https://github.com/pytorch/data

--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.19|fab848869c0f88802297bad43c0ad80f33ecabb4|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.19|fab848869c0f88802297bad43c0ad80f33ecabb4|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release0.19_lddtree|cdfea74245031c21f478d7290b08595003dc4ff9|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release0.19_lddtree|cdfea74245031c21f478d7290b08595003dc4ff9|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.7|5e6f7b7dc5f8c8409a6a140f520a045da8700451|https://github.com/pytorch/data

--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release0.19_lddtree|cdfea74245031c21f478d7290b08595003dc4ff9|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release0.19_lddtree|cdfea74245031c21f478d7290b08595003dc4ff9|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release0.19_lddtree|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release0.19_lddtree|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.7|5e6f7b7dc5f8c8409a6a140f520a045da8700451|https://github.com/pytorch/data


### PR DESCRIPTION
Relates to https://github.com/ROCm/vision/pull/7
Cherry pick of this https://github.com/pytorch/vision/pull/8982

https://ontrack-internal.amd.com/browse/SWDEV-522276
Validation:http://rocm-ci.amd.com/job/pytorch2.4-manylinux-wheels_rel-6.4/23/