### PR TITLE
[release/2.5] enable NHWC batchnorm with MIOpen

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -511,23 +511,27 @@ BatchNormBackend _select_batch_norm_backend(
     return BatchNormBackend::Cudnn;
   }
 
+  // TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM once ROCm officially supports NHWC in MIOpen
+  // See #64427
+  // non static variable is used to be able to change environment variable in runtime for testing
+  bool PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM").value_or(false);
+
   if (
       input.is_cuda()
-      && input.dim() <= MIOPEN_DIM_MAX
-      && input.scalar_type() != at::kDouble
+      && (input.dim() <= MIOPEN_DIM_MAX)
+      && (input.scalar_type() != at::kDouble)
 #if (defined(USE_ROCM) && ROCM_VERSION < 60400)
-      && input.scalar_type() != at::kBFloat16
+      && (input.scalar_type() != at::kBFloat16)
 #endif
-      && (weight.scalar_type() != at::kHalf)
-      && (weight.scalar_type() != at::kBFloat16)
+      && (weight.scalar_type() == at::kFloat) // allow only fp32 and mixed fp16/bf16
       && weight.defined() && bias.defined()
       && ((running_mean.defined() && running_var.defined())
         || (!running_mean.defined() && !running_var.defined() && training))
       && (input.dim() >= 3)
       && detail::getCUDAHooks().compiledWithMIOpen()
       && cudnn_enabled
-      && input.suggest_memory_format() != MemoryFormat::ChannelsLast
-      && input.suggest_memory_format() != MemoryFormat::ChannelsLast3d
+      && (input.suggest_memory_format() == MemoryFormat::Contiguous
+        || (input.suggest_memory_format() == MemoryFormat::ChannelsLast && PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM))
   ) {
     return BatchNormBackend::Miopen;
   }
@@ -639,7 +643,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
 	    std::cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (calling miopen_batch_norm)" << std::endl;
     return std::tuple_cat(
              at::miopen_batch_norm(
-               input.contiguous(), weight.contiguous(), bias.contiguous(),
+               input.contiguous(input.suggest_memory_format()), weight.contiguous(), bias.contiguous(),
                running_mean.defined() ? running_mean.contiguous() : running_mean,
                running_var.defined() ? running_var.contiguous() : running_var,
                training, momentum, eps),

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -531,7 +531,10 @@ BatchNormBackend _select_batch_norm_backend(
       && detail::getCUDAHooks().compiledWithMIOpen()
       && cudnn_enabled
       && (input.suggest_memory_format() == MemoryFormat::Contiguous
-        || (input.suggest_memory_format() == MemoryFormat::ChannelsLast && PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM))
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60500)
+        || (input.suggest_memory_format() == MemoryFormat::ChannelsLast && PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM)
+#endif
+        )
   ) {
     return BatchNormBackend::Miopen;
   }

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -100,7 +100,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     mode = miopenBNSpatial;
   }
 
-  auto output_t = at::empty(input->sizes(), input->options());
+  auto output_t = at::empty(input->sizes(), input->options(), input->suggest_memory_format());
   TensorArg output{ output_t, "output", 0 };
 
   auto handle = getMiopenHandle();
@@ -177,8 +177,10 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
   const Tensor& save_var_t =
       c10::value_or_else(save_var_t_opt, [] { return Tensor(); });
 
+  auto grad_output_contig =
+      grad_output_t.contiguous(input_t.suggest_memory_format());
   TensorArg input{ input_t, "input", 1 },
-            grad_output{ grad_output_t, "grad_output", 2 },
+            grad_output{ grad_output_contig, "grad_output", 2 },
             weight{ weight_t, "weight", 3 },
             save_mean{ save_mean_t, "save_mean", 4 },
             save_var{ save_var_t, "save_var", 5 };
@@ -193,7 +195,9 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
   }
   checkAllSameType(c, {input, grad_output});
   checkAllSameType(c, {weight, save_mean, save_var});
