### PR TITLE
[release/2.7] enable NHWC batchnorm by default on ROCm7.0+

### DIFF
--- a/aten/src/ATen/native/Normalization.cpp
+++ b/aten/src/ATen/native/Normalization.cpp
@@ -524,7 +524,8 @@ BatchNormBackend _select_batch_norm_backend(
   // TODO: Remove PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM once ROCm officially supports NHWC in MIOpen
   // See #64427
   // non static variable is used to be able to change environment variable in runtime for testing
-  bool PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM").value_or(false);
+  // enabled by default for ROCm >= 7.0.0
+  bool PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM = c10::utils::check_env("PYTORCH_MIOPEN_SUGGEST_NHWC_BATCHNORM").value_or(ROCM_VERSION >= 70000);
 
   if (
       input.is_cuda()


### PR DESCRIPTION
NHWC batchnorm enabled by default if ROCm>=7.0