### PR TITLE
[rocm6.4_internal_testing][SWDEV-535305] Fixed `test_extra_cuda_context` in `test_c10d_nccl.py` and refactored is_navi3_arch function

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -592,6 +592,10 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # Rank 0 takes a snapshot before collective -- this snapshot should have
         # included rank 0's own context.
         if self.rank == 0:
+            # Adding sleep statement (for Navi arch) before collectives as it helps 
+            # with memory allocation. Without sleep statement before collectives, the 
+            # torch.cuda.mem_get_info after collectives results in high memory usage
+            # resulting in test_extra_cuda_context test to fail. 
             if is_arch(NAVI_ARCH):
                 time.sleep(5)
             free, total = torch.cuda.mem_get_info(device)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -592,10 +592,10 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # Rank 0 takes a snapshot before collective -- this snapshot should have
         # included rank 0's own context.
         if self.rank == 0:
-            # Adding sleep statement (for Navi arch) before collectives as init_process_group 
-            # has an extra process which is taking time to finish on navi. Without sleep statement 
-            # before collectives, the torch.cuda.mem_get_info after collectives results in high 
-            # memory usage resulting in test_extra_cuda_context test to fail. 
+            # We need this extra sleep for NAVI_ARCH because rccl_init inside init_process_group 
+            # is happening in a separate process and it is taking longer to finish on NAVI_ARCH. 
+            # Sleeping here ensures that the init is competed successfully and mem_get_info can 
+            # get stable numbers.
             if is_arch(NAVI_ARCH):
                 time.sleep(5)
             free, total = torch.cuda.mem_get_info(device)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -593,7 +593,7 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # included rank 0's own context.
         if self.rank == 0:
             # Adding sleep statement (for Navi arch) before collectives as init_process_group 
-            # has an extra process which is taking time to finish on navi Without sleep statement 
+            # has an extra process which is taking time to finish on navi. Without sleep statement 
             # before collectives, the torch.cuda.mem_get_info after collectives results in high 
             # memory usage resulting in test_extra_cuda_context test to fail. 
             if is_arch(NAVI_ARCH):

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -592,10 +592,10 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # Rank 0 takes a snapshot before collective -- this snapshot should have
         # included rank 0's own context.
         if self.rank == 0:
-            # Adding sleep statement (for Navi arch) before collectives as it helps 
-            # with memory allocation. Without sleep statement before collectives, the 
-            # torch.cuda.mem_get_info after collectives results in high memory usage
-            # resulting in test_extra_cuda_context test to fail. 
+            # Adding sleep statement (for Navi arch) before collectives as init_process_group 
+            # has an extra process which is taking time to finish on navi Without sleep statement 
+            # before collectives, the torch.cuda.mem_get_info after collectives results in high 
+            # memory usage resulting in test_extra_cuda_context test to fail. 
             if is_arch(NAVI_ARCH):
                 time.sleep(5)
             free, total = torch.cuda.mem_get_info(device)

--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -67,6 +67,8 @@ from torch.testing._internal.common_utils import (
     TEST_WITH_DEV_DBG_ASAN,
     TEST_WITH_ROCM,
     TestCase,
+    is_arch,
+    NAVI_ARCH,
 )
 from torch.utils.cpp_extension import load_inline
 
@@ -590,6 +592,8 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         # Rank 0 takes a snapshot before collective -- this snapshot should have
         # included rank 0's own context.
         if self.rank == 0:
+            if is_arch(NAVI_ARCH):
+                time.sleep(5)
             free, total = torch.cuda.mem_get_info(device)
             used_before = float(total - free)
 

--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -11,7 +11,8 @@ from torch._inductor.utils import run_and_get_code
 from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
-    is_navi3_arch,
+    NAVI3_ARCH,
+    is_arch,
     parametrize,
     skipIfXpu,
 )
@@ -49,8 +50,8 @@ class MyModule3(torch.nn.Module):
 
 # We have to increase tolerance for navi3 because all fp16, bf16
 # GEMMs operations have an accuracy issue caused by hardware limitation
-default_atol = 3e-3 if is_navi3_arch() else 1e-3
-default_rtol = 4e-3 if is_navi3_arch() else 1e-3
+default_atol = 3e-3 if is_arch(NAVI3_ARCH) else 1e-3
+default_rtol = 4e-3 if is_arch(NAVI3_ARCH) else 1e-3
 
 
 @requires_gpu

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -112,11 +112,11 @@ NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
 NAVI3_ARCH = ("gfx1100", "gfx1101")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
 
-def is_navi3_arch():
+def is_arch(arch_list):
     if torch.cuda.is_available():
         prop = torch.cuda.get_device_properties(0)
         gfx_arch = prop.gcnArchName.split(":")[0]
-        if gfx_arch in NAVI3_ARCH:
+        if gfx_arch in arch_list:
             return True
     return False
 


### PR DESCRIPTION
In this PR, I have added a sleep statement before collectives. We need this extra sleep for NAVI_ARCH because rccl_init inside init_process_group is happening in a separate process and it is taking longer to finish on NAVI_ARCH. Sleeping here ensures that the init is competed successfully and mem_get_info can get stable numbers.
Note that in the test the sleep statement was already there after collectives. 
Also, refactored is_navi3_arch function to is_arch that takes arch list as an argument and compares with existing arch.

Tested with docker image-
compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-rel-6.4:108_ubuntu22.04_py3.10_pytorch_rocm6.4_internal_testing_aeb5d79
