### PR TITLE
[release/2.7] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.7.0|8870f33104efb9f7f307ee1374151b365d6823d4|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.7.0|8870f33104efb9f7f307ee1374151b365d6823d4|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.7.0|e5f4a5ec59578801aae9da7d2aa342ef1f4db7b0|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.7.0|e5f4a5ec59578801aae9da7d2aa342ef1f4db7b0|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.22|9eb57cd5c96be7fe31923eb65399c3819d064587|https://github.com/pytorch/vision
 centos|pytorch|torchvision|release/0.22|9eb57cd5c96be7fe31923eb65399c3819d064587|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Update Related commits for apex 

upgrade matplotlib to resolve setuptools_scm error. - https://github.com/ROCm/apex/commit/86fff107d5e73043c75003c1530dbeabce8984fb
Update fused layer norm code from upstream apex repo - https://github.com/ROCm/apex/commit/d5956c435dd326fbab7240a00aaec3d8a94587b4
Fix unit tests for transformer, fused dense, mlp - https://github.com/ROCm/apex/commit/e5f4a5ec59578801aae9da7d2aa342ef1f4db7b0
