### PR TITLE
[AUTOGENERATED] [release/2.6] [rocm6.4_internal_testing] Skipped split_scan test in test_kernel_benchmark

### DIFF
--- a/test/inductor/test_kernel_benchmark.py
+++ b/test/inductor/test_kernel_benchmark.py
@@ -427,6 +427,7 @@ class TestKernelBenchmark(TestCase):
         # 20000 * 5000 * 4 = 200MB for a
         self.check_bandwidth(compiled_module, "0.200")
 
+    @skipIfRocm #This test requires triton version 3.3+
     def test_split_scan(self):
         @torch.compile
         def f(a):


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2072 