### PR TITLE
[DO NOT CHERRY-PICK] [rocm6.5_internal_testing] Introduce __AOTRITON_VER_WITH_COMMIT

### DIFF
--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -22,7 +22,8 @@ if(NOT __AOTRITON_INCLUDED)
   # Replaces .ci/docker/aotriton_version.txt
   # Note packages information may have versions skipped (due to no ABI breaks)
   # But they must be listed from lower version to higher version
-  set(__AOTRITON_VER "0.9.2b_612896439f")
+  set(__AOTRITON_VER "0.9.2b")
+  set(__AOTRITON_VER_WITH_COMMIT "0.9.2b_612896439f")
   set(__AOTRITON_MANYLINUX_LIST
       "manylinux_2_28"  # rocm6.5
       )
@@ -89,7 +90,7 @@ if(NOT __AOTRITON_INCLUDED)
     list(GET __AOTRITON_MANYLINUX_LIST ${__AOTRITON_ROCM_INDEX} __AOTRITON_MANYLINUX)
     set(__AOTRITON_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
     string(CONCAT __AOTRITON_FILE "aotriton-"
-                                  "${__AOTRITON_VER}-${__AOTRITON_MANYLINUX}"
+                                  "${__AOTRITON_VER_WITH_COMMIT}-${__AOTRITON_MANYLINUX}"
                                   "_${__AOTRITON_ARCH}-rocm${__AOTRITON_ROCM}"
                                   "-shared.tar.${__AOTRITON_Z}")
     string(CONCAT __AOTRITON_URL "https://github.com/ROCm/aotriton/releases/download/"


### PR DESCRIPTION
To resolve build issues introduced by https://github.com/ROCm/pytorch/pull/2074, since the actual url - `https://github.com/ROCm/aotriton/releases/download/0.9.2b/aotriton-0.9.2b_612896439f-manylinux_2_28_x86_64-rocm6.5-shared.tar.gz` -  doesn't match the expected value: `/ROCm/aotriton/releases/download/0.9.2b_612896439f/aotriton-0.9.2b_612896439f-manylinux_2_28_x86_64-rocm6.5-shared.tar.gz`

Fixes build breakages like: http://rocm-ci.amd.com/job/mainline-framework-pytorch-internal-ub22-py3.10-ci/215/

Validation: http://rocm-ci.amd.com/job/mainline-framework-pytorch-internal-ub22-py3.10-ci/217/
