### PR TITLE
[release/2.4] Remove custom kwargs before calling BuildExtension.__init__(...)

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.19|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.19|d77d3f630d13f4e4a6f1e3a7fe0e56c2589a7991|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.19|4d41ad71d51dcc5732d94cd9806c94e7bf771d19|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.19|4d41ad71d51dcc5732d94cd9806c94e7bf771d19|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.7|5e6f7b7dc5f8c8409a6a140f520a045da8700451|https://github.com/pytorch/data

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -487,10 +487,11 @@ class BuildExtension(build_ext):
         return cls_with_options
 
     def __init__(self, *args, **kwargs) -> None:
-        super().__init__(*args, **kwargs)
         self.no_python_abi_suffix = kwargs.get("no_python_abi_suffix", False)
-
         self.use_ninja = kwargs.get('use_ninja', True)
+        filtered_kwargs = {kw: val for kw, val in kwargs.items() if kw not in ["no_python_abi_suffix", "use_ninja"]}
+        super().__init__(*args, **filtered_kwargs)
+
         if self.use_ninja:
             # Test if we can use ninja. Fallback otherwise.
             msg = ('Attempted to use ninja as the BuildExtension backend but '


### PR DESCRIPTION
Port fix from pytorch#149636 
Update to torchvision branch https://github.com/ROCm/vision/tree/release/0.19
Validation:http://rocm-ci.amd.com/view/Release-6.4/job/pytorch2.4-manylinux-wheels_rel-6.4/33/