### PR TITLE
[AUTOGENERATED] [release/2.7] Skipped two tests with fp8 types in test_loop_ordering for ROCm

### DIFF
--- a/test/inductor/test_loop_ordering.py
+++ b/test/inductor/test_loop_ordering.py
@@ -401,6 +401,10 @@ class LoopOrderingTest(TestCase):
 
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "FP8 requires H100+ and MI300+")
+    @skipIfRocm
+    # Related PR: https://github.com/pytorch/pytorch/pull/149369
+    # This test can't function for ROCm because fp8 'mul_cuda' op is not supported
+    # in eager mode that is required here to check vs compiled results
     def test_fp8_cast_and_t(self):
         """
         This test repros the not able to fuses issue in
@@ -424,6 +428,10 @@ class LoopOrderingTest(TestCase):
 
     @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8, "FP8 requires H100+ and MI300+")
+    @skipIfRocm
+    # Related PR: https://github.com/pytorch/pytorch/pull/149369
+    # This test can't function for ROCm because fp8 'mul_cuda' op is not supported
+    # in eager mode that is required here to check vs compiled results
     def test_fp8_pattern_2(self):
         """
         This test repros the fp8 fusion relation issue here:


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2064 