### PR TITLE
[release/2.5] [WHL] skip test if no hipcc

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -50,6 +50,7 @@ from torch.testing._internal.common_utils import (
     freeze_rng_state,
     gcIfJetson,
     get_cycles_per_ms,
+    HAS_HIPCC,
     instantiate_parametrized_tests,
     IS_ARM64,
     IS_FBCODE,
@@ -4375,6 +4376,7 @@ class TestMemPool(TestCase):
         # increments the id
         self.assertTrue(abs(pool2[1] - pool1[1]) > 0)
 
+    @unittest.skipIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
     def test_mempool_with_allocator(self):
         pool = torch.cuda.MemPool()
 

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -50,7 +50,6 @@ from torch.testing._internal.common_utils import (
     freeze_rng_state,
     gcIfJetson,
     get_cycles_per_ms,
-    HAS_HIPCC,
     instantiate_parametrized_tests,
     IS_ARM64,
     IS_FBCODE,
@@ -77,6 +76,7 @@ from torch.testing._internal.common_utils import (
     TestCase,
 )
 from torch.utils.checkpoint import checkpoint_sequential
+from torch.utils.cpp_extension import ROCM_HOME
 from torch.utils.viz._cycles import observe_tensor_cycles
 
 
@@ -4376,7 +4376,7 @@ class TestMemPool(TestCase):
         # increments the id
         self.assertTrue(abs(pool2[1] - pool1[1]) > 0)
 
-    @unittest.skipIf(TEST_WITH_ROCM and not HAS_HIPCC, "ROCm requires hipcc compiler")
+    @unittest.skipIf(TEST_WITH_ROCM and not ROCM_HOME, "ROCm requires hipcc compiler")
     def test_mempool_with_allocator(self):
         pool = torch.cuda.MemPool()
 

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -96,6 +96,7 @@ from torch.testing._comparison import (
 from torch.testing._comparison import not_close_error_metas
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.utils._import_utils import _check_module_exists
+from torch.utils.cpp_extension import ROCM_HOME
 import torch.utils._pytree as pytree
 try:
     import pytest
@@ -103,10 +104,11 @@ try:
 except ImportError:
     has_pytest = False
 
-
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
+
+HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None and shutil.which('hipcc') is not None
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -96,7 +96,6 @@ from torch.testing._comparison import (
 from torch.testing._comparison import not_close_error_metas
 from torch.testing._internal.common_dtype import get_all_dtypes
 from torch.utils._import_utils import _check_module_exists
-from torch.utils.cpp_extension import ROCM_HOME
 import torch.utils._pytree as pytree
 try:
     import pytest
@@ -104,11 +103,10 @@ try:
 except ImportError:
     has_pytest = False
 
+
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
-
-HAS_HIPCC = torch.version.hip is not None and ROCM_HOME is not None and shutil.which('hipcc') is not None
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)


### PR DESCRIPTION
Skip for some tests for wheels builds with a check for ROCM_HOME

- test_cuda.py::TestMemPool::test_mempool_with_allocator

Fixes SWDEV-529917

similar draft PR for release/2.5 https://github.com/ROCm/pytorch/pull/1697 

(partially cherry-picked from 1b312e4e739093af8db8b9e9b2fbbdb895e90bd6)


