### PR TITLE
Fix warnings issue in test_tensor_with_grad_to_scalar_warning

### DIFF
--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -43,7 +43,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     skipIfRocm, skipIfNoSciPy, TemporaryFileName, TemporaryDirectoryName,
     wrapDeterministicFlagAPITest, DeterministicGuard, CudaSyncGuard,
     bytes_to_scalar, parametrize, skipIfMPS, noncontiguous_like,
-    AlwaysWarnTypedStorageRemoval, TEST_WITH_TORCHDYNAMO, xfailIfTorchDynamo)
+    AlwaysWarnTypedStorageRemoval, TEST_WITH_TORCHDYNAMO, xfailIfTorchDynamo, set_warn_always_context)
 from multiprocessing.reduction import ForkingPickler
 from torch.testing._internal.common_device_type import (
     expectedFailureMeta,
@@ -10830,8 +10830,8 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
         self.assertFalse(torch.cuda.is_bf16_supported())
 
     def test_tensor_with_grad_to_scalar_warning(self) -> None:
-
-        with warnings.catch_warnings(record=True) as w:
+        with (warnings.catch_warnings(record=True) as w,
+                set_warn_always_context(True)):
             warnings.simplefilter("always")
 
             x = torch.tensor(2.0, requires_grad=True)
@@ -10843,9 +10843,6 @@ tensor([[[1.+1.j, 1.+1.j, 1.+1.j,  ..., 1.+1.j, 1.+1.j, 1.+1.j],
                 "Converting a tensor with requires_grad=True to a scalar may lead to unexpected behavior.",
                 str(w[0].message)
             )
-
-            _ = math.pow(x, 3)  # calling it again does not result in a second warning
-            self.assertEqual(len(w), 1)
 
 # The following block extends TestTorch with negative dim wrapping tests
 # FIXME: replace these with OpInfo sample inputs or systemic OpInfo tests


### PR DESCRIPTION
This PR is to cherry-pick test_torch.py changes from upstream [22d1359](https://github.com/pytorch/pytorch/commit/22d1359bc6b2316ee77ee134bfb258b4fa9ab643). 

This fixes the below error:
```
_____________________________________________________________________________ TestTorch.test_tensor_with_grad_to_scalar_warning ______________________________________________________________________________
Traceback (most recent call last):
  File "/root/PR/pytorch/test/test_torch.py", line 10849, in test_tensor_with_grad_to_scalar_warning
    self.assertEqual(len(w), 1)
  File "/opt/venv/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py", line 4114, in assertEqual
    raise error_metas.pop()[0].to_error(  # type: ignore[index]
AssertionError: Scalars are not equal!

Expected 1 but got 2.
Absolute difference: 1
Relative difference: 1.0

To execute this test, run the following from the base repo dir:
    python test/test_torch.py TestTorch.test_tensor_with_grad_to_scalar_warning

This message can be suppressed by setting PYTORCH_PRINT_REPRO_ON_FAILURE=0
```

This fixes https://ontrack-internal.amd.com/browse/SWDEV-532432