### PR TITLE
Added index 0 for ROCR_VISIBLE_DEVICES

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3601,7 +3601,7 @@ print(f"{torch.cuda.device_count()}")
             {"CUDA_VISIBLE_DEVICES": "0", "HIP_VISIBLE_DEVICES": None},
             {"CUDA_VISIBLE_DEVICES": None, "HIP_VISIBLE_DEVICES": "0"},
             {"CUDA_VISIBLE_DEVICES": "0,1,2,3", "HIP_VISIBLE_DEVICES": "0"},
-            {"ROCR_VISIBLE_DEVICES": "1,2,3", "HIP_VISIBLE_DEVICES": "0"},
+            {"ROCR_VISIBLE_DEVICES": "0,1,2,3", "HIP_VISIBLE_DEVICES": "0"},
             {"ROCR_VISIBLE_DEVICES": "0", "HIP_VISIBLE_DEVICES": None},
         ]
 


### PR DESCRIPTION
This PR is to fix https://ontrack-internal.amd.com/browse/SWDEV-534855: test_cuda.py::TestCuda::test_hip_device_count fails on one gpu machine.

Needs to cherry-pick it to upstream as well once this PR is merged.