### PR TITLE
[ROCm6.4_internal_testing] Update CUDAPluggableAllocator.h

### DIFF
--- a/torch/csrc/cuda/CUDAPluggableAllocator.h
+++ b/torch/csrc/cuda/CUDAPluggableAllocator.h
@@ -37,7 +37,7 @@ struct TORCH_CUDA_CPP_API CUDAPluggableAllocatorDeleterContext {
   cudaStream_t stream_;
 };
 
-#if defined(TORCH_HIP_VERSION)
+#if defined(USE_ROCM)
 using streamType = c10::hip::HIPStream;
 #else
 using streamType = c10::cuda::CUDAStream;


### PR DESCRIPTION
Altering the flag to use the correct streamType for CUDAPluggableAllocator. This is impacting Distributed Fused Adam in Rocm/APEX. 

See PR https://github.com/ROCm/apex/pull/184

Related Issue : https://ontrack-internal.amd.com/browse/SWDEV-519796
