### PR TITLE
[release/2.6] Exposing Some MIOpen Symbols

### DIFF
--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -5,6 +5,7 @@
 #include <ATen/miopen/miopen-wrapper.h>
 #include <ATen/core/Tensor.h>
 #include <ATen/TensorUtils.h>
+#include <c10/macros/Export.h>
 
 namespace at { namespace native {
 
@@ -64,7 +65,7 @@ private:
   std::unique_ptr<T, DescriptorDeleter<T, dtor>> desc_;
 };
 
-class TensorDescriptor
+class TORCH_CUDA_CPP_API TensorDescriptor
   : public Descriptor<miopenTensorDescriptor,
                       &miopenCreateTensorDescriptor,
                       &miopenDestroyTensorDescriptor>

--- a/aten/src/ATen/miopen/Handle.h
+++ b/aten/src/ATen/miopen/Handle.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include <ATen/miopen/miopen-wrapper.h>
+#include <c10/macros/Export.h>
 
 namespace at { namespace native {
 
-miopenHandle_t getMiopenHandle();
+TORCH_CUDA_CPP_API miopenHandle_t getMiopenHandle();
 
 }} // namespace

--- a/aten/src/ATen/miopen/Types.h
+++ b/aten/src/ATen/miopen/Types.h
@@ -2,10 +2,11 @@
 
 #include <ATen/miopen/miopen-wrapper.h>
 #include <ATen/Tensor.h>
+#include <c10/macros/Export.h>
 
 namespace at { namespace native {
 
-miopenDataType_t getMiopenDataType(const at::Tensor& tensor);
+TORCH_CUDA_CPP_API miopenDataType_t getMiopenDataType(const at::Tensor& tensor);
 
 int64_t miopen_version();
 


### PR DESCRIPTION
This PR exposes some MIOpen symbols, namely:

1. `miopenDataType_t getMiopenDataType(const at::Tensor& tensor)`
2. `miopenHandle_t getMiopenHandle()`
3. `class TensorDescriptor`

to enable adding extensions that make use of them.

