### PR TITLE
[AUTOGENERATED] [release/2.5] [rocm7.0_internal_testing] upgrade tensorboard compatible with numpy 2

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -310,7 +310,11 @@ z3-solver==4.12.2.0
 #Pinned versions:
 #test that import:
 
+<<<<<<< HEAD
 tensorboard==2.13.0
+=======
+tensorboard==2.18.0
+>>>>>>> c7f61f4205 ([rocm7.0_internal_testing] upgrade tensorboard compatible with numpy 2 (#2326))
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -310,11 +310,7 @@ z3-solver==4.12.2.0
 #Pinned versions:
 #test that import:
 
-<<<<<<< HEAD
-tensorboard==2.13.0
-=======
 tensorboard==2.18.0
->>>>>>> c7f61f4205 ([rocm7.0_internal_testing] upgrade tensorboard compatible with numpy 2 (#2326))
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2326 
Need to resolve conflicts