### PR TITLE
[release/2.6] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.6.0|14c8025ee4a13c21ec32b5f4d5717cd712a4a171|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.6.0|14c8025ee4a13c21ec32b5f4d5717cd712a4a171|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.6.0|2a77e08bd87950a62c720ac3db145b4b06e34a7f|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.6.0|2a77e08bd87950a62c720ac3db145b4b06e34a7f|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text

--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.6.0|7d9850a645c22e97cd612b00cd95d91b2e3a4660|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.6.0|7d9850a645c22e97cd612b00cd95d91b2e3a4660|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.6.0|f956a665aa6c526e8201df58c569bb7139d980e3|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.6.0|f956a665aa6c526e8201df58c569bb7139d980e3|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text

--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.6.0|2a77e08bd87950a62c720ac3db145b4b06e34a7f|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.6.0|2a77e08bd87950a62c720ac3db145b4b06e34a7f|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.6.0|7d9850a645c22e97cd612b00cd95d91b2e3a4660|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.6.0|7d9850a645c22e97cd612b00cd95d91b2e3a4660|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.21|4040d51ff2f04ece3732c99d50da0b7d4538ff92|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Fixing the C10_warpsize issue. replacing the macros with at::cuda::warp_size() - https://github.com/ROCm/apex/pull/243

[Replaced warpsize with C10_WARP_SIZE ](https://github.com/ROCm/apex/commit/7d9850a645c22e97cd612b00cd95d91b2e3a4660) - https://github.com/ROCm/apex/pull/252

Fix all warp size in apex -https://github.com/ROCm/apex/pull/259

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-541725