### PR TITLE
[release/2.6] Move to magma public github repo

### DIFF
--- a/.ci/docker/common/install_rocm_magma.sh
+++ b/.ci/docker/common/install_rocm_magma.sh
@@ -3,6 +3,10 @@
 
 set -ex
 
+ver() {
+    printf "%3d%03d%03d%03d" $(echo "$1" | tr '.' ' ');
+}
+
 # Magma build scripts need `python`
 ln -sf /usr/bin/python3 /usr/bin/python
 
@@ -19,11 +23,17 @@ esac
 MKLROOT=${MKLROOT:-/opt/conda/envs/py_$ANACONDA_PYTHON_VERSION}
 
 # "install" hipMAGMA into /opt/rocm/magma by copying after build
-git clone https://bitbucket.org/icl/magma.git
-pushd magma
-
-# Version 2.7.2 + ROCm related updates
-git checkout a1625ff4d9bc362906bd01f805dbbe12612953f6
+if [[ $(ver $ROCM_VERSION) -ge $(ver 7.0) ]]; then
+    git clone https://github.com/ROCm/utk-magma.git -b release/2.9.0_rocm70 magma
+    pushd magma
+    # version 2.9 + ROCm 7.0 related updates
+    git checkout 91c4f720a17e842b364e9de41edeef76995eb9ad
+else
+    git clone https://bitbucket.org/icl/magma.git
+    pushd magma
+    # Version 2.7.2 + ROCm related updates
+    git checkout a1625ff4d9bc362906bd01f805dbbe12612953f6
+fi
 
 cp make.inc-examples/make.inc.hip-gcc-mkl make.inc
 echo 'LIBDIR += -L$(MKLROOT)/lib' >> make.inc


### PR DESCRIPTION
- Changed to support new Hipblas 3.0.0 which is part of ROCm 7.0 is done.

CP of https://github.com/ROCm/pytorch/commit/ec0c539336f1afff62279d24a8c945dadd4890eb
