### PR TITLE
[Release/2.5] Update related_commits for vision

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.5.0|c1e6a5f06f3a465cfe83ce5eff4d5f68e5d150c1|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.5.0|c1e6a5f06f3a465cfe83ce5eff4d5f68e5d150c1|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.20|73066201129e201fc2e4c272d000ca225fe46150|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.20|73066201129e201fc2e4c272d000ca225fe46150|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.8|265d317aa541e6713071ddb8b137dd3d8a6b9eda|https://github.com/pytorch/data

--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.5.0|c1e6a5f06f3a465cfe83ce5eff4d5f68e5d150c1|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.5.0|c1e6a5f06f3a465cfe83ce5eff4d5f68e5d150c1|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.20|afc54f754c734d903a06194e416495e20d920ff6|https://github.com/pytorch/vision
-centos|pytorch|torchvision|release/0.20|afc54f754c734d903a06194e416495e20d920ff6|https://github.com/pytorch/vision
+ubuntu|pytorch|torchvision|release/0.20|73066201129e201fc2e4c272d000ca225fe46150|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.20|73066201129e201fc2e4c272d000ca225fe46150|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.8|265d317aa541e6713071ddb8b137dd3d8a6b9eda|https://github.com/pytorch/data


### PR DESCRIPTION
Relates to https://github.com/ROCm/vision/pull/7
Cherry pick of this https://github.com/pytorch/vision/pull/8982

https://ontrack-internal.amd.com/browse/SWDEV-522276

Validation:http://rocm-ci.amd.com/job/pytorch2.5-manylinux-wheels_rel-6.4/35/