### PR TITLE
[rocm7.0_internal_testing][SWDEV-542411] Fixed test_extra_cuda_context in test_c10d_nccl.py and refactored is_navi3_arch function

### DIFF
--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -13,7 +13,7 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     patch_test_members,
-    is_navi3_arch,
+    is_arch,
     parametrize,
     TEST_XPU,
 )
@@ -212,8 +212,8 @@ class TestDecomposeMemMM(TestCase):
     # We have to increase tolerance for navi3 because all fp16, bf16
     # GEMMs operations have an accuracy issue caused by hardware limitation
     @patch_test_members({
-        "atol": 2e-3 if is_navi3_arch() else 1e-3,
-        "rtol": 2e-3 if is_navi3_arch() else 1e-3
+        "atol": 2e-3 if is_arch() else 1e-3,
+        "rtol": 2e-3 if is_arch() else 1e-3
     })
     @parametrize(
         "m,k,n, should_decompose",
@@ -326,8 +326,8 @@ class TestDecomposeMemMM(TestCase):
     # We have to increase tolerance for navi3 because all fp16, bf16
     # GEMMs operations have an accuracy issue caused by hardware limitation
     @patch_test_members({
-        "atol": 3e-3 if is_navi3_arch() else 1e-3,
-        "rtol": 4e-3 if is_navi3_arch() else 1e-3
+        "atol": 3e-3 if is_arch() else 1e-3,
+        "rtol": 4e-3 if is_arch() else 1e-3
     })
     @parametrize(
         "m,k,n, should_decompose",

--- a/test/inductor/test_decompose_mem_bound_mm.py
+++ b/test/inductor/test_decompose_mem_bound_mm.py
@@ -13,6 +13,7 @@ from torch.testing import FileCheck
 from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     patch_test_members,
+    NAVI3_ARCH,
     is_arch,
     parametrize,
     TEST_XPU,
@@ -212,8 +213,8 @@ class TestDecomposeMemMM(TestCase):
     # We have to increase tolerance for navi3 because all fp16, bf16
     # GEMMs operations have an accuracy issue caused by hardware limitation
     @patch_test_members({
-        "atol": 2e-3 if is_arch() else 1e-3,
-        "rtol": 2e-3 if is_arch() else 1e-3
+        "atol": 2e-3 if is_arch(NAVI3_ARCH) else 1e-3,
+        "rtol": 2e-3 if is_arch(NAVI3_ARCH) else 1e-3
     })
     @parametrize(
         "m,k,n, should_decompose",
@@ -326,8 +327,8 @@ class TestDecomposeMemMM(TestCase):
     # We have to increase tolerance for navi3 because all fp16, bf16
     # GEMMs operations have an accuracy issue caused by hardware limitation
     @patch_test_members({
-        "atol": 3e-3 if is_arch() else 1e-3,
-        "rtol": 4e-3 if is_arch() else 1e-3
+        "atol": 3e-3 if is_arch(NAVI3_ARCH) else 1e-3,
+        "rtol": 4e-3 if is_arch(NAVI3_ARCH) else 1e-3
     })
     @parametrize(
         "m,k,n, should_decompose",

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -108,19 +108,11 @@ NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
 NAVI3_ARCH = ("gfx1100", "gfx1101")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
 
-def is_navi3_arch():
+def is_arch(arch_list):
     if torch.cuda.is_available():
         prop = torch.cuda.get_device_properties(0)
         gfx_arch = prop.gcnArchName.split(":")[0]
-        if gfx_arch in NAVI3_ARCH:
-            return True
-    return False
-
-def is_navi3_arch():
-    if torch.cuda.is_available():
-        prop = torch.cuda.get_device_properties(0)
-        gfx_arch = prop.gcnArchName.split(":")[0]
-        if gfx_arch in NAVI3_ARCH:
+        if gfx_arch in arch_list:
             return True
     return False
 


### PR DESCRIPTION
In this PR, I have added a sleep statement before collectives. We need this extra sleep for NAVI_ARCH because rccl_init inside init_process_group is happening in a separate process and it is taking longer to finish on NAVI_ARCH. Sleeping here ensures that the init is competed successfully and mem_get_info can get stable numbers.
Note that in the test the sleep statement was already there after collectives.
Also, refactored is_navi3_arch function to is_arch that takes arch list as an argument and compares with existing arch.

Tested with docker image-
registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16420_ubuntu22.04_py3.10_pytorch_lw_rocm7.0_internal_testing_2d567672
