### PR TITLE
[release/2.5 ] Fix fp8 issue on release/2.5 branch for Jira ticket#503871

### DIFF
--- a/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
+++ b/test/distributed/tensor/parallel/test_micro_pipeline_tp.py
@@ -27,6 +27,7 @@ from torch.distributed.tensor.parallel import (
     parallelize_module,
     RowwiseParallel,
 )
+from torch.testing._internal.common_device_type import e4m3_type
 from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     instantiate_parametrized_tests,
     MI300_ARCH,
@@ -267,8 +268,8 @@ class MicroPipelineTPTest(TestCase):
             raise AssertionError(f"Invalid A_dims: {A_dims}")
 
         A_shard_shape[gather_dim] //= self.world_size
-        A_shard = torch.rand(*A_shard_shape, device="cuda").to(torch.float8_e4m3fn)
-        B = torch.rand(16, 32, device="cuda").to(torch.float8_e4m3fn).T
+        A_shard = torch.rand(*A_shard_shape, device="cuda").to(e4m3_type)
+        B = torch.rand(16, 32, device="cuda").to(e4m3_type).T
         A_scale = torch.tensor(0.1, device="cuda")
         B_scale = torch.tensor(0.1, device="cuda")
 
@@ -355,12 +356,12 @@ class MicroPipelineTPTest(TestCase):
             return reduce_scatter_tensor(C, "avg", scatter_dim, group)
 
         if A_dims == 2:
-            A = torch.rand(64, 32, device="cuda").to(torch.float8_e4m3fn)
+            A = torch.rand(64, 32, device="cuda").to(e4m3_type)
         elif A_dims == 3:
-            A = torch.rand(2, 64, 32, device="cuda").to(torch.float8_e4m3fn)
+            A = torch.rand(2, 64, 32, device="cuda").to(e4m3_type)
         else:
             raise AssertionError(f"Invalid A_dims: {A_dims}")
-        B = torch.rand(16, 32, device="cuda").to(torch.float8_e4m3fn).T
+        B = torch.rand(16, 32, device="cuda").to(e4m3_type).T
         A_scale = torch.tensor(0.1, device="cuda")
         B_scale = torch.tensor(0.1, device="cuda")
 

--- a/torch/testing/_internal/common_device_type.py
+++ b/torch/testing/_internal/common_device_type.py
@@ -1903,3 +1903,15 @@ def skipPRIVATEUSE1(fn):
 #  This should probably enumerate all available device type test base classes.
 def get_all_device_types() -> List[str]:
     return ["cpu"] if not torch.cuda.is_available() else ["cpu", "cuda"]
+
+if torch.version.hip and "gfx94" in torch.cuda.get_device_properties(0).gcnArchName:
+    e4m3_type = torch.float8_e4m3fnuz
+    e5m2_type = torch.float8_e5m2fnuz
+    E4M3_MAX_POS = torch.finfo(torch.float8_e4m3fnuz).max
+    E5M2_MAX_POS = torch.finfo(torch.float8_e5m2fnuz).max
+else:
+    e4m3_type = torch.float8_e4m3fn
+    e5m2_type = torch.float8_e5m2
+    E4M3_MAX_POS = torch.finfo(torch.float8_e4m3fn).max
+    E5M2_MAX_POS = torch.finfo(torch.float8_e5m2).max
+


### PR DESCRIPTION
Created PR for fp8 fix on release/2.5 branch. The tests were failing in test/distributed/tensor/parallel/test_micro_pipeline_tp.py and are related to fp8 issue. The issue was reported in for Jira ticket- https://ontrack-internal.amd.com/browse/SWDEV-503871

Added fix for fp8 issue. Tested by running the test_micro_pipeline_tp.py tests and all test passed. Attached the screenshot displaying the results of the test.

<img width="937" alt="test_micro_tp_fp8_tests_rel_2 5" src="https://github.com/user-attachments/assets/da40323d-a02b-4842-9a41-e8320876c04a" />



Used this docker image for testing-
compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-rel-6.4:64_ubuntu22.04_py3.10_pytorch_release-2.5_fd9f71a