### PR TITLE
[cherry-pick][dynamo][super variable] Fix bug to use correct source

### DIFF
--- a/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/aot_eager_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cu124/dynamic_inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cu124/dynamic_inductor_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/cu124/inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/cu124/inductor_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_aot_eager_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamic_inductor_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/dynamo_eager_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/inductor_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/aot_eager_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_aot_eager_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamic_inductor_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/dynamo_eager_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_huggingface_training.csv
+++ b/benchmarks/dynamo/ci_expected_accuracy/rocm/inductor_huggingface_training.csv
@@ -82,7 +82,7 @@ ElectraForQuestionAnswering,pass,5
 
 
 
-GPT2ForSequenceClassification,pass,5
+GPT2ForSequenceClassification,pass,6
 
 
 
@@ -94,7 +94,7 @@ LayoutLMForMaskedLM,pass,5
 
 
 
-LayoutLMForSequenceClassification,pass,5
+LayoutLMForSequenceClassification,pass,6
 
 
 

--- a/test/dynamo/test_misc.py
+++ b/test/dynamo/test_misc.py
@@ -11981,6 +11981,10 @@ fn
         self.assertEqual(y, t.sin())
 
     def test_overridden_getattribute(self):
+        class Bar:
+            def __init__(self, v):
+                self.v = v
+
         class Foo:
             attribute_map = {}
 
@@ -11988,6 +11992,9 @@ fn
                 self.attribute_map = {
                     "a_premap": "a",
                 }
+                # `bar` attribute requires propagating sources correctly through
+                # object.__getattribute__
+                self.bar = Bar(5)
 
             def __setattr__(self, key, value):
                 if key in super().__getattribute__("attribute_map"):
@@ -12015,7 +12022,7 @@ fn
             return f
 
         def fn(x, f):
-            return x * f.a_premap * f.a * f.b * f.sentinel
+            return x * f.a_premap * f.a * f.b * f.sentinel * f.bar.v
 
         x = torch.randn(4)
 

