### PR TITLE
[release/2.6] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.6.0|75bdf8250d3b70e7fa6294cb87d36918bb0ddf9b|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.6.0|75bdf8250d3b70e7fa6294cb87d36918bb0ddf9b|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.6.0|14c8025ee4a13c21ec32b5f4d5717cd712a4a171|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.6.0|14c8025ee4a13c21ec32b5f4d5717cd712a4a171|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
updated Apex commit 
[release/1.6.0] Do not use warpSize as a constexpr in nhwc_batch_norm_kernel.h - https://github.com/ROCm/apex/pull/231

Fixes: https://ontrack-internal.amd.com/browse/SWDEV-541770
