### PR TITLE
[ROCm] Set vector size to 4 for in-place elementwise operations

### DIFF
--- a/aten/src/ATen/native/cuda/thread_constants.h
+++ b/aten/src/ATen/native/cuda/thread_constants.h
@@ -19,7 +19,7 @@ constexpr uint32_t num_threads() {
 #endif
 
 #ifdef USE_ROCM
-constexpr int thread_work_size() { return 8; }
+constexpr int thread_work_size() { return 16; }
 #else
 constexpr int thread_work_size() { return 4; }
 #endif


### PR DESCRIPTION
* Use vector size for in-place elementwise operations in MI300 series
* Use thread work size of 16
