### PR TITLE
[AUTOGENERATED] [rocm6.5_internal_testing] [release/2.7] Prefer hipblaslt for gfx1200, gfx1201

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -335,6 +335,9 @@ at::BlasBackend Context::blasPreferredBackend() {
     static const bool hipblaslt_preferred = []() {
       static const std::vector<std::string> archs = {
           "gfx90a", "gfx942",
+#if ROCM_VERSION >= 60300
+          "gfx1200", "gfx1201",
+#endif
 #if ROCM_VERSION >= 60500
           "gfx950"
 #endif


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2125 