### PR TITLE
[release/2.6] Update ROCm version check for triton wheel build

### DIFF
--- a/.github/scripts/amd/package_triton_wheel.sh
+++ b/.github/scripts/amd/package_triton_wheel.sh
@@ -51,7 +51,7 @@ do
 done
 
 # Required ROCm libraries
-if [[ "${MAJOR_VERSION}" == "6" ]]; then
+if [[ "${MAJOR_VERSION}" == "7" ]]; then
     libamdhip="libamdhip64.so.6"
 else
     libamdhip="libamdhip64.so.5"

--- a/.github/scripts/amd/package_triton_wheel.sh
+++ b/.github/scripts/amd/package_triton_wheel.sh
@@ -51,7 +51,7 @@ do
 done
 
 # Required ROCm libraries
-if [[ "${MAJOR_VERSION}" == "7" ]]; then
+if [[ "${MAJOR_VERSION}" >= "6" ]]; then
     libamdhip="libamdhip64.so.6"
 else
     libamdhip="libamdhip64.so.5"


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-532730
 
These are failing 
 
Passed log:
http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels-lw/104/ 
 
Failed log:
http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels-lw/106/ 
 
Error Observed:
14:44:13  +++ find /opt/ -name libamdhip64.so.5
14:44:13  ++ [[ -z '' ]]
14:44:13  ++ echo 'Error: Library file libamdhip64.so.5 is not found.'
14:44:13  Error: Library file libamdhip64.so.5 is not found.
 

Was failing because rocm mainline became 7.0 and not 6.X. Updating the version check.
