### PR TITLE
[rocm6.4_internal_testing] Skipped two tests with fp8 types in test_loop_ordering for ROCm

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -19,6 +19,7 @@ from torch._inductor.test_operators import realize
 from torch._inductor.utils import sympy_index_symbol
 from torch._inductor.virtualized import ops, V
 from torch.testing._internal.common_cuda import PLATFORM_SUPPORTS_FP8
+from torch.testing._internal.common_utils import skipIfRocm
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 from torch.utils._pytree import tree_map
 from torch.utils._sympy.functions import ModularIndexing
@@ -399,6 +400,10 @@ class LoopOrderingTest(TestCase):
         self.assertEqual(1, metrics.generated_kernel_count)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "FP8 requires H100+ and MI300+")
+    @skipIfRocm
+    # Related PR: https://github.com/pytorch/pytorch/pull/149369
+    # This test can't function for ROCm because fp8 'mul_cuda' op is not supported
+    # in eager mode that is required here to check vs compiled results
     def test_fp8_cast_and_t(self):
         """
         This test repros the not able to fuses issue in
@@ -421,6 +426,10 @@ class LoopOrderingTest(TestCase):
         self.assertEqual(1, metrics.generated_kernel_count)
 
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "FP8 requires H100+ and MI300+")
+    @skipIfRocm
+    # Related PR: https://github.com/pytorch/pytorch/pull/149369
+    # This test can't function for ROCm because fp8 'mul_cuda' op is not supported
+    # in eager mode that is required here to check vs compiled results
     def test_fp8_pattern_2(self):
         """
         This test repros the fp8 fusion relation issue here:


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-510660

This test can't function for ROCm because fp8 'mul_cuda' op is not supported in eager mode that is required here to check vs compiled results.