-  checkAllContiguous(c, {input, grad_output, save_mean, save_var});
+  checkAllContiguous(c, {save_mean, save_var});
+  TORCH_CHECK(input->is_contiguous(input->suggest_memory_format()));
+  TORCH_CHECK(grad_output->is_contiguous(input->suggest_memory_format()));
   checkDimRange(c, input, 2, 6 /* exclusive */);
   checkSameSize(c, input, grad_output);
   auto num_features = input->size(1);
@@ -208,7 +212,8 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
     mode = miopenBNSpatial;
   }
 
-  auto grad_input_t  = at::empty(input->sizes(), input->options());
+  auto grad_input_t = at::empty(
+      input->sizes(), input->options(), input->suggest_memory_format());
   auto grad_weight_t = at::empty(weight->sizes(), weight->options());
   auto grad_bias_t   = at::empty(weight->sizes(), weight->options());
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4907,54 +4907,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         run_test(input, grad)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
-    def test_batchnorm_nhwc_miopen(self):
-        def run_test(input, grad_output):
-            c = input.size(1)
-            mod = nn.BatchNorm2d(c).cuda().float()
-            mod.weight.data.uniform_()
-            mod.bias.data.uniform_()
-            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
-            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
-            ref_mod = nn.BatchNorm2d(c).cuda().float()
-            ref_mod.load_state_dict(mod.state_dict())
-            out = mod(input)
-            out.backward(grad_output)
-            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm
-                ref_out = ref_mod(ref_input)
-                ref_out.backward(ref_grad)
-            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-            self.assertTrue(ref_out.is_contiguous(memory_format=torch.channels_last))
-            self.assertEqual(out, ref_out)
-            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
-            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
-            self.assertEqual(input.grad, ref_input.grad)
-
-        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
-        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
-        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
-        try:
-            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
-            input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
-
-            grad = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-            grad = grad.contiguous(memory_format=torch.channels_last)
-            run_test(input, grad)
-            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
-            # not channels_last
-            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
-            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-            grad = grad.permute(0, 2, 1, 3)
-            run_test(input, grad)
-        finally:
-            if prev_val is None:
-                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
-            else:
-                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):
         # THNN
         input = torch.randint(1, 10, (2, 3, 2, 2), dtype=torch.half, device="cuda", requires_grad=True)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4907,6 +4907,54 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         run_test(input, grad)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
+    def test_batchnorm_nhwc_miopen(self):
+        def run_test(input, grad_output):
+            c = input.size(1)
+            mod = nn.BatchNorm2d(c).cuda().float()
+            mod.weight.data.uniform_()
+            mod.bias.data.uniform_()
+            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
+            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
+            ref_mod = nn.BatchNorm2d(c).cuda().float()
+            ref_mod.load_state_dict(mod.state_dict())
+            out = mod(input)
+            out.backward(grad_output)
+            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm
+                ref_out = ref_mod(ref_input)
+                ref_out.backward(ref_grad)
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+            self.assertTrue(ref_out.is_contiguous(memory_format=torch.channels_last))
+            self.assertEqual(out, ref_out)
+            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
+            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
+            self.assertEqual(input.grad, ref_input.grad)
+
+        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
+        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
+        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
+        try:
+            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
+            input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
+            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
+
+            grad = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
+            grad = grad.contiguous(memory_format=torch.channels_last)
+            run_test(input, grad)
+            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
+            # not channels_last
+            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
+            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
+            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
+            grad = grad.permute(0, 2, 1, 3)
+            run_test(input, grad)
+        finally:
+            if prev_val is None:
+                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
+            else:
+                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):
         # THNN
         input = torch.randint(1, 10, (2, 3, 2, 2), dtype=torch.half, device="cuda", requires_grad=True)
@@ -5025,7 +5073,89 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             inp2 = inp1.contiguous(memory_format=torch.channels_last)
             out1 = model(inp1)
             out2 = model(inp2)
