### PR TITLE
[rocm6.4_internal_testing] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|386eceade52447a68f9f74f4621d98dc5298323f|https://github.com/ROCm/apex
-centos|pytorch|apex|master|386eceade52447a68f9f74f4621d98dc5298323f|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|1c44f5d8b90fda3736e94b613e2fa7412eef51d5|https://github.com/ROCm/apex
+centos|pytorch|apex|master|1c44f5d8b90fda3736e94b613e2fa7412eef51d5|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|229d8523bfa9a2696872d76b1cdb6815028f1e03|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|229d8523bfa9a2696872d76b1cdb6815028f1e03|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|1d4ce73c57417f1af8278af56631de3c25e3bbaf|https://github.com/pytorch/text

--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|1c44f5d8b90fda3736e94b613e2fa7412eef51d5|https://github.com/ROCm/apex
-centos|pytorch|apex|master|1c44f5d8b90fda3736e94b613e2fa7412eef51d5|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|1667e85d0c3ee96ea3ee40cb48a7d159971c6851|https://github.com/ROCm/apex
+centos|pytorch|apex|master|1667e85d0c3ee96ea3ee40cb48a7d159971c6851|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|229d8523bfa9a2696872d76b1cdb6815028f1e03|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|229d8523bfa9a2696872d76b1cdb6815028f1e03|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|1d4ce73c57417f1af8278af56631de3c25e3bbaf|https://github.com/pytorch/text


### PR DESCRIPTION
Apex changes 

Building nccl_allocator only for pytorch 2.6 branch -  https://github.com/ROCm/apex/commit/a34f5c396c93adf9e2844142ba1b6281540bec3a

Change the location of the fused_dense unit tests -  https://github.com/ROCm/apex/commit/b06b4c3f6cf85ef367ae1ae8dfbd18d2c35a789e

Include run_transformer UTs in the run_rocm.sh file -  https://github.com/ROCm/apex/commit/1c44f5d8b90fda3736e94b613e2fa7412eef51d5

Fix transformer unit tests -
https://github.com/ROCm/apex/commit/1667e85d0c3ee96ea3ee40cb48a7d159971c6851

Fixes https://github.com/ROCm/frameworks-internal/issues/11932 
Fixes https://github.com/ROCm/frameworks-internal/issues/11934
