### PR TITLE
Partial cherry-pick of distributed unit tests fix from Release/2.4.

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -6694,7 +6694,7 @@ class DistributedTest:
 
             b = Bar()
             gather_objects = [b for _ in range(dist.get_world_size())]
-            with self.assertRaisesRegex(AttributeError, "Can't pickle local object"):
+            with self.assertRaisesRegex(AttributeError, "Can't (get|pickle) local object"):
                 dist.all_gather_object(
                     [None for _ in range(dist.get_world_size())],
                     gather_objects[self.rank],


### PR DESCRIPTION
Fixes #SWDEV-520036.

[Release/2.4] Fix 493250 - Fix distributed unit tests that fail on 4 GPU NAVI machine with python12, pytorch release2.4 (#1694)

Fixes #SWDEV-493250

Solving these issues in 5 different tests.

| 1 | test_ddp_apply_optim_in_backward
| 2 | test_barrier_full_group_cuda distributed/test_distributed_spawn | 3 | test_ddp_profiling_execution_trace
| 4 | test_gather_object_subgroup distributed/test_distributed_spawn | 5 | test_barrier_group_cuda distributed/test_distributed_spawn

Fixes #ISSUE_NUMBER
