### PR TITLE
[release/2.5] Prefer hipBLASLt for gfx1200, gfx1201, and gfx950

### DIFF
--- a/aten/src/ATen/Context.cpp
+++ b/aten/src/ATen/Context.cpp
@@ -323,7 +323,13 @@ at::BlasBackend Context::blasPreferredBackend() {
   if (blas_preferred_backend == at::BlasBackend::Cublaslt) {
     static const bool hipblaslt_unsupported = []() {
       static const std::vector<std::string> archs = {
-          "gfx90a", "gfx940", "gfx941", "gfx942"
+          "gfx90a", "gfx942",
+#if ROCM_VERSION >= 60300
+          "gfx1200", "gfx1201",
+#endif
+#if ROCM_VERSION >= 60500
+          "gfx950"
+#endif
       };
       for (auto index: c10::irange(getNumGPUs())) {
         if (!detail::getCUDAHooks().isGPUArch(index, archs)) {


### PR DESCRIPTION
This PR reverts the omission of gfx120x from archs that use hipBLASLt in this PR: https://github.com/ROCm/pytorch/commit/4ac3aae02d3a22257abb2939ccc8d1848f9196f3.
Also defaults to hipBLASLt on gfx950.