### PR TITLE
[release/2.6] enable NHWC batchnorm with MIOpen

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -537,7 +537,10 @@ BatchNormBackend _select_batch_norm_backend(
       && detail::getCUDAHooks().compiledWithMIOpen()
       && cudnn_enabled
       && (input.suggest_memory_format() == MemoryFormat::Contiguous
-        || (input.suggest_memory_format() == MemoryFormat::ChannelsLast && PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM))
+#if (defined(USE_ROCM) && ROCM_VERSION >= 60500)
+        || (input.suggest_memory_format() == MemoryFormat::ChannelsLast && PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM)
+#endif
+        )
   ) {
     return BatchNormBackend::Miopen;
   }

--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -517,23 +517,27 @@ BatchNormBackend _select_batch_norm_backend(
     return BatchNormBackend::Cudnn;
   }
 
+  // TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM once ROCm officially supports NHWC in MIOpen
+  // See #64427
+  // non static variable is used to be able to change environment variable in runtime for testing
+  bool PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM").value_or(false);
+
   if (
       input.is_cuda()
-      && input.dim() <= MIOPEN_DIM_MAX
-      && input.scalar_type() != at::kDouble
+      && (input.dim() <= MIOPEN_DIM_MAX)
+      && (input.scalar_type() != at::kDouble)
 #if (defined(USE_ROCM) && ROCM_VERSION < 60400)
-      && input.scalar_type() != at::kBFloat16
+      && (input.scalar_type() != at::kBFloat16)
 #endif
-      && (weight.scalar_type() != at::kHalf)
-      && (weight.scalar_type() != at::kBFloat16)
+      && (weight.scalar_type() == at::kFloat) // allow only fp32 and mixed fp16/bf16
       && weight.defined() && bias.defined()
       && ((running_mean.defined() && running_var.defined())
         || (!running_mean.defined() && !running_var.defined() && training))
       && (input.dim() >= 3)
       && detail::getCUDAHooks().compiledWithMIOpen()
       && cudnn_enabled
-      && input.suggest_memory_format() != MemoryFormat::ChannelsLast
-      && input.suggest_memory_format() != MemoryFormat::ChannelsLast3d
+      && (input.suggest_memory_format() == MemoryFormat::Contiguous
+        || (input.suggest_memory_format() == MemoryFormat::ChannelsLast && PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM))
   ) {
     return BatchNormBackend::Miopen;
   }
