### PR TITLE
[release/2.4] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.4.0|dbda778024b76fdc59498ddba695ef95bcb4e7a1|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.4.0|f0ea0feec53f4219d7febaa8294ae937a88b6ef2|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.4.0|f0ea0feec53f4219d7febaa8294ae937a88b6ef2|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.19|bbf1b41e2b24a46f69f3ceba7576d67d56459647|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.19|bbf1b41e2b24a46f69f3ceba7576d67d56459647|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
updated apex commit 
[release/1.4.0] Do not use warpSize as a constexpr in nhwc_batch_norm_kernel.h - https://github.com/ROCm/apex/pull/229

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-541770
