### PR TITLE
[release/2.5] test_decompose_mem_bound_mm.py tolerance increase for navi3x

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -106,7 +106,16 @@ except ImportError:
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
+NAVI3_ARCH = ("gfx1100", "gfx1101")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
+
+def is_navi3_arch():
+    if torch.cuda.is_available():
+        prop = torch.cuda.get_device_properties(0)
+        gfx_arch = prop.gcnArchName.split(":")[0]
+        if gfx_arch in NAVI3_ARCH:
+            return True
+    return False
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-506859

As discussed upping the tolerance level conditionalized for navi archs specifically.

Will need to be cherry picked into other branches.