@@ -645,7 +649,7 @@ std::tuple<Tensor, Tensor, Tensor, Tensor, int64_t> _batch_norm_impl_index(
 	    std::cout << "PYTORCH_MIOPEN_EXTRA_LOGGING: ********************* _batch_norm_impl_index (calling miopen_batch_norm)" << std::endl;
     return std::tuple_cat(
              at::miopen_batch_norm(
-               input.contiguous(), weight.contiguous(), bias.contiguous(),
+               input.contiguous(input.suggest_memory_format()), weight.contiguous(), bias.contiguous(),
                running_mean.defined() ? running_mean.contiguous() : running_mean,
                running_var.defined() ? running_var.contiguous() : running_var,
                training, momentum, eps),

--- a/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
+++ b/aten/src/ATen/native/miopen/BatchNorm_miopen.cpp
@@ -100,7 +100,7 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm(
     mode = miopenBNSpatial;
   }
 
-  auto output_t = at::empty(input->sizes(), input->options());
+  auto output_t = at::empty(input->sizes(), input->options(), input->suggest_memory_format());
   TensorArg output{ output_t, "output", 0 };
 
   auto handle = getMiopenHandle();
@@ -177,8 +177,10 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
   const Tensor& save_var_t =
       save_var_t_opt.value_or(Tensor());
 
+  auto grad_output_contig =
+      grad_output_t.contiguous(input_t.suggest_memory_format());
   TensorArg input{ input_t, "input", 1 },
-            grad_output{ grad_output_t, "grad_output", 2 },
+            grad_output{ grad_output_contig, "grad_output", 2 },
             weight{ weight_t, "weight", 3 },
             save_mean{ save_mean_t, "save_mean", 4 },
             save_var{ save_var_t, "save_var", 5 };
@@ -193,7 +195,9 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
   }
   checkAllSameType(c, {input, grad_output});
   checkAllSameType(c, {weight, save_mean, save_var});
-  checkAllContiguous(c, {input, grad_output, save_mean, save_var});
+  checkAllContiguous(c, {save_mean, save_var});
+  TORCH_CHECK(input->is_contiguous(input->suggest_memory_format()));
+  TORCH_CHECK(grad_output->is_contiguous(input->suggest_memory_format()));
   checkDimRange(c, input, 2, 6 /* exclusive */);
   checkSameSize(c, input, grad_output);
   auto num_features = input->size(1);
@@ -208,7 +212,8 @@ std::tuple<Tensor, Tensor, Tensor> miopen_batch_norm_backward(
     mode = miopenBNSpatial;
   }
 
-  auto grad_input_t  = at::empty(input->sizes(), input->options());
+  auto grad_input_t = at::empty(
+      input->sizes(), input->options(), input->suggest_memory_format());
   auto grad_weight_t = at::empty(weight->sizes(), weight->options());
   auto grad_bias_t   = at::empty(weight->sizes(), weight->options());
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -7,6 +7,7 @@ import unittest
 import io
 import itertools
 import warnings
+import os
 import pickle
 import re
 from copy import deepcopy
@@ -29,7 +30,7 @@ from torch.nn.utils.fusion import fuse_linear_bn_weights
 from torch.nn import Buffer, Parameter
 from torch.nn.parallel._functions import Broadcast
 from torch.testing._internal.common_dtype import integral_types, get_all_math_dtypes, floating_types
-from torch.testing._internal.common_utils import freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
+from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, run_tests, TestCase, skipIfNoLapack, skipIfRocm, \
     TEST_NUMPY, TEST_SCIPY, TEST_WITH_CROSSREF, TEST_WITH_ROCM, \
     download_file, get_function_arglist, load_tests, skipIfMPS, \
     IS_PPC, \
@@ -4967,54 +4968,6 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         run_test(input, grad)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
-    @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
-    def test_batchnorm_nhwc_miopen(self):
-        def run_test(input, grad_output):
-            c = input.size(1)
-            mod = nn.BatchNorm2d(c).cuda().float()
-            mod.weight.data.uniform_()
-            mod.bias.data.uniform_()
-            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
-            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
-            ref_mod = nn.BatchNorm2d(c).cuda().float()
-            ref_mod.load_state_dict(mod.state_dict())
-            out = mod(input)
-            out.backward(grad_output)
-            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm
-                ref_out = ref_mod(ref_input)
-                ref_out.backward(ref_grad)
-            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
-            self.assertTrue(ref_out.is_contiguous(memory_format=torch.channels_last))
-            self.assertEqual(out, ref_out)
-            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
-            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
-            self.assertEqual(input.grad, ref_input.grad)
-
-        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
-        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
-        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
-        try:
-            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
-            input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
-
-            grad = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
-            grad = grad.contiguous(memory_format=torch.channels_last)
-            run_test(input, grad)
-            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
-            # not channels_last
-            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
-            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
-            grad = grad.permute(0, 2, 1, 3)
-            run_test(input, grad)
-        finally:
-            if prev_val is None:
-                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
-            else:
-                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
-
-    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):
         # THNN
         input = torch.randint(1, 10, (2, 3, 2, 2), dtype=torch.half, device="cuda", requires_grad=True)
@@ -5136,86 +5089,167 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             self.assertEqual(out1, out2)
 
     @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
