### PR TITLE
[rocm7.0_internal_testing] Update test_binary_ufuncs.py

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1447,7 +1447,7 @@ class TestBinaryUfuncs(TestCase):
         try:
             np_res = np.power(to_np(base), to_np(np_exponent))
             expected = (
-                torch.from_numpy(np_res)
+                torch.from_numpy(np_res).to(dtype=base.dtype)
                 if isinstance(np_res, np.ndarray)
                 else torch.tensor(np_res, dtype=base.dtype)
             )
@@ -1466,7 +1466,7 @@ class TestBinaryUfuncs(TestCase):
         else:
             if isinstance(base, torch.Tensor):
                 actual = base.pow(exponent)
-                self.assertEqual(actual, expected.to(dtype=actual.dtype, device=actual.device))
+                self.assertEqual(actual, expected.to(actual))
                 actual = base.clone()
                 # When base is a 0-dim cpu tensor and exp is a cuda tensor, we exp `pow` to work but `pow_` to fail, since
                 # `pow` will try to create the output tensor on a cuda device, but `pow_` needs to use the cpu tensor as the output
@@ -1480,8 +1480,8 @@ class TestBinaryUfuncs(TestCase):
                     self.assertRaisesRegex(RuntimeError, regex, base.pow_, exponent)
                 elif torch.can_cast(torch.result_type(base, exponent), base.dtype):
                     actual2 = actual.pow_(exponent)
-                    self.assertEqual(actual, expected.to(dtype=actual.dtype, device=actual.device))
-                    self.assertEqual(actual2, expected.to(dtype=actual.dtype, device=actual.device))
+                    self.assertEqual(actual, expected)
+                    self.assertEqual(actual2, expected)
                 else:
                     self.assertRaisesRegex(
                         RuntimeError,

--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1466,7 +1466,7 @@ class TestBinaryUfuncs(TestCase):
         else:
             if isinstance(base, torch.Tensor):
                 actual = base.pow(exponent)
-                self.assertEqual(actual, expected.to(actual))
+                self.assertEqual(actual, expected.to(dtype=actual.dtype, device=actual.device))
                 actual = base.clone()
                 # When base is a 0-dim cpu tensor and exp is a cuda tensor, we exp `pow` to work but `pow_` to fail, since
                 # `pow` will try to create the output tensor on a cuda device, but `pow_` needs to use the cpu tensor as the output
@@ -1480,8 +1480,8 @@ class TestBinaryUfuncs(TestCase):
                     self.assertRaisesRegex(RuntimeError, regex, base.pow_, exponent)
                 elif torch.can_cast(torch.result_type(base, exponent), base.dtype):
                     actual2 = actual.pow_(exponent)
-                    self.assertEqual(actual, expected)
-                    self.assertEqual(actual2, expected)
+                    self.assertEqual(actual, expected.to(dtype=actual.dtype, device=actual.device))
+                    self.assertEqual(actual2, expected.to(dtype=actual.dtype, device=actual.device))
                 else:
                     self.assertRaisesRegex(
                         RuntimeError,


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-537835
Related to https://github.com/ROCm/pytorch/commit/cf324795568f35f91a78fae9cb8f0efc8d955351
Not a Navi specific failure:
```
  File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_internal/common_device_type.py", line 1412, in only_fn
    return fn(slf, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/jenkins/pytorch/test/test_binary_ufuncs.py", line 1671, in test_cuda_tensor_pow_scalar_tensor
    self._test_pow(base, exp)
  File "/var/lib/jenkins/pytorch/test/test_binary_ufuncs.py", line 1482, in _test_pow
    self.assertEqual(actual, expected)
  File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/torch/testing/_internal/common_utils.py", line 4052, in assertEqual
    raise error_metas.pop()[0].to_error(
AssertionError: The values for attribute 'dtype' do not match: torch.float32 != torch.float64.
```

Using .to(actual) without specifying dtype/device assumes actual is a tensor or tensor-like, which may fail silently or promote. Fixed by explicitly matching dtype and device. Going from https://github.com/pytorch/pytorch/issues/107302
Fix:
```
root@ubb4-rack-22:/var/lib/jenkins/pytorch# TEST_CONFIG=default HIP_VISIBLE_DEVICES=0 PYTORCH_TEST_WITH_ROCM=1 python test/test_binary_ufuncs.py TestBinaryUfuncsCUDA.test_cuda_tensor_pow_scalar_tensor_cuda
/opt/conda/envs/py_3.12/lib/python3.12/site-packages/hypothesis/entry_points.py:23: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources

Running tests...
----------------------------------------------------------------------
.
----------------------------------------------------------------------
Ran 1 test in 0.141s

OK

Generating XML reports...
root@ubb4-rack-22:/var/lib/jenkins/pytorch# pip list | grep numpy
numpy                   2.1.2

```