### PR TITLE
[rocm6.4_internal_testing] reorder skip decorators for test_RNN_dropout_state

### DIFF
--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4345,8 +4345,9 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
                 # Check that backward does not cause a hard error
                 outs[0].sum().backward()
 
-    @skipIfRocm("fails because ROCm doesn't support 'dropout' in RNN")
     @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
+    @skipIfRocm(msg="ROCm doesn't support 'dropout' for RNN "
+                "(WIP to enable dropout https://github.com/pytorch/pytorch/pull/144572)")
     def test_RNN_dropout_state(self):
         for p in (0, 0.1234):
             for train in (True, False):


### PR DESCRIPTION
python failed for the entire `test_nn.py` file if `@skipIfRocm` comes first before `@unittest.skipIf` for test_RNN_dropout_state

This PR is to reordering decorators for test_RNN_dropout_state

Fixes this PR https://github.com/ROCm/pytorch/pull/1970 with wrong decorator sequence