-    @parametrize_test("mixed", [False, True])
-    @parametrize_test("dtype", [torch.float, torch.half, torch.bfloat16])
-    def test_batchnorm_nhwc_eval(self, mixed, dtype):
-        if mixed and dtype == torch.float:
-            self.skipTest("mixed precision is useless for float32")
-        if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
-            self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
-        if TEST_WITH_ROCM:
-            self.skipTest("NHWC batchnorm disabled on ROCm6.4 SWDEV-510757 SWDEV-509640")
+    @parametrize_test("mode", ["train", "inference"], name_fn=lambda x: x)
+    @parametrize_test(
+        # test verifies cudnn/miopen batchnorm with the reference backend or memory format
+        # memory_format - one of ("NCHW", NHWC")
+        # ref_backend - one of ("cpu", "native", "NCHW", "NHWC")
+        #   "cpu"    - cpu backend with the same memory_format will be used as reference
+        #   "native" - native backend (`with torch.backends.cudnn.flags(enabled=False)`)
+        #              with the same memory_format will be used
+        #   "NCHW" or "NHWC" - the same backend will be used but another memory format
+        # mixed - True or False. Mixed batchnorm mode where inputs are 16-bit and batchnorm is fp32
+        #
+        "memory_format,ref_backend,mixed,dtype",
+        [
+            ("NCHW", "cpu", False, torch.float),
+            ("NCHW", "cpu", True, torch.half),
+            ("NCHW", "cpu", True, torch.bfloat16),
 
-        (N, C, H, W) = 2, 64, 50, 50
-        model = torch.nn.BatchNorm2d(C, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
-        model = model.eval().cuda()
-        if not mixed:
-            model = model.to(dtype)
-        inp1 = torch.randn(N, C, H, W, device=torch.device('cuda'), dtype=dtype)
-        inp2 = inp1.contiguous(memory_format=torch.channels_last)
-        out1 = model(inp1)
-        out2 = model(inp2)
-        self.assertEqual(out1, out2)
+            ("NCHW", "native", False, torch.float),
+            ("NCHW", "native", True, torch.half),
+            # this config failed for train and passed for inference on ROCm
+            # subtest(("NCHW", "native", True, torch.bfloat16), decorators=[unittest.expectedFailure]),
 
-    @parametrize_test("layout", ["NCHW", "NHWC"])
-    @parametrize_test("mixed", [False, True])
-    @parametrize_test("dtype", [torch.float, torch.half, torch.bfloat16])
-    def test_batchnorm(self, layout, mixed, dtype):
-        def _batchnorm2d_helper(dtype, memory_format, mixed: bool):
-            def _run_test(input, grad_output, mixed: bool):
-                c = input.size(1)
-                mod = nn.BatchNorm2d(c).cuda()
-                ref_mod = nn.BatchNorm2d(c).cuda()
-                if not mixed:
-                    mod = mod.to(dtype=input.dtype)
-                    ref_mod = ref_mod.to(dtype=input.dtype)
+            ("NHWC", "cpu", False, torch.float),
+            ("NHWC", "cpu", True, torch.half),
+            ("NHWC", "cpu", True, torch.bfloat16),
 
-                mod.weight.data.uniform_()
-                mod.bias.data.uniform_()
+            ("NHWC", "native", False, torch.float),
+            ("NHWC", "native", True, torch.half),
+            ("NHWC", "native", True, torch.bfloat16),
 
-                ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
-                ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
-                ref_mod.load_state_dict(mod.state_dict())
+            ("NHWC", "NCHW", False, torch.float),
+            ("NHWC", "NCHW", True, torch.half),
+            ("NHWC", "NCHW", True, torch.bfloat16),
+        ],
+        name_fn=lambda f, b, m, t: f"{f}_vs_{b}{'_mixed' if m else ''}_{dtype_name(t)}"
+    )
+    def test_batchnorm(self, mode, memory_format, ref_backend, mixed, dtype):
+        def _create_tensor(size, memory_format, dtype, device):
+            t = torch.empty(size=size, memory_format=memory_format, dtype=dtype, device=device)
+            t = t.random_(1, 10)
+            return t
 
-                out = mod(input)
-                out.backward(grad_output)
-                with torch.backends.cudnn.flags(enabled=False):  # force to use native nhwc batchnorm
-                    ref_out = ref_mod(ref_input)
-                    ref_out.backward(ref_grad)
-                self.assertTrue(out.is_contiguous(memory_format=memory_format))
-                self.assertTrue(ref_out.is_contiguous(memory_format=memory_format))
-                self.assertEqual(out, ref_out)
-                self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
-                self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
-                self.assertEqual(mod.running_mean, ref_mod.running_mean)
-                self.assertEqual(mod.running_var, ref_mod.running_var)
-                self.assertEqual(input.grad, ref_input.grad)
+        def _get_ref_device(backend: str , device: str):
+            # If 'backend' specifies the memory format, return 'device' arg, otherwise return a device matches the backend
+            if backend in ("NHWC", "NCHW"):
+                return device
+            if backend == "native":
+                return "cuda"
+            if backend == "cpu":
+                return "cpu"
+            else:
+                raise ValueError("Unknown backend")
+
+        def _get_backend_memory_format(backend: str, memory_format: torch.memory_format) -> torch.memory_format:
+            # If 'backend' specifies the memory format, return it, otherwise look at 'memory_format' arg
+            if backend == "NHWC":
+                return torch.channels_last
+            if backend == "NCHW":
+                return torch.contiguous_format
+            if memory_format in (torch.contiguous_format, torch.channels_last):
+                return memory_format
+            raise ValueError("Unable to detect memory format for backend={backend} and memory_format={memory_format}")
+
+        def _get_memory_format(t: torch.Tensor) -> torch.memory_format:
+            if t.is_contiguous(memory_format=torch.contiguous_format):
+                return torch.contiguous_format
+            if t.is_contiguous(memory_format=torch.channels_last):
+                return torch.channels_last
+            return ValueError("Unsupported memory_format")
+
+        def _create_backend(inp: torch.Tensor, mixed: bool = False):
+            mod = nn.BatchNorm2d(inp.size(1), device=inp.device, dtype=torch.float if mixed else inp.dtype)
+            return mod
+
+        def _test_batchnorm_train(inp, grad, mixed, ref_inp, ref_grad, ref_backend):
+            mod = _create_backend(inp, mixed).train()
+            mod.weight.data.uniform_()
+            mod.bias.data.uniform_()
+
+            ref_mod = _create_backend(ref_inp, mixed).train()
+            ref_mod.load_state_dict(mod.state_dict())
+
+            out = mod(inp)
+            out.backward(grad)
+
+            with torch.backends.cudnn.flags(enabled=False) if ref_backend == "native" else contextlib.nullcontext():
+                ref_out = ref_mod(ref_inp)
+                ref_out.backward(ref_grad)
+
+            self.assertTrue(out.is_contiguous(memory_format=_get_memory_format(inp)))
+            self.assertTrue(ref_out.is_contiguous(memory_format=_get_memory_format(ref_inp)))
+            self.assertEqual(out, ref_out)
+            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
+            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
+            self.assertEqual(mod.running_mean, ref_mod.running_mean)
+            self.assertEqual(mod.running_var, ref_mod.running_var)
+            self.assertEqual(inp.grad, ref_inp.grad)
+
+        def _train(memory_format, ref_backend, mixed, dtype):
+            memory_format = torch.contiguous_format if memory_format == "NCHW" else torch.channels_last
+            ref_memory_format = _get_backend_memory_format(ref_backend, memory_format)
+            ref_device = _get_ref_device(ref_backend, device="cuda")
 
             size = (4, 8, 2, 2)
-            input = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
-            input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
-            grad = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
-            grad = grad.contiguous(memory_format=memory_format)
-            _run_test(input, grad, mixed)
-            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
-            # not channels_last
-            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
-            input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
-            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
-            grad = grad.permute(0, 2, 1, 3)
-            _run_test(input, grad, mixed)
+            inp = _create_tensor(size, memory_format, dtype, device="cuda").detach().requires_grad_()
+            grad = _create_tensor(size, memory_format, dtype, device="cuda")
+            ref_inp = inp.detach().clone(memory_format=ref_memory_format).to(device=ref_device).requires_grad_()
+            ref_grad = grad.detach().clone(memory_format=ref_memory_format).to(device=ref_device)
 
-        if TEST_WITH_ROCM and layout == "NHWC":
-            self.skipTest("NHWC batchnorm disabled on ROCm6.4 SWDEV-510757")
-        if mixed and dtype == torch.float:
-            self.skipTest("mixed precision is useless for float32")
-        if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
-            self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
-        if TEST_WITH_ROCM and layout == "NCHW" and dtype == torch.bfloat16 and mixed:
-            self.skipTest("MIOpen tolerance issue for NCHW BF16 mixed batchnorm SWDEV-507600")
+            _test_batchnorm_train(inp=inp, grad=grad, mixed=mixed,
+                                  ref_inp=ref_inp, ref_grad=ref_grad, ref_backend=ref_backend)
 
-        memory_format = torch.contiguous_format if layout == "NCHW" else torch.channels_last
-        _batchnorm2d_helper(dtype, memory_format=memory_format, mixed=mixed)
+            # TODO: enable permute logic later
+            # size = (2, 8, 8, 1)
+            # input = _create_tensor(size, memory_format, dtype, device="cuda").detach().requires_grad_()
+            # grad = _create_tensor(size, memory_format=torch.contiguous_format, dtype=dtype, device="cuda")
+            # # grad = _create_tensor(size, memory_format=memory_format, dtype=dtype, device="cuda")
+
+            # ref_input = input.detach().clone(memory_format=ref_memory_format).to(device=ref_device).requires_grad_(True)
+            # ref_grad = grad.detach().clone(memory_format=torch.contiguous_format).to(device=ref_device)
+            # # ref_grad = grad.detach().clone(memory_format=ref_memory_format).to(device=ref_device)
+
+            # if memory_format == torch.channels_last:
+            #     grad = grad.permute(0, 2, 1, 3)
+            #     # grad = grad.permute(0, 2, 3, 1)
+            # if ref_memory_format == torch.channels_last:
+            #     ref_grad = ref_grad.permute(0, 2, 1, 3)
+            #     # ef_grad = ref_grad.permute(0, 2, 3, 1)
+            # _test_batchnorm_train(input=input, grad=grad, mixed=mixed,
+            #                       ref_input=ref_input, ref_grad=ref_grad, ref_backend=ref_backend)
+
+        def _inference(memory_format, ref_backend, mixed, dtype):
+            memory_format = torch.contiguous_format if memory_format == "NCHW" else torch.channels_last
+            ref_memory_format = _get_backend_memory_format(ref_backend, memory_format)
+            ref_device = _get_ref_device(ref_backend, device="cuda")
+
+            size = (2, 64, 50, 50)
+            inp = _create_tensor(size, memory_format, dtype, device="cuda")
+            ref_inp = inp.detach().clone(memory_format=ref_memory_format).to(device=ref_device)
+            mod = _create_backend(inp, mixed).eval()
+            ref_mod = _create_backend(ref_inp, mixed).eval()
+
+            out = mod(inp)
+            with torch.backends.cudnn.flags(enabled=False) if ref_backend == "native" else contextlib.nullcontext():
+                ref_out = ref_mod(ref_inp)
+            self.assertEqual(out, ref_out)
+
+        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM once ROCm officially supports NHWC in MIOpen
+        PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM = "PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM"
+        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM)
+        try:
+            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM] = "1"
+            if mode == "train":
+                _train(memory_format, ref_backend, mixed, dtype)
+            else:
+                _inference(memory_format, ref_backend, mixed, dtype)
+        finally:
+            if prev_val is None:
+                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM]
+            else:
+                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM] = prev_val
 
     def test_batchnorm_load_state_dict(self):
         bn = torch.nn.BatchNorm2d(3)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -4967,6 +4967,54 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         run_test(input, grad)
 
     @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
