### PR TITLE
[NO CP] skip inductor tests on MI35x

### DIFF
--- a/test/inductor/test_aot_inductor.py
+++ b/test/inductor/test_aot_inductor.py
@@ -5227,6 +5227,11 @@ GPU_TEST_FAILURES = {
     "test_fft_c2c": fail_gpu(("xpu",), is_skip=True),
     "test_stft": fail_gpu(("xpu",)),
 }
+if TEST_WITH_ROCM:
+    prop = torch.cuda.get_device_properties(0)
+    gcnArchName = prop.gcnArchName.split(":")[0]
+    if "gfx95" in gcnArchName:
+        GPU_TEST_FAILURES["test_stft"] = fail_gpu(("cuda", "xpu")) # override "test_stft" for MI35x also
 
 
 class AOTInductorTestABICompatibleCpu(TestCase):

--- a/test/inductor/test_gpu_cpp_wrapper.py
+++ b/test/inductor/test_gpu_cpp_wrapper.py
@@ -7,7 +7,7 @@ from typing import NamedTuple
 import torch
 from torch._inductor import config
 from torch._inductor.test_case import TestCase as InductorTestCase
-from torch.testing._internal.common_utils import slowTest
+from torch.testing._internal.common_utils import TEST_WITH_ROCM, slowTest
 from torch.testing._internal.inductor_utils import GPU_TYPE, RUN_GPU
 
 
@@ -308,6 +308,16 @@ if RUN_GPU:
             test_failures_gpu_wrapper[
                 f"{test_name}_gpu_dynamic_shapes"
             ] = test_torchinductor.TestFailure(("gpu_wrapper",), is_skip=True)
+
+    if TEST_WITH_ROCM:
+        prop = torch.cuda.get_device_properties(0)
+        gcnArchName = prop.gcnArchName.split(":")[0]
+        if "gfx95" in gcnArchName:
+            skip_list = ["test_mm_plus_mm2"]
+            for test_name in skip_list:
+                test_failures_gpu_wrapper[
+                    f"{test_name}"
+                ] = test_torchinductor.TestFailure(("gpu_wrapper",), is_skip=True)
 
     test_torchinductor.copy_tests(
         GpuWrapperTemplate, TestGpuWrapper, "gpu_wrapper", test_failures_gpu_wrapper


### PR DESCRIPTION
Skip inductor tests on MI35x:

- inductor/test_gpu_cpp_wrapper.py::TestGpuWrapper::test_mm_plus_mm2_gpu_wrapper
- inductor/test_aot_inductor.py::AOTInductorTestABICompatibleGpu::test_stft_cuda

Tests cannot be skipped in the usual way with @skipIf decorator

Tests are failing on MI35x with `AssertionError` in `rocm7.0_internal_testing` branch
And with `torch.AcceleratorError: HIP error: invalid device function` in `release/2.8`

Fixes SWDEV-542678

```
python inductor/test_gpu_cpp_wrapper.py -v -k test_mm_plus_mm2_gpu_wrapper
...
OK (skipped=1)

python inductor/test_aot_inductor.py -v -k test_stft_cuda
...
OK (expected failures=1)
```