### PR TITLE
[release/2.7] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.7.0|e5f4a5ec59578801aae9da7d2aa342ef1f4db7b0|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.7.0|e5f4a5ec59578801aae9da7d2aa342ef1f4db7b0|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.7.0|5bd253d9eb6f59d16a1e4a977fe7ba5ff1d1bec8|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.7.0|5bd253d9eb6f59d16a1e4a977fe7ba5ff1d1bec8|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.22|9eb57cd5c96be7fe31923eb65399c3819d064587|https://github.com/pytorch/vision
 centos|pytorch|torchvision|release/0.22|9eb57cd5c96be7fe31923eb65399c3819d064587|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Reset torch default device to cpu after running the amp unit tests. https://github.com/ROCm/apex/pull/221 
https://github.com/ROCm/apex/commit/5bd253d9eb6f59d16a1e4a977fe7ba5ff1d1bec8

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-523467

