### PR TITLE
[release/2.6] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.6.0|69ee42b272179fa3091211309d1f5e61b5167282|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.6.0|69ee42b272179fa3091211309d1f5e61b5167282|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.6.0|2550ea6ef334f1b1d83b6a64e183797455615776|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.6.0|2550ea6ef334f1b1d83b6a64e183797455615776|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Following changes are added : 

Building nccl_allocator only for pytorch 2.6 branch - https://github.com/ROCm/apex/commit/8ee83055447af32a5b5949fb3ff7a213391c9b91

Change the location of the fused_dense unit tests. -  https://github.com/ROCm/apex/commit/2550ea6ef334f1b1d83b6a64e183797455615776

