### PR TITLE
[rocm] Add rocm code for test_profiler_cuda_sync_events 

### DIFF
--- a/test/profiler/test_profiler.py
+++ b/test/profiler/test_profiler.py
@@ -1390,8 +1390,10 @@ class TestProfiler(TestCase):
                 with open(fname) as f:
                     j = json.load(f)
                     cats = {e.get("cat", None) for e in j["traceEvents"]}
+                    names = {e.get("name", None) for e in j["traceEvents"]}
+
             self.assertTrue(
-                "cuda_sync" in cats,
+                "cuda_sync" in cats or "hipDeviceSynchronize" in names,
                 "Expected to find cuda_sync event" f" found = {cats}",
             )
 


### PR DESCRIPTION
The unit test checks whether cuda sync is found in the torch profiler dump. Cuda sync internally calls cudaDeviceSynchronize or hipDeviceSynchronize.

For nvidia, the cudaDeviceSynchronize calls ContextSync which has category of cuda_sync 
![image](https://github.com/user-attachments/assets/26fa62d2-1b29-41d5-9594-b9244cef9339)

whereas rocm, hipDeviceSynchronize has no internal calls.
![image](https://github.com/user-attachments/assets/a0fb684f-cb16-484c-ba13-d9c67b7db0de)

The solution would be to search for hipDeviceSynchronize in the profiler event names for rocm.

Fixes #[480147](https://ontrack-internal.amd.com/browse/SWDEV-480147)
