### PR TITLE
[release/2.5] Change gfx110x and gfx120x BLAS Preferred Backend to rocBLAS

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -323,10 +323,7 @@ at::BlasBackend Context::blasPreferredBackend() {
   if (blas_preferred_backend == at::BlasBackend::Cublaslt) {
     static const bool hipblaslt_unsupported = []() {
       static const std::vector<std::string> archs = {
-          "gfx90a", "gfx940", "gfx941", "gfx942",
-#if ROCM_VERSION >= 60300
-          "gfx1100", "gfx1101", "gfx1200", "gfx1201"
-#endif
+          "gfx90a", "gfx940", "gfx941", "gfx942"
       };
       for (auto index: c10::irange(getNumGPUs())) {
         if (!detail::getCUDAHooks().isGPUArch(index, archs)) {


### PR DESCRIPTION
hipBLASLt causes performance regression on gfx110x and gfx120x. This PR removes them from the list of supported architectures.
