### PR TITLE
[release/2.5] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.5.0|ff21eb1c3f8efc9e1a5b37fb5e6cbfc0bca381a7|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.5.0|ff21eb1c3f8efc9e1a5b37fb5e6cbfc0bca381a7|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.5.0|dae446893a424f9a055cdf1434fb5d1e4e58187d|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.5.0|dae446893a424f9a055cdf1434fb5d1e4e58187d|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text

--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.5.0|c3443d434c9d4803dcbbfd21b7237124a074bd54|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.5.0|c3443d434c9d4803dcbbfd21b7237124a074bd54|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.5.0|ff21eb1c3f8efc9e1a5b37fb5e6cbfc0bca381a7|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.5.0|ff21eb1c3f8efc9e1a5b37fb5e6cbfc0bca381a7|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text

--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|release/1.5.0|dae446893a424f9a055cdf1434fb5d1e4e58187d|https://github.com/ROCm/apex
-centos|pytorch|apex|release/1.5.0|dae446893a424f9a055cdf1434fb5d1e4e58187d|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|release/1.5.0|9110ead044b93c318c7872f4fdc3df8f76cffa06|https://github.com/ROCm/apex
+centos|pytorch|apex|release/1.5.0|9110ead044b93c318c7872f4fdc3df8f76cffa06|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
 centos|pytorch|torchvision|release/0.20|04d8fc4ae648ab5bfb12870bc579c772da843e73|https://github.com/ROCm/vision
 ubuntu|pytorch|torchtext|release/0.18.0|9bed85d7a7ae13cf8c28598a88d8e461fe1afcb4|https://github.com/pytorch/text


### PR DESCRIPTION
Fixing the C10_warpsize issue. replacing the macros with at::cuda::warp_size() - https://github.com/ROCm/apex/pull/242
[Replaced warpsize with C10_WARP_SIZE ](https://github.com/ROCm/apex/commit/dae446893a424f9a055cdf1434fb5d1e4e58187d) - https://github.com/ROCm/apex/pull/251

Fix all warp size in apex - https://github.com/ROCm/apex/pull/258

Fixes : https://ontrack-internal.amd.com/browse/SWDEV-541725