+    @unittest.skipIf(not TEST_CUDNN, "needs cudnn")
+    def test_batchnorm_nhwc_miopen(self):
+        def run_test(input, grad_output):
+            c = input.size(1)
+            mod = nn.BatchNorm2d(c).cuda().float()
+            mod.weight.data.uniform_()
+            mod.bias.data.uniform_()
+            ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
+            ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
+            ref_mod = nn.BatchNorm2d(c).cuda().float()
+            ref_mod.load_state_dict(mod.state_dict())
+            out = mod(input)
+            out.backward(grad_output)
+            with torch.backends.cudnn.flags(enabled=False): # force to use native nhwc batchnorm
+                ref_out = ref_mod(ref_input)
+                ref_out.backward(ref_grad)
+            self.assertTrue(out.is_contiguous(memory_format=torch.channels_last))
+            self.assertTrue(ref_out.is_contiguous(memory_format=torch.channels_last))
+            self.assertEqual(out, ref_out)
+            self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
+            self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
+            self.assertEqual(input.grad, ref_input.grad)
+
+        # TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC once ROCm officially supports NHWC in MIOpen
+        PYTORCH_MIOPEN_SUGGEST_NHWC = "PYTORCH_MIOPEN_SUGGEST_NHWC"
+        prev_val = os.getenv(PYTORCH_MIOPEN_SUGGEST_NHWC)
+        try:
+            os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = "1"
+            input = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
+            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
+
+            grad = torch.randint(1, 10, (4, 8, 2, 2), dtype=torch.float32, device="cuda")
+            grad = grad.contiguous(memory_format=torch.channels_last)
+            run_test(input, grad)
+            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
+            # not channels_last
+            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
+            input = input.contiguous(memory_format=torch.channels_last).detach().requires_grad_()
+            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=torch.float32, device="cuda")
+            grad = grad.permute(0, 2, 1, 3)
+            run_test(input, grad)
+        finally:
+            if prev_val is None:
+                del os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC]
+            else:
+                os.environ[PYTORCH_MIOPEN_SUGGEST_NHWC] = prev_val
+
+    @unittest.skipIf(not TEST_CUDA, "CUDA unavailable")
     def test_batchnorm_cudnn_half(self):
         # THNN
         input = torch.randint(1, 10, (2, 3, 2, 2), dtype=torch.half, device="cuda", requires_grad=True)
