### PR TITLE
[release/2.0] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.0.0|8d873bb61daff04e77fedc0673f420f440a430a2|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.0.0|8d873bb61daff04e77fedc0673f420f440a430a2|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.15|a3db092ccf1b1389ffabdd04fe8961925645d4a2|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.15|a3db092ccf1b1389ffabdd04fe8961925645d4a2|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.15|c91a98ea151087866b482909888451d1840853e1|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.15|c91a98ea151087866b482909888451d1840853e1|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.15|4571036cf66c539e50625218aeb99a288d79f3e1|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.15|4571036cf66c539e50625218aeb99a288d79f3e1|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.6|e1feeb2542293e42f083d24301386db6c003eeee|https://github.com/pytorch/data


### PR DESCRIPTION
Instead of using build_wheel.sh we remove the file and build in the [else block](https://github.com/ROCm/rocAutomation/blob/82e21b6a617965341e8d4a1ea4194a363028dc05/pytorch/manylinux_rocm_wheels/build_torchvision_wheel_inside_docker.sh#L29) This way we are able to build successfully
fixes https://ontrack-internal.amd.com/browse/SWDEV-522993
Relates to  https://github.com/ROCm/vision/pull/8

