### PR TITLE
[release/2.5] enable py3.13

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -159,7 +159,6 @@ pillow==10.3.0 ; python_version <= "3.12"
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:
-pybind11==3.0.0
 
 protobuf==4.25.1
 #Description:  Google’s data interchange format

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -154,7 +154,8 @@ optree==0.12.1
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==10.3.0
+pillow==11.0.0 ; python_version == "3.13"
+pillow==10.3.0 ; python_version <= "3.12"
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -154,8 +154,7 @@ optree==0.12.1
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==11.0.0 ; python_version == "3.13"
-pillow==10.3.0 ; python_version < "3.12"
+pillow==10.3.0
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -160,7 +160,8 @@ pillow==10.3.0 ; python_version <= "3.12"
 #Pinned versions: 10.3.0
 #test that import:
 
-protobuf==4.25.1
+protobuf==3.20.2 ; python_version <= "3.12"
+protobuf==4.25.1 ; python_version == "3.13"
 #Description:  Google’s data interchange format
 #Pinned versions: 3.20.1
 #test that import: test_tensorboard.py
@@ -322,7 +323,8 @@ pywavelets==1.6.0
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==6.0.0
+lxml==5.0.0 ; python_version <= "3.12"
+lxml==6.0.0 ; python_version == "3.13"
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -159,8 +159,9 @@ pillow==10.3.0 ; python_version < "3.12"
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:
+pybind11==3.0.0
 
-protobuf==3.20.2
+protobuf==4.25.1
 #Description:  Google’s data interchange format
 #Pinned versions: 3.20.1
 #test that import: test_tensorboard.py
@@ -322,7 +323,7 @@ pywavelets==1.6.0
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==5.0.0
+lxml==6.0.0
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries
@@ -335,7 +336,8 @@ sympy==1.13.1 ; python_version >= "3.9"
 #Pinned versions:
 #test that import:
 
-onnx==1.16.1
+onnx==1.16.1 ; python_version <= "3.12"
+onnx==1.18.0 ; python_version == "3.13"
 #Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
pip installed requirements.txt and .ci/docker/requirements-ci.txt

Local validation: `Successfully installed dataclasses_json-0.6.7 expecttest-0.3.0 jinja2-3.1.6 lintrunner-0.12.7 marshmallow-3.26.1 mypy-1.14.0 onnxscript-0.2.2 pyzstd-0.17.0 sympy-1.13.3 tlparse-0.3.30 typing-inspect-0.9.0 z3-solver-4.12.6.0`