@@ -5085,7 +5133,89 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
             inp2 = inp1.contiguous(memory_format=torch.channels_last)
             out1 = model(inp1)
             out2 = model(inp2)
-            self.assertTrue(torch.equal(out1, out2))
+            self.assertEqual(out1, out2)
+
+    @unittest.skipIf(not torch.cuda.is_available(), "CUDA not available")
+    @parametrize_test("mixed", [False, True])
+    @parametrize_test("dtype", [torch.float, torch.half, torch.bfloat16])
+    def test_batchnorm_nhwc_eval(self, mixed, dtype):
+        if mixed and dtype == torch.float:
+            self.skipTest("mixed precision is useless for float32")
+        if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
+            self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
+        if TEST_WITH_ROCM:
+            self.skipTest("NHWC batchnorm disabled on ROCm6.4 SWDEV-510757 SWDEV-509640")
+
+        (N, C, H, W) = 2, 64, 50, 50
+        model = torch.nn.BatchNorm2d(C, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)
+        model = model.eval().cuda()
+        if not mixed:
+            model = model.to(dtype)
+        inp1 = torch.randn(N, C, H, W, device=torch.device('cuda'), dtype=dtype)
+        inp2 = inp1.contiguous(memory_format=torch.channels_last)
+        out1 = model(inp1)
+        out2 = model(inp2)
+        self.assertEqual(out1, out2)
+
+    @parametrize_test("layout", ["NCHW", "NHWC"])
+    @parametrize_test("mixed", [False, True])
+    @parametrize_test("dtype", [torch.float, torch.half, torch.bfloat16])
+    def test_batchnorm(self, layout, mixed, dtype):
+        def _batchnorm2d_helper(dtype, memory_format, mixed: bool):
+            def _run_test(input, grad_output, mixed: bool):
+                c = input.size(1)
+                mod = nn.BatchNorm2d(c).cuda()
+                ref_mod = nn.BatchNorm2d(c).cuda()
+                if not mixed:
+                    mod = mod.to(dtype=input.dtype)
+                    ref_mod = ref_mod.to(dtype=input.dtype)
+
+                mod.weight.data.uniform_()
+                mod.bias.data.uniform_()
+
+                ref_input = input.detach().clone(memory_format=torch.preserve_format).requires_grad_(True)
+                ref_grad = grad.detach().clone(memory_format=torch.preserve_format)
+                ref_mod.load_state_dict(mod.state_dict())
+
+                out = mod(input)
+                out.backward(grad_output)
+                with torch.backends.cudnn.flags(enabled=False):  # force to use native nhwc batchnorm
+                    ref_out = ref_mod(ref_input)
+                    ref_out.backward(ref_grad)
+                self.assertTrue(out.is_contiguous(memory_format=memory_format))
+                self.assertTrue(ref_out.is_contiguous(memory_format=memory_format))
+                self.assertEqual(out, ref_out)
+                self.assertEqual(mod.weight.grad, ref_mod.weight.grad)
+                self.assertEqual(mod.bias.grad, ref_mod.bias.grad)
+                self.assertEqual(mod.running_mean, ref_mod.running_mean)
+                self.assertEqual(mod.running_var, ref_mod.running_var)
+                self.assertEqual(input.grad, ref_input.grad)
+
+            size = (4, 8, 2, 2)
+            input = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
+            input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
+            grad = torch.randint(1, 10, size=size, dtype=dtype, device="cuda")
+            grad = grad.contiguous(memory_format=memory_format)
+            _run_test(input, grad, mixed)
+            # see #42588, grad is channels_last contiguous, but grad.suggest_memory_format (rightly) return "contiguous"
+            # not channels_last
+            input = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
+            input = input.contiguous(memory_format=memory_format).detach().requires_grad_()
+            grad = torch.randint(1, 10, (2, 8, 8, 1), dtype=dtype, device="cuda")
+            grad = grad.permute(0, 2, 1, 3)
+            _run_test(input, grad, mixed)
+
+        if TEST_WITH_ROCM and layout == "NHWC":
+            self.skipTest("NHWC batchnorm disabled on ROCm6.4 SWDEV-510757")
+        if mixed and dtype == torch.float:
+            self.skipTest("mixed precision is useless for float32")
+        if TEST_WITH_ROCM and not mixed and dtype in (torch.half, torch.bfloat16):
+            self.skipTest("pure mode not supported for bf16/fp16 on ROCm")
+        if TEST_WITH_ROCM and layout == "NCHW" and dtype == torch.bfloat16 and mixed:
+            self.skipTest("MIOpen tolerance issue for NCHW BF16 mixed batchnorm SWDEV-507600")
+
+        memory_format = torch.contiguous_format if layout == "NCHW" else torch.channels_last
+        _batchnorm2d_helper(dtype, memory_format=memory_format, mixed=mixed)
 
     def test_batchnorm_load_state_dict(self):
         bn = torch.nn.BatchNorm2d(3)
