### PR TITLE
[AUTOGENERATED] [rocm6.4_internal_testing] [release/2.5] test_decompose_mem_bound_mm.py tolerance increase for navi3x

### DIFF
--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -11,6 +11,7 @@ from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
+    is_navi3_arch,
     parametrize,
     skipIfXpu,
 )
@@ -46,6 +47,11 @@ class MyModule3(torch.nn.Module):
         output = torch.mm(input1, input2)
         return output
 
+# We have to increase tolerance for navi3 because all fp16, bf16
+# GEMMs operations have an accuracy issue caused by hardware limitation
+default_atol = 3e-3 if is_navi3_arch() else 1e-3
+default_rtol = 4e-3 if is_navi3_arch() else 1e-3
+
 
 @requires_gpu
 @skipIfXpu(
@@ -59,7 +65,7 @@ class MyModule3(torch.nn.Module):
 )
 @instantiate_parametrized_tests
 class TestDecomposeMemMM(TestCase):
-    def compare_dict_tensors(self, ref_dict, res_dict, rtol=1e-3, atol=1e-3):
+    def compare_dict_tensors(self, ref_dict, res_dict, rtol=default_rtol, atol=default_atol):
         if len(set(ref_dict.keys())) != len(set(res_dict.keys())):
             return False
         for key1 in ref_dict.keys():
@@ -69,17 +75,17 @@ class TestDecomposeMemMM(TestCase):
                 return False
         return True
 
-    def compare_pred(self, module, traced, input, rtol=1e-3, atol=1e-3):
+    def compare_pred(self, module, traced, input, rtol=default_rtol, atol=default_atol):
         ref = module(*input)
         res = traced(*input)
         self.assertEqual(ref, res, rtol=rtol, atol=atol)
 
-    def compare_parameters(self, module, traced, rtol=1e-3, atol=1e-3):
+    def compare_parameters(self, module, traced, rtol=default_rtol, atol=default_atol):
         ref_params = dict(module.named_parameters())
         res_params = dict(traced.named_parameters())
         self.assertTrue(self.compare_dict_tensors(ref_params, res_params, rtol, atol))
 
-    def compare_gradients(self, module, traced, rtol=1e-3, atol=1e-3):
+    def compare_gradients(self, module, traced, rtol=default_rtol, atol=default_atol):
         ref_grad = {key: param.grad for key, param in module.named_parameters()}
         res_grad = {key: param.grad for key, param in traced.named_parameters()}
         self.assertTrue(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -109,7 +109,20 @@ except ImportError:
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
+<<<<<<< HEAD
 
+=======
+NAVI3_ARCH = ("gfx1100", "gfx1101")
+NAVI4_ARCH = ("gfx1200", "gfx1201")
+>>>>>>> 4ce2c1490e ([release/2.5] test_decompose_mem_bound_mm.py tolerance increase for navi3x (#2129))
+
+def is_navi3_arch():
+    if torch.cuda.is_available():
+        prop = torch.cuda.get_device_properties(0)
+        gfx_arch = prop.gcnArchName.split(":")[0]
+        if gfx_arch in NAVI3_ARCH:
+            return True
+    return False
 
 def freeze_rng_state(*args, **kwargs):
     return torch.testing._utils.freeze_rng_state(*args, **kwargs)


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2129 
Need to resolve conflicts