### PR TITLE
Use BUILD_BYPRODUCTS instead of INSTALL_BYPRODUCTS in ExternalProject_Add

### DIFF
--- a/cmake/External/ck_kernels.cmake
+++ b/cmake/External/ck_kernels.cmake
@@ -50,7 +50,7 @@ if(NOT __ck_kernels_included)
       INSTALL_COMMAND ${CMAKE_COMMAND} -E copy_directory
       "${CMAKE_CURRENT_BINARY_DIR}/ck_kernels_tarball"
       "${ck_kernels_install_dir}"
-      INSTALL_BYPRODUCTS "${ck_kernels_install_path}"
+      BUILD_BYPRODUCTS "${ck_kernels_install_path}"
     )
     add_dependencies(__ck_kernels_lib ck_kernels_external)
     message(STATUS "Using CK_kernels from pre-compiled binary ${ck_kernels_package_full_url}; installed at ${ck_kernels_install_dir}")


### PR DESCRIPTION
In this PR made changes to ck_kernels.cmake to use BUILD_BYPRODUCTS instead of INSTALL_BYPRODUCTS in ExternalProject_Add function. It's an attempt to check if it fixes CK library build issue with Jenkins.
Tested locally with manual pytorch installation and the build was successful.