### PR TITLE
[release/2.6] [SWDEV-529824] Fix Float16 CooperativeReduction Test Failure

### DIFF
--- a/test/inductor/test_cooperative_reductions.py
+++ b/test/inductor/test_cooperative_reductions.py
@@ -34,7 +34,8 @@ class CooperativeReductionTests(TestCase):
         torch._dynamo.reset()
 
     def run_and_check(self, fn, args, *, expect_kernel_count=1):
-        expected = fn(*args)
+        args_cpu = [tensor.cpu().to(torch.float32) for tensor in args]
+        expected = fn(*args_cpu).to(torch.float16)
         fn = torch.compile(fn, fullgraph=True)
         result, (source_code,) = run_and_get_code(fn, *args)
         self.assertEqual(result, expected)


### PR DESCRIPTION
- Previously expected values were calculated on GPU using same dtype as result values
- Now expected values are calculated on CPU using Float32 dtype
- This fixes a test failure that was observed on Navi48 where difference between Eager mode (expected) and Inductor / Triton (result) did not meet the error tolerance when sum was evaluated on an array of Float16 values