@@ -8257,7 +8387,6 @@ class TestNNDeviceType(NNTestCase):
                         self.assertEqual(affine_tensor[0, i, r, c], grid_out[:3], exact_dtype=False)
 
             self.assertEqual(scipy_ary, gridsample_ary.reshape_as(scipy_ary))
-
 
     @onlyCUDA
     @dtypes(torch.float, torch.half)

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -5104,12 +5104,13 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         [
             ("NCHW", "cpu", False, torch.float),
             ("NCHW", "cpu", True, torch.half),
+            # NCHW bfloat16 path uses native kernels for rocm<=6.3
             # train failed on rocm<=6.3 due to native tolerance issue SWDEV-507600
             subtest(("NCHW", "cpu", True, torch.bfloat16), decorators=[skipIfRocmVersionLessThan((6, 4))]),
 
             ("NCHW", "native", False, torch.float),
             ("NCHW", "native", True, torch.half),
-            # this config failed for train and passed for inference on ROCm
+            # this config failed for train and passed for inference on ROCm6.4
             # subtest(("NCHW", "native", True, torch.bfloat16), decorators=[unittest.expectedFailure]),
 
             ("NHWC", "cpu", False, torch.float),
@@ -5122,6 +5123,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
             ("NHWC", "NCHW", False, torch.float),
             ("NHWC", "NCHW", True, torch.half),
+            # NCHW bfloat16 path uses native kernels for rocm<=6.3
             # train failed on rocm<=6.3 due to native tolerance issue SWDEV-507600
             subtest(("NHWC", "NCHW", True, torch.bfloat16), decorators=[skipIfRocmVersionLessThan((6, 4))]),
         ],

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -35,7 +35,7 @@ from torch.testing._internal.common_utils import dtype_name, freeze_rng_state, r
     download_file, get_function_arglist, load_tests, skipIfMPS, \
     IS_PPC, \
     parametrize as parametrize_test, subtest, instantiate_parametrized_tests, \
