### PR TITLE
[release/2.6] enable py3.13

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -156,12 +156,13 @@ optree==0.13.0
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==11.0.0
+pillow==11.0.0 ; python_version == "3.13"
+pillow==10.3.0 ; python_version <= "3.12"
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:
 
-protobuf==3.20.2
+protobuf==4.25.1
 #Description:  Google’s data interchange format
 #Pinned versions: 3.20.1
 #test that import: test_tensorboard.py
@@ -324,7 +325,7 @@ pywavelets==1.7.0 ; python_version >= "3.12"
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==5.3.0
+lxml==6.0.0
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries
@@ -336,7 +337,8 @@ sympy==1.13.1 ; python_version >= "3.9"
 #Pinned versions:
 #test that import:
 
-onnx==1.17.0
+onnx==1.16.1 ; python_version <= "3.12"
+onnx==1.18.0 ; python_version == "3.13"
 #Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -156,13 +156,12 @@ optree==0.13.0
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==11.0.0 ; python_version == "3.13"
-pillow==10.3.0 ; python_version <= "3.12"
+pillow==11.0.0
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:
-
-protobuf==4.25.1
+protobuf==3.20.2 ; python_version <= "3.12"
+protobuf==4.25.1 ; python_version == "3.13"
 #Description:  Google’s data interchange format
 #Pinned versions: 3.20.1
 #test that import: test_tensorboard.py
@@ -325,7 +324,8 @@ pywavelets==1.7.0 ; python_version >= "3.12"
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==6.0.0
+lxml==5.3.0 ; python_version <= "3.12"
+lxml==6.0.0 ; python_version == "3.13"
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries


### PR DESCRIPTION
pip installed requirements.txt and .ci/docker/requirements-ci.txt

Local validation: `Successfully installed boto3-1.35.42 botocore-1.35.99 click-8.1.8 fbscribelogger-0.1.7 mypy-1.13.0 pywavelets-1.7.0 s3transfer-0.10.4 tlparse-0.3.25`