### PR TITLE
[rocm6.5_internal_testing] Update kineto rocprof commit (#2015)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -88,7 +88,6 @@
 [submodule "third_party/kineto"]
     path = third_party/kineto
     url = https://github.com/ROCm/kineto.git
-    branch = rocprof_sdk_rocm6.5_internal_testing
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
 	url = https://github.com/mreineck/pocketfft

--- a/.gitmodules
+++ b/.gitmodules
@@ -88,6 +88,7 @@
 [submodule "third_party/kineto"]
     path = third_party/kineto
     url = https://github.com/ROCm/kineto.git
+    branch = rocprof_sdk_rocm6.5_internal_testing
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
 	url = https://github.com/mreineck/pocketfft

--- a/.gitmodules
+++ b/.gitmodules
@@ -87,7 +87,7 @@
 	url = https://github.com/NVIDIA/cudnn-frontend.git
 [submodule "third_party/kineto"]
     path = third_party/kineto
-    url = https://github.com/pytorch/kineto
+    url = https://github.com/ROCm/kineto.git
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
 	url = https://github.com/mreineck/pocketfft


### PR DESCRIPTION
change kineto repo to ROCm

Use kineto workaround for non-amd systems

(cherry picked from commit 402deb262174f83d414b66ce8f757a7289274b2c)