-    skipIfTorchDynamo, gcIfJetson, set_default_dtype
+    skipIfTorchDynamo, skipIfRocmVersionLessThan, gcIfJetson, set_default_dtype
 from torch.testing._internal.common_cuda import TEST_CUDA, TEST_MULTIGPU, TEST_CUDNN, PLATFORM_SUPPORTS_FLASH_ATTENTION
 from torch.testing._internal.common_nn import NNTestCase, NewModuleTest, CriterionTest, \
     module_tests, criterion_tests, loss_reference_fns, _create_basic_net, \
@@ -5104,7 +5104,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         [
             ("NCHW", "cpu", False, torch.float),
             ("NCHW", "cpu", True, torch.half),
-            ("NCHW", "cpu", True, torch.bfloat16),
+            # train failed on rocm<=6.3 due to native tolerance issue SWDEV-507600
+            subtest(("NCHW", "cpu", True, torch.bfloat16), decorators=[skipIfRocmVersionLessThan((6, 4))]),
 
             ("NCHW", "native", False, torch.float),
             ("NCHW", "native", True, torch.half),
@@ -5121,7 +5122,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
 
             ("NHWC", "NCHW", False, torch.float),
             ("NHWC", "NCHW", True, torch.half),
-            ("NHWC", "NCHW", True, torch.bfloat16),
+            # train failed on rocm<=6.3 due to native tolerance issue SWDEV-507600
+            subtest(("NHWC", "NCHW", True, torch.bfloat16), decorators=[skipIfRocmVersionLessThan((6, 4))]),
         ],
         name_fn=lambda f, b, m, t: f"{f}_vs_{b}{'_mixed' if m else ''}_{dtype_name(t)}"
     )

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -2788,7 +2788,7 @@
   self, weight, bias: "grad.defined() ? convolution_backward_symint(grad, self, weight, bias->sym_sizes(), stride, padding, dilation, false, std::vector<c10::SymInt>(padding.size(), 0), groups, grad_input_mask) : std::tuple<Tensor, Tensor, Tensor>()"
 
 - name: miopen_batch_norm(Tensor input, Tensor weight, Tensor? bias, Tensor? running_mean, Tensor? running_var, bool training, float exponential_average_factor, float epsilon) -> (Tensor, Tensor, Tensor)
