### PR TITLE
[release/2.7] enable py3.13

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -157,13 +157,13 @@ optree==0.13.0
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==11.0.0 ; python_version == "3.13"
-pillow==10.3.0 ; python_version <= "3.12"
+pillow==11.0.0
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:
 
-protobuf==4.25.1
+protobuf==3.20.2 ; python_version <= "3.12"
+protobuf==4.25.1 ; python_version == "3.13"
 #Description:  Google’s data interchange format
 #Pinned versions: 3.20.1
 #test that import: test_tensorboard.py
@@ -326,7 +326,8 @@ pywavelets==1.7.0 ; python_version >= "3.12"
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==6.0.0
+lxml==5.3.0 ; python_version <= "3.12"
+lxml==6.0.0 ; python_version == "3.13"
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -157,12 +157,13 @@ optree==0.13.0
 #test_pointwise_ops.py, test_dtensor_ops.py, test_torchinductor.py, test_fx.py,
 #test_fake_tensor.py, test_mps.py
 
-pillow==11.0.0
+pillow==11.0.0 ; python_version == "3.13"
+pillow==10.3.0 ; python_version <= "3.12"
 #Description:  Python Imaging Library fork
 #Pinned versions: 10.3.0
 #test that import:
 
-protobuf==3.20.2
+protobuf==4.25.1
 #Description:  Google’s data interchange format
 #Pinned versions: 3.20.1
 #test that import: test_tensorboard.py
@@ -325,7 +326,7 @@ pywavelets==1.7.0 ; python_version >= "3.12"
 #Pinned versions: 1.4.1
 #test that import:
 
-lxml==5.3.0
+lxml==6.0.0
 #Description: This is a requirement of unittest-xml-reporting
 
 # Python-3.9 binaries
@@ -337,7 +338,8 @@ sympy==1.13.3
 #Pinned versions:
 #test that import:
 
-onnx==1.17.0
+onnx==1.16.1 ; python_version <= "3.12"
+onnx==1.18.0 ; python_version == "3.13"
 #Description: Required by mypy and test_public_bindings.py when checking torch.onnx._internal
 #Pinned versions:
 #test that import:


### PR DESCRIPTION
pip installed requirements.txt and .ci/docker/requirements-ci.txt

Local validation: `Successfully installed jinja2-3.1.6 lintrunner-0.12.7 mypy-1.14.0 onnxscript-0.2.2 sympy-1.13.3 tlparse-0.3.30 z3-solver-4.12.6.0`
