### PR TITLE
[release/2.4] hipDataType

### DIFF
--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -25,36 +25,35 @@
 namespace at::cuda::tunable {
 
 template <typename T>
-constexpr hipDataType HipDataTypeFor();
+constexpr hipDataType HipBlasDataTypeFor();
 
 template <>
-constexpr hipDataType HipDataTypeFor<float>() {
-  return HIP_R_32F;
+constexpr hipDataType HipBlasDataTypeFor<float>() {
+  return HIPBLAS_R_32F;
 }
 
 template <>
-constexpr hipDataType HipDataTypeFor<Half>() {
-  return HIP_R_16F;
+constexpr hipDataType HipBlasDataTypeFor<Half>() {
+  return HIPBLAS_R_16F;
 }
 
 template <>
-constexpr hipDataType HipDataTypeFor<BFloat16>() {
-  return HIP_R_16BF;
+constexpr hipDataType HipBlasDataTypeFor<BFloat16>() {
+  return HIPBLAS_R_16B;
 }
 
 template <>
-constexpr hipDataType HipDataTypeFor<double>() {
-  return HIP_R_64F;
+constexpr hipDataType HipBlasDataTypeFor<double>() {
+  return HIPBLAS_R_64F;
 }
 
 template <>
-constexpr hipDataType HipDataTypeFor<c10::Float8_e4m3fnuz>() {
+constexpr hipDataType HipBlasDataTypeFor<c10::Float8_e4m3fnuz>() {
   return HIP_R_8F_E4M3_FNUZ;
 }
 
 template <>
-
-constexpr hipDataType HipDataTypeFor<c10::Float8_e5m2fnuz>() {
+constexpr hipDataType HipBlasDataTypeFor<c10::Float8_e5m2fnuz>() {
   return HIP_R_8F_E5M2_FNUZ;
 }
 

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -25,35 +25,36 @@
 namespace at::cuda::tunable {
 
 template <typename T>
-constexpr hipDataType HipBlasDataTypeFor();
+constexpr hipDataType HipDataTypeFor();
 
 template <>
-constexpr hipDataType HipBlasDataTypeFor<float>() {
-  return HIPBLAS_R_32F;
+constexpr hipDataType HipDataTypeFor<float>() {
+  return HIP_R_32F;
 }
 
 template <>
-constexpr hipDataType HipBlasDataTypeFor<Half>() {
-  return HIPBLAS_R_16F;
+constexpr hipDataType HipDataTypeFor<Half>() {
+  return HIP_R_16F;
 }
 
 template <>
-constexpr hipDataType HipBlasDataTypeFor<BFloat16>() {
-  return HIPBLAS_R_16B;
+constexpr hipDataType HipDataTypeFor<BFloat16>() {
+  return HIP_R_16BF;
 }
 
 template <>
-constexpr hipDataType HipBlasDataTypeFor<double>() {
-  return HIPBLAS_R_64F;
+constexpr hipDataType HipDataTypeFor<double>() {
+  return HIP_R_64F;
 }
 
 template <>
-constexpr hipDataType HipBlasDataTypeFor<c10::Float8_e4m3fnuz>() {
+constexpr hipDataType HipDataTypeFor<c10::Float8_e4m3fnuz>() {
   return HIP_R_8F_E4M3_FNUZ;
 }
 
 template <>
-constexpr hipDataType HipBlasDataTypeFor<c10::Float8_e5m2fnuz>() {
+
+constexpr hipDataType HipDataTypeFor<c10::Float8_e5m2fnuz>() {
   return HIP_R_8F_E5M2_FNUZ;
 }
 

--- a/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
+++ b/aten/src/ATen/cuda/tunable/GemmHipblaslt.h
@@ -328,9 +328,9 @@ class HipblasltGemmOp : public Callable<ParamsT> {
     TuningStatus Call(const ParamsT* params) override {
       hipblasOperation_t transa_outer = MapLayoutToHipBlasLt(ALayout);
       hipblasOperation_t transb_outer = MapLayoutToHipBlasLt(BLayout);
-      auto a_datatype = HipBlasDataTypeFor<AT>();
-      auto b_datatype = HipBlasDataTypeFor<BT>();
-      auto in_out_datatype = HipBlasDataTypeFor<CT>();
+      auto a_datatype = HipDataTypeFor<AT>();
+      auto b_datatype = HipDataTypeFor<BT>();
+      auto in_out_datatype = HipDataTypeFor<CT>();
       auto opa = _hipblasOpFromChar(params->transa);
       auto opb = _hipblasOpFromChar(params->transb);
 
@@ -461,9 +461,9 @@ template <typename AT, typename BT, typename CT, BlasOp ALayout, BlasOp BLayout,
 auto GetHipBlasLtTypeStringAndOps() {
   hipblasOperation_t transa_outer = MapLayoutToHipBlasLt(ALayout);
   hipblasOperation_t transb_outer = MapLayoutToHipBlasLt(BLayout);
-  auto a_datatype = HipBlasDataTypeFor<AT>();
-  auto b_datatype = HipBlasDataTypeFor<BT>();
-  auto in_out_datatype = HipBlasDataTypeFor<CT>();
+  auto a_datatype = HipDataTypeFor<AT>();
+  auto b_datatype = HipDataTypeFor<BT>();
+  auto in_out_datatype = HipDataTypeFor<CT>();
   std::vector<hipblasLtMatmulHeuristicResult_t> heuristic_result;
 
   hipblasLtHandle_t handle;


### PR DESCRIPTION
Grepped for "HipBlasDataTypeFor" after changing definitions from HipBlasDataTypeFor to HipDataTypeFor and did not find any other instances of this besides the **GemmHipblaslt.h** file. 

Resolves https://ontrack-internal.amd.com/browse/SWDEV-536855
Build validated for 6.4:
http://rocm-ci.amd.com/view/Release-6.4/job/framework-pytorch-2.4-ub22-py3.10-ci_rel-6.4/61/
Build validated for mainline:
http://rocm-ci.amd.com/job/mainline-pytorch2.4-manylinux-wheels/248/