### PR TITLE
Clean up CUDA state between tests

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -442,6 +442,10 @@ class TestCuda(TestCase):
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
     def test_set_per_process_memory_fraction(self):
+        if torch.version.hip:
+           torch.cuda.empty_cache()
+           torch.cuda.reset_peak_memory_stats()
+
         orig = torch.cuda.get_per_process_memory_fraction(0)
         try:
             # test invalid fraction value.

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -445,7 +445,6 @@ class TestCuda(TestCase):
         if torch.version.hip and ('gfx1101' in torch.cuda.get_device_properties(0).gcnArchName):
            torch.cuda.empty_cache()
            torch.cuda.reset_peak_memory_stats()
-
         orig = torch.cuda.get_per_process_memory_fraction(0)
         try:
             # test invalid fraction value.

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -442,7 +442,7 @@ class TestCuda(TestCase):
         IS_JETSON, "oom reporting has issues on jetson igx due to partial nvml support"
     )
     def test_set_per_process_memory_fraction(self):
-        if torch.version.hip:
+        if torch.version.hip and ('gfx1101' in torch.cuda.get_device_properties(0).gcnArchName):
            torch.cuda.empty_cache()
            torch.cuda.reset_peak_memory_stats()
 


### PR DESCRIPTION
This PR fixes the unit test,
```
test/test_cuda.py::TestCuda::test_set_per_process_memory_fraction FAILED [0.1163s]

Traceback (most recent call last):
  File "/var/lib/jenkins/pytorch/test/test_cuda.py", line 471, in test_set_per_process_memory_fraction
    tmp_tensor = torch.empty(application, dtype=torch.int8, device="cuda")
RuntimeError: Trying to create tensor with negative dimension -5681285432: [-5681285432]
```
This error is specific to gfx1101 arch. 
This error is coming from an integer overflow when another unit test, `test/test_cuda.py::TestCuda::test_randint_generation_for_large_numel` creates a tensor with a huge numel, which overflows into a higher `torch.cuda.max_memory_reserved()` when you call `test/test_cuda.py::TestCuda::test_set_per_process_memory_fraction` afterward. To avoid this we introduced `torch.cuda.empty_cache()` and `torch.cuda.reset_peak_memory_stats()` to clean up CUDA states.

JIRA: https://ontrack-internal.amd.com/browse/SWDEV-535295