### PR TITLE
[release/2.6] remove xfail from 'batch_norm_with_update'

### DIFF
--- a/test/functorch/test_ops.py
+++ b/test/functorch/test_ops.py
@@ -438,13 +438,6 @@ class TestOperators(TestCase):
                 ),  # Works on ROCm
                 xfail("torch.ops.aten._flash_attention_forward"),
                 xfail("torch.ops.aten._efficient_attention_forward"),
-                # RuntimeError: Expected contiguous tensor, but got
-                # non-contiguous tensor for argument #2 'grad_output'
-                decorate(
-                    "_batch_norm_with_update",
-                    decorator=expectedFailureIf(TEST_WITH_ROCM),
-                    device_type="cuda",
-                ),
             }
         ),
     )
@@ -2374,13 +2367,6 @@ class TestOperators(TestCase):
             skip("sparse.sampled_addmm", ""),
             skip("sparse.mm", "reduce"),
             skip("native_layer_norm", "", device_type="cpu"),
-            # RuntimeError: Expected contiguous tensor, but got
-            # non-contiguous tensor for argument #2 'grad_output'
-            decorate(
-                "_batch_norm_with_update",
-                decorator=expectedFailureIf(TEST_WITH_ROCM),
-                device_type="cuda",
-            ),
         },
     )
     @opsToleranceOverride(


### PR DESCRIPTION
remove `xfail` from `batch_norm_with_update` op in `test_grad` and `test_vmap_autograd_grad`

these tests are passed since ROCm6.4

Fixes https://ontrack-internal.amd.com/browse/SWDEV-529820

(cherry picked from commit 99b075842070e2b73625440d8712b87e1833515c)
