### PR TITLE
[rocm7.0_internal_testing] mx fpx: Skip test_blockwise_mxfloatx

### DIFF
--- a/test/test_matmul_cuda.py
+++ b/test/test_matmul_cuda.py
@@ -1382,6 +1382,7 @@ class TestFP8Matmul(TestCase):
             sqnr = compute_error(C_ref, C)
             assert sqnr.item() > approx_match_sqnr_target
 
+    @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_FP8 or IS_WINDOWS, f8_msg)
     @parametrize("recipe", ["mxfp8", "nvfp4"])
     def test_blockwise_mxfp8_nvfp4_error_messages(self, device, recipe) -> None:
@@ -1615,6 +1616,7 @@ class TestFP8Matmul(TestCase):
         )
         torch.testing.assert_close(C, C_ref, atol=0, rtol=0)
 
+    @skipIfRocm
     @unittest.skipIf(not PLATFORM_SUPPORTS_MX_GEMM, mx_skip_msg)
     def test_blockwise_nvfp4_compile(self) -> None:
 


### PR DESCRIPTION
Issue is tracked by SWDEV-535267

This PR skips two test methods (test_blockwise_mxfp8_nvfp4_error_messages and test_blockwise_nvfp4_compile) when running on ROCm platform to address an issue tracked by SWDEV-535267.

- Adds @skipIfRocm decorators to skip tests that are failing on ROCm 7.0 internal testing
- Targets specific matrix multiplication tests related to MX float formats


