### PR TITLE
[rocm7.0_internal_testing] Update related_commits

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,5 +1,5 @@
-ubuntu|pytorch|apex|master|ed2d044e5839139f5d35371923a1e31d47bb57c9|https://github.com/ROCm/apex
-centos|pytorch|apex|master|ed2d044e5839139f5d35371923a1e31d47bb57c9|https://github.com/ROCm/apex
+ubuntu|pytorch|apex|master|19eed3c8dfab07f39fbb4ae1d9d00af4dc01c6a2|https://github.com/ROCm/apex
+centos|pytorch|apex|master|19eed3c8dfab07f39fbb4ae1d9d00af4dc01c6a2|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 centos|pytorch|torchvision|main|d84aa8936db75d73a6b8085316f4e2a802fe0b99|https://github.com/pytorch/vision
 ubuntu|pytorch|torchtext|main|bde7ecdb6ba9179ccd30cde60a6550478d0a359f|https://github.com/pytorch/text


### PR DESCRIPTION
Disabling Aiter Installation in default build - https://github.com/ROCm/apex/pull/254

Replaced warpsize with C10_WARP_SIZE in group batch norm - https://github.com/ROCm/apex/pull/249

Fixes https://ontrack-internal.amd.com/browse/SWDEV-541770
https://ontrack-internal.amd.com/browse/SWDEV-542835
