### PR TITLE
[release/2.6] Use -ge for numeric comparison

### DIFF
--- a/.github/scripts/amd/package_triton_wheel.sh
+++ b/.github/scripts/amd/package_triton_wheel.sh
@@ -51,7 +51,7 @@ do
 done
 
 # Required ROCm libraries
-if [[ "${MAJOR_VERSION}" >= "6" ]]; then
+if [[ "$MAJOR_VERSION" -ge 6 ]]; then
     libamdhip="libamdhip64.so.6"
 else
     libamdhip="libamdhip64.so.5"


### PR DESCRIPTION
http://rocm-ci.amd.com/blue/organizations/jenkins/rocm-pytorch-manylinux-wheel-builder/detail/rocm-pytorch-manylinux-wheel-builder/2009/pipeline/131/
`/pytorch/.github/scripts/amd/package_triton_wheel.sh: line 54: syntax error in conditional expression`

Validation: http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels/79/