### PR TITLE
[release/2.6] Remove --no-index and --no-deps flags

### DIFF
--- a/.ci/pytorch/common_utils.sh
+++ b/.ci/pytorch/common_utils.sh
@@ -67,13 +67,13 @@ function pip_install_whl() {
     # Loop through each path and install individually
     for path in "${paths[@]}"; do
       echo "Installing $path"
-      python3 -mpip install --no-index --no-deps "$path"
+      python3 -mpip install "$path"
     done
   else
     # Loop through each argument and install individually
     for path in "${args[@]}"; do
       echo "Installing $path"
-      python3 -mpip install --no-index --no-deps "$path"
+      python3 -mpip install "$path"
     done
   fi
 }


### PR DESCRIPTION
Removing --no-deps and --no-index flags because the old setuptools was installing the requirements of the torch wheel along with those of the torchvision wheel when using the old setuptools version (<80.0.1) and in versions greater than setuptools 80.0.1, the new setuptools does not install the requirements of the torch wheel and torchvision wheel. Resolves 
https://ontrack-internal.amd.com/browse/SWDEV-531011

Validation:
http://rocm-ci.amd.com/job/framework-pytorch-2.6-ub22-py3.10-ci_rel-6.4-preview/60/