### PR TITLE
[release/2.6] Upgrade numpy

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -240,8 +240,7 @@ scikit-image==0.22.0 ; python_version >= "3.10"
 #Pinned versions: 0.20.3
 #test that import:
 
-scipy==1.10.1 ; python_version <= "3.11"
-scipy==1.14.1 ; python_version >= "3.12"
+scipy==1.14.1
 # Pin SciPy because of failing distribution tests (see #60347)
 #Description: scientific python
 #Pinned versions: 1.10.1

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -110,10 +110,7 @@ networkx==2.8.8
 #Pinned versions: 1.10.0.post1
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
-numba==0.49.0 ; python_version < "3.9"
-numba==0.55.2 ; python_version == "3.9"
-numba==0.55.2 ; python_version == "3.10"
-numba==0.60.0 ; python_version == "3.12"
+numba==0.61.2
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.54.1, 0.49.0, <=0.49.1
 #test that import: test_numba_integration.py
@@ -131,13 +128,9 @@ numba==0.60.0 ; python_version == "3.12"
 #test_nn.py, test_namedtensor.py, test_linalg.py, test_jit_cuda_fuser.py,
 #test_jit.py, test_indexing.py, test_datapipe.py, test_dataloader.py,
 #test_binary_ufuncs.py
-numpy==1.22.4; python_version == "3.9" or python_version == "3.10"
-numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
-numpy==2.1.2; python_version >= "3.13"
+numpy==2.1.2
 
-pandas==2.0.3; python_version < "3.13"
-pandas==2.2.3; python_version >= "3.13"
-
+pandas==2.2.3
 #onnxruntime
 #Description: scoring engine for Open Neural Network Exchange (ONNX) models
 #Pinned versions: 1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,7 @@
 astunparse==1.6.3
 expecttest==0.2.1
 hypothesis==5.35.1
-numpy==1.22.4; python_version == "3.9" or python_version == "3.10"
-numpy==1.26.2; python_version == "3.11" or python_version == "3.12"
-numpy==2.1.2; python_version >= "3.13"
+numpy==2.1.2
 psutil==7.0.0
 pyyaml==6.0.2
 requests==2.32.3


### PR DESCRIPTION
Relates to: https://github.com/ROCm/builder/pull/82

Validation: http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels/120/

Ran import torch, import numpy, import pandas and the microbenchmark in image called 
_**registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16180_ubuntu24.04_py3.12_pytorch_lw_release2.6_upgrade_numpy_57e5941d**_

```
root@ubb4-rack-22:/var/lib/jenkins/pytorch-micro-benchmarking# pip list | grep pandas
pandas                  2.2.3
root@ubb4-rack-22:/var/lib/jenkins/pytorch-micro-benchmarking# pip list | grep numpy
numpy                   2.1.2

Python 3.12.3 (main, Feb  4 2025, 14:48:35) [GCC 13.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import pandas
>>> import numpy
>>> import torch
>>> exit()

root@ubb4-rack-22:/var/lib/jenkins# cd pytorch-micro-benchmarking/
root@ubb4-rack-22:/var/lib/jenkins/pytorch-micro-benchmarking# python3 micro_benchmarking_pytorch.py --network resnet50
/opt/venv/lib/python3.12/site-packages/redis/connection.py:77: UserWarning: redis-py works best with hiredis. Please consider installing
  warnings.warn(msg)
INFO: running forward and backward for warmup.
INFO: running the benchmark..
OK: finished running benchmark..
--------------------SUMMARY--------------------------
Microbenchmark for network : resnet50
Num devices: 1
Dtype: FP32
Mini batch size [img] : 64
Time per mini-batch : 0.1023630142211914
Throughput [img/sec] : 625.2258248443663
root@ubb4-rack-22:/var/lib/jenkins/pytorch-micro-benchmarking#

```
