### PR TITLE
Revert "[release/2.6] Change gfx110x BLAS preferred backend (Take 2) (#2158)"

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -193,7 +193,7 @@ static bool isSupportedHipLtROCmArch(int index) {
     static const std::vector<std::string> archs = {
         "gfx90a", "gfx942"
 #if ROCM_VERSION >= 60300
-        , "gfx1200", "gfx1201"
+        , "gfx1100", "gfx1101", "gfx1200", "gfx1201"
 #endif
 #if ROCM_VERSION >= 60500
         , "gfx950"


### PR DESCRIPTION

## Description
- This reverts commit 5de86ce8b693d40faddf26e2eba7d660f3af68c7.

## Motivation and Context
- Fixes performance drop for Bert model inference and train workloads. hipBLASLt is not preferred but it is supported on gfx1100 and gfx1101.