### PR TITLE
 [Release/2.6] Backport softmax fixes from 2.8dev

### DIFF
--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -468,7 +468,7 @@ ilpReduce(index_t shift,
     if (offset >= shift && offset < size) {
       threadVal = r(threadVal, data[offset]);
     }
-    size -= blockDim.x;
+    size -= blockDim.x > size ? size : blockDim.x;
     data += blockDim.x;
   }
   index_t last = size % (ILP * blockDim.x);
@@ -518,7 +518,7 @@ WriteFpropResultsVectorized(
     if (offset >= shift && offset < size) {
       output[offset] = epilogue(input[offset]);
     }
-    size -= blockDim.x;
+    size -= blockDim.x > size ? size : blockDim.x;
     input += blockDim.x;
     output += blockDim.x;
   }

--- a/aten/src/ATen/native/cuda/SoftMax.cu
+++ b/aten/src/ATen/native/cuda/SoftMax.cu
@@ -573,7 +573,7 @@ WriteBpropResultsVectorized(
     if (threadIdx.x >= shift) {
       gradInput[offset] = epilogue(gradOutput[offset], output[offset]);
     }
-    size -= blockDim.x;
+    size -= blockDim.x > size ? size : blockDim.x;
     gradInput += blockDim.x;
     output += blockDim.x;
     gradOutput += blockDim.x;

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -10499,6 +10499,13 @@ class TestNNDeviceType(NNTestCase):
         run_test(2200000000, 1)  # invalid configuration argument https://github.com/pytorch/pytorch/issues/52716
 
     @onlyCUDA
+    @dtypes(torch.double)
+    def test_softmax_double(self, device, dtype):
+        logits = torch.randn(5, 513, dtype=dtype, device=device)
+        expected_ones = F.log_softmax(logits, dim=1).exp().sum(dim=1)
+        self.assertEqual(expected_ones, torch.ones_like(expected_ones))
+
+    @onlyCUDA
     @dtypes(torch.half)
     @largeTensorTest("20GB")
     @largeTensorTest("2GB", "cpu")


### PR DESCRIPTION
This fixes OOB memory access for followng code
``` python
import torch
qk = torch.randn((9,1017), dtype=torch.float64, device='cuda')
smqk = torch.softmax(qk, dim=-1)
```