### PR TITLE
[rocm7.0_internal_testing] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|89c37c81523484bf0c5b75054e0208952b8fe710|https://github.com/ROCm/apex
-centos|pytorch|apex|master|89c37c81523484bf0c5b75054e0208952b8fe710|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|d533e3fb331be0ef496a7fc02a4e3ec611b78501|https://github.com/ROCm/apex
+centos|pytorch|apex|master|d533e3fb331be0ef496a7fc02a4e3ec611b78501|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|bde7ecdb6ba9179ccd30cde60a6550478d0a359f|https://github.com/pytorch/text

--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|d533e3fb331be0ef496a7fc02a4e3ec611b78501|https://github.com/ROCm/apex
-centos|pytorch|apex|master|d533e3fb331be0ef496a7fc02a4e3ec611b78501|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|95c7ed20de6d512a7a1c6b1d6b72b2f20febf5de|https://github.com/ROCm/apex
+centos|pytorch|apex|master|95c7ed20de6d512a7a1c6b1d6b72b2f20febf5de|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|bde7ecdb6ba9179ccd30cde60a6550478d0a359f|https://github.com/pytorch/text


### PR DESCRIPTION
1 ) [master] Added AITER as a submodule and use in fused_rope.py - https://github.com/ROCm/apex/commit/d533e3fb331be0ef496a7fc02a4e3ec611b78501

2) Not using warpSize as a constexpr in nhwc_batch_norm_kernel.h. replaces the variable use with the correct values based on the architecture we're running on. - https://github.com/ROCm/apex/commit/7f38d9d2991c3ee16912070ddfc84f841e939d20

3) [Replacing c10_warp_size with platform based warp_size values](https://github.com/ROCm/apex/commit/95c7ed20de6d512a7a1c6b1d6b72b2f20febf5de)

Fixes 
1) https://ontrack-internal.amd.com/browse/SWDEV-496182
2) https://ontrack-internal.amd.com/browse/SWDEV-541770
3) https://ontrack-internal.amd.com/browse/SWDEV-541725
