### PR TITLE
[release/2.0] Remove custom kwargs before calling BuildExtension.__init__(...)

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.0.0|8d873bb61daff04e77fedc0673f420f440a430a2|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.0.0|8d873bb61daff04e77fedc0673f420f440a430a2|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.15|e9069657f5912665b7e35af93fad67a3827487a4|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.15|e9069657f5912665b7e35af93fad67a3827487a4|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.15|a3db092ccf1b1389ffabdd04fe8961925645d4a2|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.15|a3db092ccf1b1389ffabdd04fe8961925645d4a2|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.15|4571036cf66c539e50625218aeb99a288d79f3e1|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.15|4571036cf66c539e50625218aeb99a288d79f3e1|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.6|e1feeb2542293e42f083d24301386db6c003eeee|https://github.com/pytorch/data

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -464,10 +464,11 @@ class BuildExtension(build_ext):
         return cls_with_options
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
         self.no_python_abi_suffix = kwargs.get("no_python_abi_suffix", False)
-
         self.use_ninja = kwargs.get('use_ninja', True)
+        filtered_kwargs = {kw: val for kw, val in kwargs.items() if kw not in ["no_python_abi_suffix", "use_ninja"]}
+        super().__init__(*args, **filtered_kwargs)
+
         if self.use_ninja:
             # Test if we can use ninja. Fallback otherwise.
             msg = ('Attempted to use ninja as the BuildExtension backend but '


### PR DESCRIPTION
Port fix from pytorch#149636 
Update to torchvision branch https://github.com/ROCm/vision/tree/release/0.15
Validation:http://rocm-ci.amd.com/view/Release-6.4/job/pytorch2.0-manylinux-wheels_rel-6.4/32/
