### PR TITLE
[release/2.6] Change gfx110x BLAS preferred backend (Take 2)

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -193,7 +193,7 @@ static bool isSupportedHipLtROCmArch(int index) {
     static const std::vector<std::string> archs = {
         "gfx90a", "gfx942"
 #if ROCM_VERSION >= 60300
-        , "gfx1100", "gfx1101", "gfx1200", "gfx1201"
+        , "gfx1200", "gfx1201"
 #endif
 #if ROCM_VERSION >= 60500
         , "gfx950"


### PR DESCRIPTION
A path, `gemm_and_bias` in `aten/src/ATen/native/cuda/Blas.cpp` which is controlled by the `DISABLE_ADDMM_CUDA_LT` env variable also uses hipBLASLt, which was not addressed in the previous PR https://github.com/ROCm/pytorch/pull/2053/files. 
This PR removes the gfx110x support for hipBLASLt in this path as well.