### PR TITLE
[release/2.7][ROCm][tunableop] UT tolerance increase for matmul_small_brute_force_…

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -4704,6 +4704,7 @@ class TestLinalg(TestCase):
     @onlyCUDA
     @skipCUDAIfNotRocm  # Skipping due to SM89 OOM in CI, UT doesn't do much on NV anyways
     @dtypes(*floating_types_and(torch.half))
+    @precisionOverride({torch.float16: 1e-1})  # TunableOp may occasionally find less precise solution
     def test_matmul_small_brute_force_tunableop(self, device, dtype):
         # disable tunableop buffer rotation for all tests everywhere, it can be slow
         # We set the TunableOp numerical check environment variable here because it is


### PR DESCRIPTION
TunableOp will sometimes find a less precise solution due to the small input vectors used in this UT. Bumping up tolerance to eliminate flakiness.

Pull Request resolved: https://github.com/pytorch/pytorch/pull/158788
Approved by: https://github.com/jeffdaily

(cherry picked from commit c917c63282c467ef942c99da3ce4fa57bceba603)

