### PR TITLE
[rocm6.5_internal_testing] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|a31598cfa1f1d90137e1b5cdc3ab17cff2cafa30|https://github.com/ROCm/apex
-centos|pytorch|apex|master|a31598cfa1f1d90137e1b5cdc3ab17cff2cafa30|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|81eb2fbfbc843a0cbcfff3470a6c392efb83ca44|https://github.com/ROCm/apex
+centos|pytorch|apex|master|81eb2fbfbc843a0cbcfff3470a6c392efb83ca44|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|bde7ecdb6ba9179ccd30cde60a6550478d0a359f|https://github.com/pytorch/text


### PR DESCRIPTION
Reset the torch default device to CPU after running the amp unit tests.   [#220 ](https://github.com/ROCm/apex/pull/220) https://github.com/ROCm/apex/commit/81eb2fbfbc843a0cbcfff3470a6c392efb83ca44

Fixes - https://ontrack-internal.amd.com/browse/SWDEV-523467