-  input, weight, bias: "grad.defined() ? (training ? miopen_batch_norm_backward(input, grad.contiguous(), weight, running_mean, running_var, result1, result2, epsilon) : native_batch_norm_backward(grad, input, weight, running_mean, running_var, result1, result2, training, epsilon, grad_input_mask)) : std::tuple<Tensor, Tensor, Tensor>()"
+  input, weight, bias: "grad.defined() ? (training ? miopen_batch_norm_backward(input, grad.contiguous(input.suggest_memory_format()), weight, running_mean, running_var, result1, result2, epsilon) : native_batch_norm_backward(grad, input, weight, running_mean, running_var, result1, result2, training, epsilon, grad_input_mask)) : std::tuple<Tensor, Tensor, Tensor>()"
   result0: batch_norm_jvp(input_p, input_t, weight_p, weight_t, bias_p, bias_t, running_mean, running_var, result1, result2, training, epsilon)
 
 - name: miopen_batch_norm_backward(Tensor input, Tensor grad_output, Tensor weight, Tensor? running_mean, Tensor? running_var, Tensor? save_mean, Tensor? save_var, float epsilon) -> (Tensor, Tensor, Tensor)


### PR DESCRIPTION
This PR enables NHWC batchnorm on MIOpen in release/2.6 branch

`ROCm version >= 6.5` and `PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM=1` environment variable required to enable nhwc batchnorm 

This PR branch for `release/2.6` was built and tested using docker image: `compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-dkms-no-npi-hipclang:15845_ubuntu22.04_py3.10_pytorch_rocm6.4_internal_testing_8190c80`. 

New batchnorm tests introduced:
train:
```
test_batchnorm_train_NCHW_vs_cpu_float32 (__main__.TestNN) ... ok (0.040s)
test_batchnorm_train_NCHW_vs_cpu_mixed_bfloat16 (__main__.TestNN) ... ok (0.007s)
test_batchnorm_train_NCHW_vs_cpu_mixed_float16 (__main__.TestNN) ... ok (0.005s)
test_batchnorm_train_NCHW_vs_native_float32 (__main__.TestNN) ... ok (0.089s)
test_batchnorm_train_NCHW_vs_native_mixed_float16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_train_NHWC_vs_NCHW_float32 (__main__.TestNN) ... ok (0.020s)
test_batchnorm_train_NHWC_vs_NCHW_mixed_bfloat16 (__main__.TestNN) ... ok (0.006s)
test_batchnorm_train_NHWC_vs_NCHW_mixed_float16 (__main__.TestNN) ... ok (0.006s)
test_batchnorm_train_NHWC_vs_cpu_float32 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_train_NHWC_vs_cpu_mixed_bfloat16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_train_NHWC_vs_cpu_mixed_float16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_train_NHWC_vs_native_float32 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_train_NHWC_vs_native_mixed_bfloat16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_train_NHWC_vs_native_mixed_float16 (__main__.TestNN) ... ok (0.004s)
```
  
inference:
```
test_batchnorm_inference_NCHW_vs_cpu_float32 (__main__.TestNN) ... ok (0.025s)
test_batchnorm_inference_NCHW_vs_cpu_mixed_bfloat16 (__main__.TestNN) ... ok (0.005s)
test_batchnorm_inference_NCHW_vs_cpu_mixed_float16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_inference_NCHW_vs_native_float32 (__main__.TestNN) ... ok (0.102s)
test_batchnorm_inference_NCHW_vs_native_mixed_float16 (__main__.TestNN) ... ok (0.003s)
test_batchnorm_inference_NHWC_vs_NCHW_float32 (__main__.TestNN) ... ok (0.018s)
test_batchnorm_inference_NHWC_vs_NCHW_mixed_bfloat16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_inference_NHWC_vs_NCHW_mixed_float16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_inference_NHWC_vs_cpu_float32 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_inference_NHWC_vs_cpu_mixed_bfloat16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_inference_NHWC_vs_cpu_mixed_float16 (__main__.TestNN) ... ok (0.004s)
test_batchnorm_inference_NHWC_vs_native_float32 (__main__.TestNN) ... ok (0.003s)
test_batchnorm_inference_NHWC_vs_native_mixed_bfloat16 (__main__.TestNN) ... ok (0.003s)
test_batchnorm_inference_NHWC_vs_native_mixed_float16 (__main__.TestNN) ... ok (0.003s)
```