### PR TITLE
[rocm6.5_internal_testing] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|09ffa0ad472ad4d8663668dfb282973908ccd9aa|https://github.com/ROCm/apex
-centos|pytorch|apex|master|09ffa0ad472ad4d8663668dfb282973908ccd9aa|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|a31598cfa1f1d90137e1b5cdc3ab17cff2cafa30|https://github.com/ROCm/apex
+centos|pytorch|apex|master|a31598cfa1f1d90137e1b5cdc3ab17cff2cafa30|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|bde7ecdb6ba9179ccd30cde60a6550478d0a359f|https://github.com/pytorch/text


### PR DESCRIPTION
Update Related commits for apex 

upgrade matplotlib to resolve setuptools_scm error. - https://github.com/ROCm/apex/commit/6468501d7220acc1e840303f559aaac8e0527ce0 
Update fused layer norm code from upstream apex repo - https://github.com/ROCm/apex/commit/6729b2b4a66b4b9dcf3b4d62fcf4f7621a04381a
Fix unit tests for transformer, fused dense, mlp - https://github.com/ROCm/apex/commit/a31598cfa1f1d90137e1b5cdc3ab17cff2cafa30