-            self.assertTrue(torch.equal(out1, out2))
+            self.assertEqual(out1, out2)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @parametrize_test("mixed", [False, True])
+    @parametrize_test("dtype", [torch.float, torch.half, torch.bfloat16])
+    def test_batchnorm_nhwc_eval(self, mixed, dtype):
+        if mixed and dtype == torch.float:
+            self.skipTest("mixed precision is useless for float32")
+        if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
+            self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
+        if TEST_WITH_ROCM:
+            self.skipTest("NHWC batchnorm disabled on ROCm6.4 SWDEV-510757 SWDEV-509640")
+
+        (N, C, H, W) = 2, 64, 50, 50
+        model = torch.nn.BatchNorm2d(C, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
+        model = model.eval().cuda()
+        if not mixed:
+            model = model.to(dtype)
+        inp1 = torch.randn(N, C, H, W, device=torch.device('cuda'), dtype=dtype)
+        inp2 = inp1.contiguous(memory_format=torch.channels_last)
+        out1 = model(inp1)
+        out2 = model(inp2)
+        self.assertEqual(out1, out2)
+
+    @parametrize_test("layout", ["NCHW", "NHWC"])
+    @parametrize_test("mixed", [False, True])
+    @parametrize_test("dtype", [torch.float, torch.half, torch.bfloat16])
+    def test_batchnorm(self, layout, mixed, dtype):
+        def _batchnorm2d_helper(dtype, memory_format, mixed: bool):
+            def _run_test(input, grad_output, mixed: bool):
+                c = input.size(1)
+                mod = nn.BatchNorm2d(c).cuda()
+                ref_mod = nn.BatchNorm2d(c).cuda()
+                if not mixed:
+                    mod = mod.to(dtype=input.dtype)
+                    ref_mod = ref_mod.to(dtype=input.dtype)
+
+                mod.weight.data.uniform_()
+                mod.bias.data.uniform_()
+
+                ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
+                ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
+                ref_mod.load_state_dict(mod.state_dict())
+
+                out = mod(input)
+                out.backward(grad_output)
+                with torch.backends.cudnn.flags(enabled=False):  # force to use native nhwc batchnorm
+                    ref_out = ref_mod(ref_input)
+                    ref_out.backward(ref_grad)
+                self.assertTrue(out.is_contiguous(memory_format=memory_format))
+                self.assertTrue(ref_out.is_contiguous(memory_format=memory_format))
+                self.assertEqual(out, ref_out)
+                self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
+                self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
+                self.assertEqual(mod.running_mean, ref_mod.running_mean)
+                self.assertEqual(mod.running_var, ref_mod.running_var)
+                self.assertEqual(input.grad, ref_input.grad)
+
+            size = (4, 8, 2, 2)
+            input = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
+            input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
+            grad = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
+            grad = grad.contiguous(memory_format=memory_format)
+            _run_test(input, grad, mixed)
+            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
+            # not channels_last
+            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
+            input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
+            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
+            grad = grad.permute(0, 2, 1, 3)
+            _run_test(input, grad, mixed)
+
+        if TEST_WITH_ROCM and layout == "NHWC":
+            self.skipTest("NHWC batchnorm disabled on ROCm6.4 SWDEV-510757")
+        if mixed and dtype == torch.float:
+            self.skipTest("mixed precision is useless for float32")
+        if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
+            self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
+        if TEST_WITH_ROCM and layout == "NCHW" and dtype == torch.bfloat16 and mixed:
+            self.skipTest("MIOpen tolerance issue for NCHW BF16 mixed batchnorm SWDEV-507600")
+
+        memory_format = torch.contiguous_format if layout == "NCHW" else torch.channels_last
+        _batchnorm2d_helper(dtype, memory_format=memory_format, mixed=mixed)
 
     def test_batchnorm_load_state_dict(self):
         bn = torch.nn.BatchNorm2d(3)
@@ -8197,7 +8327,6 @@ class TestNNDeviceType(NNTestCase):
                         self.assertEqual(affine_tensor[0, i, r, c], grid_out[:3], exact_dtype=False)
 
             self.assertEqual(scipy_ary, gridsample_ary.reshape_as(scipy_ary))
-
 
     @onlyCUDA
     @dtypes(torch.float, torch.half)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2771,7 +2771,7 @@
   self, weight, bias: "grad.defined() ? convolution_backward_symint(grad, self, weight, bias->sym_sizes(), stride, padding, dilation, false, std::vector<c10::SymInt>(padding.size(), 0), groups, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
 
 - name: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
-  input, weight, bias: "grad.defined() ? (training ? miopen_batch_norm_backward(input, grad.contiguous(), weight, running_mean, running_var, result1, result2, epsilon) : native_batch_norm_backward(grad, input, weight, running_mean, running_var, result1, result2, training, epsilon, grad_input_mask)) : std::tuple<Tensor, Tensor, Tensor>()"
+  input, weight, bias: "grad.defined() ? (training ? miopen_batch_norm_backward(input, grad.contiguous(input.suggest_memory_format()), weight, running_mean, running_var, result1, result2, epsilon) : native_batch_norm_backward(grad, input, weight, running_mean, running_var, result1, result2, training, epsilon, grad_input_mask)) : std::tuple<Tensor, Tensor, Tensor>()"
   result0: batch_norm_jvp(input_p, input_t, weight_p, weight_t, bias_p, bias_t, running_mean, running_var, result1, result2, training, epsilon)
 
 - name: miopen_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon) -> (Tensor, Tensor, Tensor)


