### PR TITLE
[release/2.6] Remove custom kwargs before calling BuildExtension.__init__(...)

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -522,10 +522,11 @@ class BuildExtension(build_ext):
         return cls_with_options
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
         self.no_python_abi_suffix = kwargs.get("no_python_abi_suffix", False)
-
         self.use_ninja = kwargs.get('use_ninja', True)
+        filtered_kwargs = {kw: val for kw, val in kwargs.items() if kw not in ["no_python_abi_suffix", "use_ninja"]}
+        super().__init__(*args, **filtered_kwargs)
+
         if self.use_ninja:
             # Test if we can use ninja. Fallback otherwise.
             msg = ('Attempted to use ninja as the BuildExtension backend but '


### PR DESCRIPTION
Port fix from pytorch#149636 
Validation:http://rocm-ci.amd.com/view/Release-6.4/job/pytorch2.6-manylinux-wheels_rel-6.4-preview/22/