### PR TITLE
Revert "Change gfx110x BLAS preferred backend"

### DIFF
--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -259,7 +259,7 @@ static bool isSupportedHipLtROCmArch(int index) {
     static const std::vector<std::string> archs = {
         "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60300
-        "gfx1200", "gfx1201",
+        "gfx1100", "gfx1101", "gfx1200", "gfx1201"
 #endif
 #if ROCM_VERSION >= 60500
         "gfx950"

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -259,7 +259,7 @@ static bool isSupportedHipLtROCmArch(int index) {
     static const std::vector<std::string> archs = {
         "gfx90a", "gfx942",
 #if ROCM_VERSION >= 60300
-        "gfx1100", "gfx1101", "gfx1200", "gfx1201"
+        "gfx1100", "gfx1101", "gfx1200", "gfx1201",
 #endif
 #if ROCM_VERSION >= 60500
         "gfx950"


### PR DESCRIPTION

## Description
- This reverts commit [9030e36](https://github.com/ROCm/pytorch/commit/9030e36161d13711437de5e593bb851241f766da).

## Motivation and Context
- Fixes performance drop for Bert model inference and train workloads. hipBLASLt is not preferred but it is supported on gfx1100 and gfx1101.