### PR TITLE
[ROCm][rocm6.5_internal_testing] skip test_multimem_all_gather test in test_symmetric_memory distributed tests

### DIFF
--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1012,7 +1012,7 @@ class SymmMemCollectiveTest(MultiProcessTestCase):
                 atol=1e-01,
             )
 
-    @skipIfRocm
+    @requires_multicast_support()
     @skip_if_lt_x_gpu(4)
     @parametrize("align_bytes", [4, 8, 16])
     def test_multimem_all_gather(self, align_bytes: int) -> None:

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -1012,6 +1012,7 @@ class SymmMemCollectiveTest(MultiProcessTestCase):
                 atol=1e-01,
             )
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(4)
     @parametrize("align_bytes", [4, 8, 16])
     def test_multimem_all_gather(self, align_bytes: int) -> None:


### PR DESCRIPTION
This PR is created to skip test_multimem_all_gather test in test_symmetric_memory distributed tests in rocm6.5_internal_testing branch. The test_multimem_all_gather test is merged upstream and will be supported from release/2.7 onwards.