### PR DESCRIPTION
NHWC batchnorm on MIOpen in preview mode
supported modes:
* NCHW/NHWC fp32
* NCHW/NHWC fp16/bf16 mixed mode (with fp16 input/gradinet and fp32 scale/bias)

redundant NHWC-NCHW-NHWC conversions for MiopenBatchNormBackward is fixed

NHWC batchnorm disabled by default. Environment variable PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM=1 enables NHWC batchnorm (separately from NHWC convolution)

new batchnorm tests (most of them are skipped by default) (only for debugging purposes):
```
test_batchnorm_layout_NCHW_mixed_False_bfloat16 - skipped - not supported mode
test_batchnorm_layout_NCHW_mixed_False_float16 - skippes - not supported mode
test_batchnorm_layout_NCHW_mixed_False_float32 - passed
test_batchnorm_layout_NCHW_mixed_True_bfloat16 - skipped - tolerance issue
test_batchnorm_layout_NCHW_mixed_True_float16 - passed
test_batchnorm_layout_NCHW_mixed_True_float32 - skipped - useless
test_batchnorm_layout_NHWC_mixed_False_bfloat16 - skipped - NHWC
test_batchnorm_layout_NHWC_mixed_False_float16 - skippes - not supported mode
test_batchnorm_layout_NHWC_mixed_False_float32 - skippes - not supported mode
test_batchnorm_layout_NHWC_mixed_True_bfloat16 - skipped - NHWC
test_batchnorm_layout_NHWC_mixed_True_float16 - skipped - NHWC
test_batchnorm_layout_NHWC_mixed_True_float32 - skipped - useless

test_batchnorm_nhwc_eval_mixed_False_bfloat16 - skipped - not supported mode
test_batchnorm_nhwc_eval_mixed_False_float16 - skipped - not supported mode
test_batchnorm_nhwc_eval_mixed_False_float32 - skipped - NHWC
test_batchnorm_nhwc_eval_mixed_True_bfloat16 - skipped - NHWC
test_batchnorm_nhwc_eval_mixed_True_float16 - skipped - NHWC
test_batchnorm_nhwc_eval_mixed_True_float32 - skipped - useless
```

(cherry picked from commit a1e8b0e925114d34e9feb994fb76e447b6bf264d)
(cherry picked from commit 8c39322153d9608f06f69cdc588cbe0acd2d53aa)
(cherry picked from commit d726574c808284976e943858ee2ce9b40ccbb5db)
(cherry picked from commit 432b200751f5dc3eb636e0639c182029ff7af750)
(cherry picked from commit 398bd573dcde7a5f5e69c00e1e5a02fd349aee71) 
(cherry picked from commit d9668352f0d960457a40e1ea9458aa11d8668c8d)
