### PR TITLE
[release/2.4] upgrade numpy

### DIFF
--- a/.ci/docker/common/install_conda.sh
+++ b/.ci/docker/common/install_conda.sh
@@ -74,27 +74,12 @@ if [ -n "$ANACONDA_PYTHON_VERSION" ]; then
   # Install PyTorch conda deps, as per https://github.com/pytorch/pytorch README
   if [[ $(uname -m) == "aarch64" ]]; then
     CONDA_COMMON_DEPS="astunparse pyyaml setuptools openblas==0.3.25=*openmp* ninja==1.11.1 scons==4.5.2"
-
-    if [ "$ANACONDA_PYTHON_VERSION" = "3.8" ]; then
-      conda_install numpy=1.24.4 ${CONDA_COMMON_DEPS}
-    else
-      conda_install numpy=1.26.2 ${CONDA_COMMON_DEPS}
-    fi
   else
     CONDA_COMMON_DEPS="astunparse pyyaml mkl=2021.4.0 mkl-include=2021.4.0 setuptools"
 
     case "$ANACONDA_PYTHON_VERSION" in 
-      3.11|3.12)
-        NUMPY_SPEC="numpy=1.26.*"          # allowed upper‑bound in PyTorch
-        ;;
-      3.10)
-        NUMPY_SPEC="numpy>=1.24,<1.27"     # first series with Py3.10 wheels
-        ;;
-      *)
-        NUMPY_SPEC="numpy=1.21.2"          # Py3.7–3.9 builds
-        ;;
       esac
-      conda_install ${NUMPY_SPEC} ${CONDA_COMMON_DEPS}
+      conda_install ${CONDA_COMMON_DEPS}
       
   fi
 

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -111,16 +111,13 @@ networkx==2.8.8
 #Pinned versions: 1.10.0.post1
 #test that import: run_test.py, test_cpp_extensions_aot.py,test_determination.py
 
-numba==0.49.0 ; python_version < "3.9"
-numba==0.54.1 ; python_version == "3.9"
-numba==0.55.2 ; python_version == "3.10"
-numba==0.60.0 ; python_version == "3.12"
+numba==0.61.2
 #Description: Just-In-Time Compiler for Numerical Functions
 #Pinned versions: 0.54.1, 0.49.0, <=0.49.1
 #test that import: test_numba_integration.py
 #For numba issue see https://github.com/pytorch/pytorch/issues/51511
 
-#numpy
+numpy=2.1.2
 #Description: Provides N-dimensional arrays and linear algebra
 #Pinned versions: 1.20
 #test that import: test_view_ops.py, test_unary_ufuncs.py, test_type_promotion.py,

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -117,7 +117,7 @@ numba==0.61.2
 #test that import: test_numba_integration.py
 #For numba issue see https://github.com/pytorch/pytorch/issues/51511
 
-numpy=2.1.2
+numpy==2.1.2
 #Description: Provides N-dimensional arrays and linear algebra
 #Pinned versions: 1.20
 #test that import: test_view_ops.py, test_unary_ufuncs.py, test_type_promotion.py,

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -234,8 +234,7 @@ scikit-image==0.20.0 ; python_version >= "3.10"
 #Pinned versions: 0.20.3
 #test that import:
 
-scipy==1.10.1 ; python_version <= "3.11"
-scipy==1.12.0 ; python_version == "3.12"
+scipy==1.14.1 ; python_version > "3.9"
 # Pin SciPy because of failing distribution tests (see #60347)
 #Description: scientific python
 #Pinned versions: 1.10.1

--- a/related_commits
+++ b/related_commits
@@ -1,7 +1,7 @@
 ubuntu|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
 centos|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.19|4d41ad71d51dcc5732d94cd9806c94e7bf771d19|https://github.com/ROCm/vision
-centos|pytorch|torchvision|release/0.19|4d41ad71d51dcc5732d94cd9806c94e7bf771d19|https://github.com/ROCm/vision
+ubuntu|pytorch|torchvision|release/0.19|bbf1b41e2b24a46f69f3ceba7576d67d56459647|https://github.com/ROCm/vision
+centos|pytorch|torchvision|release/0.19|bbf1b41e2b24a46f69f3ceba7576d67d56459647|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 centos|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text
 ubuntu|pytorch|torchdata|release/0.7|5e6f7b7dc5f8c8409a6a140f520a045da8700451|https://github.com/pytorch/data

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 astunparse==1.6.3
 expecttest!=0.2.0
 hypothesis==5.35.1
-numpy<2
+numpy=2.1.2
 psutil==6.0.0
 pyyaml==6.0.1
 requests==2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 astunparse==1.6.3
 expecttest!=0.2.0
 hypothesis==5.35.1
-numpy=2.1.2
+numpy==2.1.2
 psutil==6.0.0
 pyyaml==6.0.1
 requests==2.32.3


### PR DESCRIPTION
Relates to: https://github.com/ROCm/builder/pull/82

Moves torchvision commit to unpin numpy dependency: https://github.com/ROCm/vision/commits/bbf1b41e2b24a46f69f3ceba7576d67d56459647

Validation: http://rocm-ci.amd.com/job/mainline-pytorch2.4-manylinux-wheels/272/
http://rocm-ci.amd.com/job/mainline-pytorch2.4-manylinux-wheels/282/
From: **registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16281_ubuntu22.04_py3.11_pytorch_lw_release2.4_upgrade_numpy_134c11da**