--- a/torch/_dynamo/guards.py
+++ b/torch/_dynamo/guards.py
@@ -102,6 +102,7 @@ from .source import (
     FlattenScriptObjectSource,
     FloatTensorSource,
     FSDPNNModuleSource,
+    GenericAttrSource,
     GetItemSource,
     GlobalSource,
     GlobalStateSource,
@@ -1042,6 +1043,14 @@ class GuardBuilder(GuardBuilderBase):
         elif istype(source, GradSource):
             assert base_guard_manager  # to make mypy happy
             out = base_guard_manager.grad_manager(
+                source=source_name,
+                example_value=example_value,
+                guard_manager_enum=guard_manager_enum,
+            )
+        elif istype(source, GenericAttrSource):
+            assert base_guard_manager  # to make mypy happy
+            out = base_guard_manager.generic_getattr_manager(
+                attr=source.member,
                 source=source_name,
                 example_value=example_value,
                 guard_manager_enum=guard_manager_enum,

--- a/torch/_dynamo/source.py
+++ b/torch/_dynamo/source.py
@@ -241,6 +241,30 @@ class AttrSource(ChainedSource):
 
 
 @dataclasses.dataclass(frozen=True)
+class GenericAttrSource(ChainedSource):
+    member: str
+
+    def __post_init__(self):
+        assert self.base, "Can't construct an AttrSource without a valid base source"
+        if "." in self.member:
+            member_parts = self.member.split(".")
+            object.__setattr__(
+                self, "base", AttrSource(self.base, ".".join(member_parts[:-1]))
+            )
+            object.__setattr__(self, "member", member_parts[-1])
+
+    def reconstruct(self, codegen):
+        codegen(self.base)
+        codegen.extend_output(codegen.create_load_attrs(self.member))
+
+    def guard_source(self):
+        return self.base.guard_source()
+
+    def name(self):
+        return f"object.__getattribute__({self.base.name()}, {self.member!r})"
+
+
+@dataclasses.dataclass(frozen=True)
 class LocalCellSource(Source):
     """
     Conceptually, this class is `LocalSource` for cell objects implicitly

--- a/torch/_dynamo/variables/misc.py
+++ b/torch/_dynamo/variables/misc.py
@@ -38,7 +38,13 @@ from ..create_parameter_op import do_not_convert_to_tracable_parameter
 from ..exc import raise_observed_exception, unimplemented
 from ..guards import GuardBuilder, install_guard
 from ..mutation_guard import unpatched_nn_module_init
-from ..source import AttrSource, GetItemSource, TypeSource, WeakRefCallSource
+from ..source import (
+    AttrSource,
+    GenericAttrSource,
+    GetItemSource,
+    TypeSource,
+    WeakRefCallSource,
+)
 from ..utils import (
     check_unspec_or_constant_args,
     cmp_name_to_op_mapping,
@@ -260,12 +266,16 @@ class SuperVariable(VariableTracker):
                 return result
 
             try:
-                attr_value = self.objvar.value.__getattribute__(attr_name)
+                # NB - use object.__getattribute__ to prevent running any user code
+                attr_value = object.__getattribute__(self.objvar.value, attr_name)
             except AttributeError:
                 raise_observed_exception(AttributeError, tx)
 
-            source = self.source and AttrSource(self.source, attr_name)
-            return VariableTracker.build(tx, attr_value, source)
+            attr_source = None
+            if self.objvar.source is not None:
+                # setup a object.__getattribute__(self.objvar, name) source
+                attr_source = GenericAttrSource(self.objvar.source, attr_name)
+            return VariableTracker.build(tx, attr_value, attr_source)
 
         unimplemented(f"non-function or method super: {inner_fn}")
 

--- a/torch/csrc/dynamo/guards.cpp
+++ b/torch/csrc/dynamo/guards.cpp
@@ -3489,6 +3489,85 @@ class GetAttrGuardAccessor : public GuardAccessor {
 };
 
 /**
+ * Represents object.__getattribute__(obj, attr_name) acccessor.
+ */
+class GenericGetAttrGuardAccessor : public GuardAccessor {
+ public:
+  GenericGetAttrGuardAccessor(
+      RootGuardManager* root,
+      py::str name,
+      std::string source,
+      py::handle example_value,
+      py::handle guard_manager_enum)
+      : GuardAccessor(
+            root,
+            name,
+            std::move(source),
+            example_value,
+            guard_manager_enum),
+        _attr_name(name.ptr()) {}
+
+  // NB: Intentional duplication between check_nopybind and
+  // check_verbose_nopybind.
+  bool check_nopybind(PyObject* obj, bool matches_dict_tag = false)
+      override { // borrowed ref
+    PyObject* x = PyObject_GenericGetAttr(obj, _attr_name); // new ref
+    if (x == nullptr) {
+      // Attribute absent, clear the exception and return false.
+      PyErr_Clear();
+      return false;
+    }
+    bool result = _guard_manager->check_nopybind(x);
+    Py_DECREF(x);
+    return result;
+  }
+
+  GuardDebugInfo check_verbose_nopybind(
+      PyObject* obj) override { // borrowed ref
+    PyObject* x = PyObject_GenericGetAttr(obj, _attr_name); // new ref
+    if (x == nullptr) {
+      // Attribute absent, clear the exception and return false.
+      PyErr_Clear();
+      return GuardDebugInfo(
+          false, "getattr failed on source " + get_source(), 0);
+    }
+    GuardDebugInfo result = _guard_manager->check_verbose_nopybind(x);
+    Py_DECREF(x);
+    return result;
+  }
+
+  std::string repr() const override {
+    // Helpful when priting GuardManager tree structure.
+    return "GenericGetAttrGuardAccessor(" +
+        py::str(_attr_name).cast<std::string>() + ")";
+  }
+
+ public: // cloning functions
+  GenericGetAttrGuardAccessor(
+      GuardManager* guard_manager,
+      GenericGetAttrGuardAccessor* from)
+      : GuardAccessor(guard_manager, from) {
+    from->clone_visitor(this);
+  }
+
+  GuardAccessor* clone(
+      RootGuardManager* cloned_root,
+      const py::function& clone_filter_fn) override {
+    return clone_common<GenericGetAttrGuardAccessor>(
+        cloned_root, clone_filter_fn);
+  }
+
+  void clone_visitor(GenericGetAttrGuardAccessor* to) {
+    to->_attr_name = _attr_name;
+  }
+
+ private:
+  // no need of py::object here because the attr_name is already passed on to
+  // the base class as accessor_key which is a py::object.
+  PyObject* _attr_name{nullptr};
+};
+
+/**
  * Represents x.__dict__ acccessor.
  */
 class GetGenericDictGuardAccessor : public GuardAccessor {
@@ -5350,6 +5429,12 @@ PyObject* torch_c_dynamo_guards_init() {
       std::unique_ptr<GetAttrGuardAccessor>>(py_m, "GetAttrGuardAccessor");
   // NOLINTNEXTLINE(bugprone-unused-raii)
   py::class_<
+      GenericGetAttrGuardAccessor,
+      GuardAccessor,
+      std::unique_ptr<GenericGetAttrGuardAccessor>>(
+      py_m, "GenericGetAttrGuardAccessor");
+  // NOLINTNEXTLINE(bugprone-unused-raii)
+  py::class_<
       GetGenericDictGuardAccessor,
       GuardAccessor,
       std::unique_ptr<GetGenericDictGuardAccessor>>(
@@ -5911,6 +5996,16 @@ PyObject* torch_c_dynamo_guards_init() {
                 example_value,
                 guard_manager_enum);
           },
+          py::arg("source"),
+          py::arg("example_value"),
+          py::arg("guard_manager_enum"),
+          py::return_value_policy::reference)
+      // return by reference because C++ GuardManager has the ownership of
+      // accessors and guard managers
+      .def(
+          "generic_getattr_manager",
+          &GuardManager::get_child_manager<GenericGetAttrGuardAccessor>,
+          py::arg("attr"),
           py::arg("source"),
           py::arg("example_value"),
           py::arg("guard_manager_enum"),


### PR DESCRIPTION
Upstream transformers unit tests seeing issues for example 
torch._dynamo.exc.Unsupported: Unexpected type in sourceless builder transformers.models.gemma2.configuration_gemma2.Gemma2Config

Cherry picking this upstream PR because it is listed as a solution to the problem in some issue discussions 
https://github.com/pytorch/pytorch/issues/150994