### PR TITLE
[AUTOGENERATED] [release/2.7] [rocm7.0_internal_testing] upgrade tensorboard compatible with numpy 2

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -313,8 +313,7 @@ z3-solver==4.12.6.0
 #Pinned versions:
 #test that import:
 
-tensorboard==2.13.0 ; python_version < "3.13"
-tensorboard==2.18.0 ; python_version >= "3.13"
+tensorboard==2.18.0
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2326 