### PR TITLE
[release/2.6] Use miniforge instead of miniconda; pin to CMake 3.x; install sqlite

### DIFF
--- a/.ci/docker/centos-rocm/Dockerfile
+++ b/.ci/docker/centos-rocm/Dockerfile
@@ -41,6 +41,7 @@ RUN bash ./install_user.sh && rm install_user.sh
 # Install conda and other packages (e.g., numpy, pytest)
 ARG ANACONDA_PYTHON_VERSION
 ARG CONDA_CMAKE
+ARG BUILD_ENVIRONMENT
 ENV ANACONDA_PYTHON_VERSION=$ANACONDA_PYTHON_VERSION
 ENV PATH /opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/bin:/opt/conda/bin:$PATH
 COPY requirements-ci.txt /opt/conda/requirements-ci.txt

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -6,7 +6,7 @@ set -ex
 if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   BASE_URL="https://repo.anaconda.com/miniconda"
   CONDA_FILE="Miniconda3-latest-Linux-x86_64.sh"
-  if [[ $(uname -m) == "aarch64" ]] || [[ "$BUILD_ENVIRONMENT" == *xpu* ]]; then
+  if [[ $(uname -m) == "aarch64" ]] || [[ "$BUILD_ENVIRONMENT" == *xpu* ]] || [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
     BASE_URL="https://github.com/conda-forge/miniforge/releases/latest/download"
     CONDA_FILE="Miniforge3-Linux-$(uname -m).sh"
   fi

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -64,6 +64,11 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # which is provided in libstdcxx 12 and up.
   conda_install libstdcxx-ng=12.3.0 --update-deps -c conda-forge
 
+  # Miniforge installer doesn't install sqlite by default
+  if [[ "$BUILD_ENVIRONMENT" == *rocm* ]]; then
+    conda_install sqlite
+  fi
+
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   if [[ $(uname -m) == "aarch64" ]]; then
     conda_install "openblas==0.3.28=*openmp*"

--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -85,7 +85,7 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # following builds that we know should use conda. Specifically, Ubuntu bionic
   # and focal cannot find conda mkl with stock cmake, so we need a cmake from conda
   if [ -n "${CONDA_CMAKE}" ]; then
-    conda_install cmake
+    conda_install cmake=3.31.6
   fi
 
   # Magma package names are concatenation of CUDA major and minor ignoring revision

--- a/.ci/docker/ubuntu-rocm/Dockerfile
+++ b/.ci/docker/ubuntu-rocm/Dockerfile
@@ -27,6 +27,7 @@ RUN bash ./install_user.sh && rm install_user.sh
 # Install conda and other packages (e.g., numpy, pytest)
 ARG ANACONDA_PYTHON_VERSION
 ARG CONDA_CMAKE
+ARG BUILD_ENVIRONMENT
 ENV ANACONDA_PYTHON_VERSION=$ANACONDA_PYTHON_VERSION
 ENV PATH /opt/conda/envs/py_$ANACONDA_PYTHON_VERSION/bin:/opt/conda/bin:$PATH
 COPY requirements-ci.txt /opt/conda/requirements-ci.txt


### PR DESCRIPTION
* Using miniforge avoids rate limit errors when using miniconda installer and default conda package channel: `[2025-04-15T19:29:19.374Z] CondaHTTPError: HTTP 429 TERMS OF SERVICE RATE LIMIT EXCEEDED for url <https://repo.anaconda.com/pkgs/main/linux-64/repodata.json>`
* However, conda-forge channel brings in CMake 4.0 by default, which is not compatible with older PyTorch release branches. Hence, pin CMake to 3.x
* Also, miniforge installation of conda does *not* install sqlite conda package by default, hence explicitly install sqlite packages (needed in [install_rocm.sh](https://github.com/ROCm/pytorch/blob/use_miniforge_release_2.6/.ci/docker/common/install_rocm.sh#L60))

Validation: http://rocm-ci.amd.com/job/mainline-framework-pytorch-2.6-ub22-py3.10-ci/50/