### PR TITLE
[release/2.6] [ROCm] NLLLoss (torch.nll_loss) Performance Tuning by Dynamically Selecting # of GPU threads #149548

### DIFF
--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -153,9 +153,13 @@ Tensor& binary_cross_entropy_backward_out_cuda(const Tensor& grad, const Tensor&
 // -----------------------------------
 namespace {
 
+#if defined(USE_ROCM)
 int nll_loss_threads(int64_t nframe){
   return std::clamp(1 << static_cast<int64_t>(std::round(std::log2(nframe/16))), 32, 1024);
 }
+#else
+constexpr int NLL_LOSS_THREADS = 32;
+#endif
 
 // NOTE(crcrpar): `Byte` support was added for https://github.com/pytorch/pytorch/issues/59765.
 #define AT_DISPATCH_NLL_LOSS_INDEX_TYPES(TYPE, NAME, ...)                     \
@@ -241,9 +245,14 @@ __global__ void nll_loss_forward_reduce_cuda_kernel_2d(
     int64_t n_classes,
     int64_t ignore_index) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
+  #if defined(USE_ROCM)
   extern __shared__ unsigned char shmem[];
   accscalar_t* sh_inputs = reinterpret_cast<accscalar_t*>(shmem);
   accscalar_t* acc_weight = reinterpret_cast<accscalar_t*>(shmem + blockDim.x * sizeof(accscalar_t));
+  #else
+  __shared__ accscalar_t sh_inputs[NLL_LOSS_THREADS],
+      acc_weight[NLL_LOSS_THREADS];
+  #endif
 
   sh_inputs[threadIdx.x] = static_cast<accscalar_t>(0);
   acc_weight[threadIdx.x] = static_cast<accscalar_t>(0);
@@ -385,11 +394,18 @@ void nll_loss_forward_out_cuda_template(
               "nll_loss_forward_reduce_cuda_kernel_2d_index",
               [&] {
                 using accscalar_t = at::acc_type<scalar_t, /*is_cuda*/true>;
+#if defined (USE_ROCM)
                 int nthreads = nll_loss_threads(input.size(0));
+#endif
                 nll_loss_forward_reduce_cuda_kernel_2d<scalar_t, accscalar_t, index_t>
                     <<<1,
+#if defined (USE_ROCM)
                        nthreads,
                        nthreads * sizeof(accscalar_t) * 2,
+#else
+                       NLL_LOSS_THREADS,
+                       0,
+#endif
                        at::cuda::getCurrentCUDAStream()>>>(
                         output.mutable_data_ptr<scalar_t>(),
                         total_weight.mutable_data_ptr<scalar_t>(),
@@ -572,7 +588,13 @@ void nll_loss_backward_out_cuda_template(
               "nll_loss_backward_reduce_cuda_kernel_2d_index",
               [&] {
             nll_loss_backward_reduce_cuda_kernel_2d<scalar_t, index_t>
-                <<<1, nll_loss_threads(input.size(0)), 0, at::cuda::getCurrentCUDAStream()>>>(
+                <<<1,
+#if defined (USE_ROCM)
+                    nll_loss_threads(input.size(0))
+#else
+                    NLL_LOSS_THREADS
+#endif
+                    , 0, at::cuda::getCurrentCUDAStream()>>>(
                     grad_input.mutable_data_ptr<scalar_t>(),
                     grad_output.const_data_ptr<scalar_t>(),
                     target.const_data_ptr<index_t>(),

--- a/aten/src/ATen/native/cuda/Loss.cu
+++ b/aten/src/ATen/native/cuda/Loss.cu
@@ -153,7 +153,9 @@ Tensor& binary_cross_entropy_backward_out_cuda(const Tensor& grad, const Tensor&
 // -----------------------------------
 namespace {
 
-constexpr int NLL_LOSS_THREADS = 32;
+int nll_loss_threads(int64_t nframe){
+  return std::clamp(1 << static_cast<int64_t>(std::round(std::log2(nframe/16))), 32, 1024);
+}
 
 // NOTE(crcrpar): `Byte` support was added for https://github.com/pytorch/pytorch/issues/59765.
 #define AT_DISPATCH_NLL_LOSS_INDEX_TYPES(TYPE, NAME, ...)                     \
@@ -239,12 +241,13 @@ __global__ void nll_loss_forward_reduce_cuda_kernel_2d(
     int64_t n_classes,
     int64_t ignore_index) {
   // NOLINTNEXTLINE(cppcoreguidelines-init-variables)
-  __shared__ accscalar_t sh_inputs[NLL_LOSS_THREADS],
-      acc_weight[NLL_LOSS_THREADS];
+  extern __shared__ unsigned char shmem[];
+  accscalar_t* sh_inputs = reinterpret_cast<accscalar_t*>(shmem);
+  accscalar_t* acc_weight = reinterpret_cast<accscalar_t*>(shmem + blockDim.x * sizeof(accscalar_t));
 
   sh_inputs[threadIdx.x] = static_cast<accscalar_t>(0);
   acc_weight[threadIdx.x] = static_cast<accscalar_t>(0);
-  for (int i = threadIdx.x; i < nframe; i += NLL_LOSS_THREADS) {
+  for (int i = threadIdx.x; i < nframe; i += blockDim.x) {
     index_t t = target[i];
     if (t != ignore_index) {
       CHECK_INDEX_IN_CLASS(t, n_classes);
@@ -260,7 +263,7 @@ __global__ void nll_loss_forward_reduce_cuda_kernel_2d(
   if (threadIdx.x == 0) {
     accscalar_t output_acc = 0;
     accscalar_t total_weight_acc = 0;
-    for (int i = 0; i < NLL_LOSS_THREADS; ++i) {
+    for (int i = 0; i < blockDim.x; ++i) {
       output_acc += sh_inputs[i];
       total_weight_acc += acc_weight[i];
     }
@@ -382,10 +385,11 @@ void nll_loss_forward_out_cuda_template(
               "nll_loss_forward_reduce_cuda_kernel_2d_index",
               [&] {
                 using accscalar_t = at::acc_type<scalar_t, /*is_cuda*/true>;
+                int nthreads = nll_loss_threads(input.size(0));
                 nll_loss_forward_reduce_cuda_kernel_2d<scalar_t, accscalar_t, index_t>
                     <<<1,
-                       NLL_LOSS_THREADS,
-                       0,
+                       nthreads,
+                       nthreads * sizeof(accscalar_t) * 2,
                        at::cuda::getCurrentCUDAStream()>>>(
                         output.mutable_data_ptr<scalar_t>(),
                         total_weight.mutable_data_ptr<scalar_t>(),
@@ -464,7 +468,7 @@ __global__ void nll_loss_backward_reduce_cuda_kernel_2d(
   const auto grad = -(size_average ? *grad_output / *total_weight
                                    : *grad_output);
 
-  for (int i = threadIdx.x; i < nframe; i += NLL_LOSS_THREADS) {
+  for (int i = threadIdx.x; i < nframe; i += blockDim.x) {
     const index_t t = target[i];
     if (t != ignore_index) {
       CHECK_INDEX_IN_CLASS(t, n_classes);
@@ -568,7 +572,7 @@ void nll_loss_backward_out_cuda_template(
               "nll_loss_backward_reduce_cuda_kernel_2d_index",
               [&] {
             nll_loss_backward_reduce_cuda_kernel_2d<scalar_t, index_t>
-                <<<1, NLL_LOSS_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+                <<<1, nll_loss_threads(input.size(0)), 0, at::cuda::getCurrentCUDAStream()>>>(
                     grad_input.mutable_data_ptr<scalar_t>(),
                     grad_output.const_data_ptr<scalar_t>(),
                     target.const_data_ptr<index_t>(),


### PR DESCRIPTION
Mirroring https://github.com/pytorch/pytorch/pull/149548 for release/2.6
