### PR TITLE
[rocm6.4_internal_testing] Default to hipBLAS on gfx110x

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -192,9 +192,6 @@ static bool isSupportedHipLtROCmArch(int index) {
     std::string device_arch = prop->gcnArchName;
     static const std::vector<std::string> archs = {
         "gfx90a", "gfx940", "gfx941", "gfx942",
-#if ROCM_VERSION >= 60300
-        "gfx1100", "gfx1101"
-#endif
     };
     for (std::string arch : archs) {
         size_t substring = device_arch.find(arch);


### PR DESCRIPTION
gfx110x experiences perf regression when using hipBLASLt. Defaulting to hipBLAS instead.