### PR TITLE
[AUTOGENERATED] [release/2.7] Skipped *_stress_cuda UTs in test_c10d_gloo

### DIFF
--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -53,7 +53,11 @@ from torch.testing._internal.common_utils import (
     retry_on_connect_failures,
     run_tests,
     skip_but_pass_in_sandcastle,
+<<<<<<< HEAD
     skipIfRocmArch,
+=======
+    skipIfRocm,
+>>>>>>> 2269e37502 (Skipped *_stress_cuda UTs in test_c10d_gloo in release/2.5 branch. (#2317))
     TestCase,
 )
 
@@ -387,6 +391,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i * self.world_size + self.rank]) for i in range(1000)]
         self._test_broadcast_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_broadcast_stress_cuda(self):
@@ -492,6 +497,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_allreduce_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_allreduce_stress_cuda(self):
@@ -924,6 +930,8 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
     @skip_but_pass_in_sandcastle(
         "Test is flaky, see https://github.com/pytorch/pytorch/issues/15963"
     )
+
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_scatter_stress_cuda(self):
@@ -1098,6 +1106,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_gather_stress(inputs, lambda t: t.clone())
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @skipIfRocmArch(MI300_ARCH)
     @requires_gloo()
@@ -1234,6 +1243,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_allgather_stress(inputs, lambda t: t.clone())
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_allgather_stress_cuda(self):
@@ -1420,6 +1430,7 @@ class ProcessGroupGlooTest(MultiProcessTestCase):
         inputs = [torch.tensor([i + self.rank]) for i in range(1000)]
         self._test_reduce_stress(inputs)
 
+    @skipIfRocm
     @skip_if_lt_x_gpu(2)
     @requires_gloo()
     def test_reduce_stress_cuda(self):

--- a/test/distributed/test_c10d_gloo.py
+++ b/test/distributed/test_c10d_gloo.py
@@ -53,11 +53,8 @@ from torch.testing._internal.common_utils import (
     retry_on_connect_failures,
     run_tests,
     skip_but_pass_in_sandcastle,
-<<<<<<< HEAD
     skipIfRocmArch,
-=======
     skipIfRocm,
->>>>>>> 2269e37502 (Skipped *_stress_cuda UTs in test_c10d_gloo in release/2.5 branch. (#2317))
     TestCase,
 )
 


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2317 
Need to resolve conflicts