### PR TITLE
Skip test_conv_model_runtime test for rocm on release/2.5 branch

### DIFF
--- a/test/distributed/_tools/test_runtime_estimator.py
+++ b/test/distributed/_tools/test_runtime_estimator.py
@@ -8,7 +8,7 @@ from torch import nn, optim
 from torch._subclasses.fake_tensor import FakeTensorMode
 from torch.distributed._tools.runtime_estimator import RuntimeEstimator
 from torch.testing._internal.common_cuda import TEST_CUDA
-from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, TestCase
+from torch.testing._internal.common_utils import run_tests, skipIfTorchDynamo, skipIfRocm, TestCase
 from torch.testing._internal.distributed._tensor.common_dtensor import (
     ModelArgs,
     Transformer,
@@ -164,6 +164,7 @@ class TestRuntimeEstimator(TestCase):
         self.assertAlmostEqual(benchmark_accuracy, 1.0, delta=0.2)
         self.assertAlmostEqual(roofline_accuracy, 1.0, delta=0.3)
 
+    @skipIfRocm
     @skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/115653")
     @unittest.skipIf(not TEST_CUDA, "CUDA not available")
     def test_conv_model_runtime(

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -1566,6 +1566,21 @@ def skipIfTorchInductor(msg="test doesn't currently work with torchinductor",
 
     return decorator
 
+def skipIfRocm(func=None, *, msg="test doesn't currently work on the ROCm stack"):
+    def dec_fn(fn):
+        reason = f"skipIfRocm: {msg}"
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if TEST_WITH_ROCM:
+                raise unittest.SkipTest(reason)
+            else:
+                return fn(*args, **kwargs)
+        return wrapper
+    if func:
+        return dec_fn(func)
+    return dec_fn
+
 def serialTest(condition=True):
     """
     Decorator for running tests serially.  Requires pytest


### PR DESCRIPTION
In this PR, I am skipping test_conv_model_runtime test for rocm on release/2.5 branch. The test passes on release/2.6 branch.
The test was failing for Jira ticket- https://ontrack-internal.amd.com/browse/SWDEV-506864

Tested using docker image- registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16362_ubuntu24.04_py3.12_pytorch_lw_release-2.5_a1ad153c