### PR TITLE
[AUTOGENERATED] [release/2.6] [release/2.5] Skipped *_stress_cuda UTs in test_c10d_gloo

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -52,6 +52,7 @@ from torch.testing._internal.common_utils import (
     retry_on_connect_failures,
     run_tests,
     skip_but_pass_in_sandcastle,
+    skipIfRocm,
     TestCase,
 )
 
@@ -385,6 +386,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i * self.world_size + self.rank]) for i in range(1000)]
         self._test_broadcast_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_broadcast_stress_cuda(self):
@@ -490,6 +492,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_allreduce_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_allreduce_stress_cuda(self):
@@ -922,6 +925,8 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
     @skip_but_pass_in_sandcastle(
         "Test is flaky, see https://github.com/pytorch/pytorch/issues/15963"
     )
+
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_scatter_stress_cuda(self):
@@ -1096,6 +1101,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_gather_stress(inputs, lambda t: t.clone())
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_gather_stress_cuda(self):
@@ -1231,6 +1237,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_allgather_stress(inputs, lambda t: t.clone())
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_allgather_stress_cuda(self):
@@ -1417,6 +1424,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_reduce_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_reduce_stress_cuda(self):


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2317 