### PR TITLE
[rocm6.4_internal_testing] Skipped split_scan test in test_kernel_benchmark

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -429,6 +429,7 @@ class TestKernelBenchmark(TestCase):
         # 20000 * 5000 * 4 = 200MB for a
         self.check_bandwidth(compiled_module, "0.200")
 
+    @skipIfRocm #This test requires triton version 3.3+
     def test_split_scan(self):
         @torch.compile
         def f(a):


### PR DESCRIPTION
Fixes one part of https://ontrack-internal.amd.com/browse/SWDEV-480219?focusedId=18920795&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-18920795

The test requires triton version 3.3+ and rocm6.4_internal_testing branch only has 3.2 version so it's not supported.

This needs to be cherry picked later ONLY in release/2.6