### PR TITLE
[release/2.5][SWDEV-506865] Update UT tolerance

### DIFF
--- a/test/distributed/pipelining/test_schedule_multiproc.py
+++ b/test/distributed/pipelining/test_schedule_multiproc.py
@@ -574,7 +574,7 @@ class ScheduleTest(MultiProcContinousTest):
             for name, p in stage_module.named_parameters():
                 ref_p = ref_submod.get_parameter(name)
                 try:
-                    torch.testing.assert_close(p.grad, ref_p.grad, rtol=1e-5, atol=4e-5)
+                    torch.testing.assert_close(p.grad, ref_p.grad, rtol=1e-5, atol=8e-5)
                 except AssertionError:
                     print(
                         f"Parameter test failed for {submod_name}.{name}: {p.grad} vs {ref_p.grad}"


### PR DESCRIPTION
Since, we no longer default to hipblaslt as the preferred backend for NAVI31, we are running into a very small accuracy issue. Updating this toleratnce for `test_schedule_with_native_zero_bubble_ScheduleClass1` in `test_schedule_multiproc.py`. From 2.6 onwards, this should be supported without any changes.

Fixes #ISSUE_NUMBER
