### PR TITLE
[AUTOGENERATED] [rocm7.0_internal_testing] [release/2.6] Fix dtype before comparing torch and numpy tensors

### DIFF
--- a/test/test_binary_ufuncs.py
+++ b/test/test_binary_ufuncs.py
@@ -1447,7 +1447,7 @@ class TestBinaryUfuncs(TestCase):
         try:
             np_res = np.power(to_np(base), to_np(np_exponent))
             expected = (
-                torch.from_numpy(np_res).to(dtype=base.dtype)
+                torch.from_numpy(np_res)
                 if isinstance(np_res, np.ndarray)
                 else torch.tensor(np_res, dtype=base.dtype)
             )
@@ -1480,8 +1480,8 @@ class TestBinaryUfuncs(TestCase):
                     self.assertRaisesRegex(RuntimeError, regex, base.pow_, exponent)
                 elif torch.can_cast(torch.result_type(base, exponent), base.dtype):
                     actual2 = actual.pow_(exponent)
-                    self.assertEqual(actual, expected)
-                    self.assertEqual(actual2, expected)
+                    self.assertEqual(actual, expected.to(actual))
+                    self.assertEqual(actual2, expected.to(actual))
                 else:
                     self.assertRaisesRegex(
                         RuntimeError,


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2340 