### PR TITLE
Added serialTest to test_host_memory_stats

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -162,6 +162,7 @@ class TestCuda(TestCase):
         for thread in threads:
             thread.join()
 
+    @serialTest
     def test_host_memory_stats(self):
         # Helper functions
         def empty_stats():


### PR DESCRIPTION
This unit test fails when entire test suite is running. Adapting the change from upstream: https://github.com/pytorch/pytorch/pull/152454
Fixes test_cuda.py::TestCuda::test_host_memory_stats