### PR TITLE
[Release/2.6] Update related_commits for vision

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.6.0|04ba0f171fe55cbdc8b939e28696d39c602eaaf9|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.6.0|04ba0f171fe55cbdc8b939e28696d39c602eaaf9|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.21|7af698794eded568735f9519593603c1ec889eba|https://github.com/pytorch/vision
-centos|pytorch|torchvision|release/0.21|7af698794eded568735f9519593603c1ec889eba|https://github.com/pytorch/vision
+ubuntu|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.10|a4bed25873e071ecb4d4206a47b5326965283ad4|https://github.com/pytorch/data


### PR DESCRIPTION
Relates to https://github.com/ROCm/vision/pull/7
Cherry pick of this https://github.com/pytorch/vision/pull/8982
https://ontrack-internal.amd.com/browse/SWDEV-522276
Validation:
http://rocm-ci.amd.com/job/pytorch2.6-manylinux-wheels_rel-6.4-preview/9/