### PR TITLE
[release/2.6] Fix dtype before comparing torch and numpy tensors

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1446,7 +1446,7 @@ class TestBinaryUfuncs(TestCase):
         try:
             np_res = np.power(to_np(base), to_np(np_exponent))
             expected = (
-                torch.from_numpy(np_res).to(dtype=base.dtype)
+                torch.from_numpy(np_res)
                 if isinstance(np_res, np.ndarray)
                 else torch.tensor(np_res, dtype=base.dtype)
             )
@@ -1479,8 +1479,8 @@ class TestBinaryUfuncs(TestCase):
                     self.assertRaisesRegex(RuntimeError, regex, base.pow_, exponent)
                 elif torch.can_cast(torch.result_type(base, exponent), base.dtype):
                     actual2 = actual.pow_(exponent)
-                    self.assertEqual(actual, expected)
-                    self.assertEqual(actual2, expected)
+                    self.assertEqual(actual, expected.to(actual))
+                    self.assertEqual(actual2, expected.to(actual))
                 else:
                     self.assertRaisesRegex(
                         RuntimeError,


### PR DESCRIPTION
Cast numpy dtype result to torch dtype result before compare

Numpy  returns `np.power(float32, int64) => float64` [Promotion rules for Python scalars](https://numpy.org/neps/nep-0050-scalar-promotion.html)
Pytorch returns `torch.pow(float32, int64) => float32`

Reverts https://github.com/ROCm/pytorch/pull/2287 and fixes tests in a different way

Fixes:
- SWDEV-538110 - `'dtype' do not match: torch.float32 != torch.float64`
- SWDEV-539171 - `AttributeError: 'float' object has no attribute 'dtype`

