### PR TITLE
[release/2.4] Conditionalize versioning for conda

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -83,11 +83,19 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   else
     CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
 
-    if [ "$ANACONDA_PYTHON_VERSION" = "3.11" ] || [ "$ANACONDA_PYTHON_VERSION" = "3.12" ]; then
-      conda_install numpy=1.26.0 ${CONDA_COMMON_DEPS}
-    else
-      conda_install numpy=1.21.2 ${CONDA_COMMON_DEPS}
-    fi
+    case "$ANACONDA_PYTHON_VERSION" in 
+      3.11|3.12)
+        NUMPY_SPEC="numpy=1.26.*"          # allowed upper‑bound in PyTorch
+        ;;
+      3.10)
+        NUMPY_SPEC="numpy>=1.24,<1.27"     # first series with Py3.10 wheels
+        ;;
+      *)
+        NUMPY_SPEC="numpy=1.21.2"          # Py3.7–3.9 builds
+        ;;
+      esac
+      conda_install ${NUMPY_SPEC} ${CONDA_COMMON_DEPS}
+      
   fi
 
   # Install llvm-8 as it is required to compile llvmlite-0.30.0 from source


### PR DESCRIPTION
https://ontrack-internal.amd.com/browse/SWDEV-528304
Build error in UB22.04 with release/2.4.
```
[2025-04-17T05:48:09.594Z] LibMambaUnsatisfiableError: Encountered problems while solving:
[2025-04-17T05:48:09.594Z]   - package numpy-1.21.2-py37h620df1f_0 requires python_abi 3.7 *_pypy37_pp73, but none of the providers can be installed
[2025-04-17T05:48:09.594Z] 
[2025-04-17T05:48:09.594Z] Could not solve for environment specs
[2025-04-17T05:48:09.594Z] The following packages are incompatible
[2025-04-17T05:48:09.594Z] ├─ numpy 1.21.2**  is installable with the potential options
[2025-04-17T05:48:09.594Z] │  ├─ numpy 1.21.2 would require
[2025-04-17T05:48:09.594Z] │  │  └─ python_abi 3.7 *_pypy37_pp73, which can be installed;
[2025-04-17T05:48:09.594Z] │  ├─ numpy 1.21.2 would require
[2025-04-17T05:48:09.594Z] │  │  ├─ python >=3.7,<3.8.0a0 , which can be installed;
[2025-04-17T05:48:09.594Z] │  │  └─ python_abi 3.7.* *_cp37m, which can be installed;
[2025-04-17T05:48:09.594Z] │  ├─ numpy 1.21.2 would require
[2025-04-17T05:48:09.594Z] │  │  ├─ python >=3.8,<3.9.0a0 , which can be installed;
[2025-04-17T05:48:09.594Z] │  │  └─ python_abi 3.8.* *_cp38, which can be installed;
[2025-04-17T05:48:09.594Z] │  └─ numpy 1.21.2 would require
[2025-04-17T05:48:09.594Z] │     ├─ python >=3.9,<3.10.0a0 , which can be installed;
[2025-04-17T05:48:09.594Z] │     └─ python_abi 3.9.* *_cp39, which can be installed;
[2025-04-17T05:48:09.594Z] └─ python 3.10**  is not installable because it conflicts with any installable versions previously reported.
```
Validation:
http://rocm-ci.amd.com/job/framework-pytorch-2.4-ub22-py3.10-ci_rel-6.4/34/
