### PR TITLE
[release/2.7] Fix test_rnn_check_device tests for P1 Jira SWDEV-542659

### DIFF
--- a/aten/src/ATen/miopen/Descriptors.h
+++ b/aten/src/ATen/miopen/Descriptors.h
@@ -120,12 +120,11 @@ struct TORCH_CUDA_CPP_API ConvolutionDescriptor
   }
 };
 
-// NOLINTNEXTLINE(bugprone-exception-escape)
-struct TORCH_CUDA_CPP_API DropoutDescriptor
-    : public Descriptor<
-          miopenDropoutDescriptor,
-          &miopenCreateDropoutDescriptor,
-          &miopenDestroyDropoutDescriptor> {
+struct DropoutDescriptor
+  : public Descriptor<miopenDropoutDescriptor,
+                      &miopenCreateDropoutDescriptor,
+                      &miopenDestroyDropoutDescriptor>
+{
     void set(miopenHandle_t handle, float dropout, void* states, size_t stateSizeInBytes,
              unsigned long long seed, bool use_mask, bool state_evo, miopenRNGType_t rng_mode) {
       MIOPEN_CHECK(miopenSetDropoutDescriptor(mut_desc(), handle, dropout, states, stateSizeInBytes, seed, use_mask, state_evo, rng_mode));
@@ -143,8 +142,13 @@ struct TORCH_CUDA_CPP_API RNNDescriptor
                       &miopenDestroyRNNDescriptor>
 {
     void set(int64_t hidden_size, int64_t num_layers, miopenRNNInputMode_t input_mode, miopenRNNDirectionMode_t direction, miopenRNNMode_t rnn_mode,
-              miopenRNNBiasMode_t bias_mode, miopenRNNAlgo_t algorithm, miopenDataType_t datatype) {
+             miopenRNNBiasMode_t bias_mode, miopenRNNAlgo_t algorithm, miopenDataType_t datatype) {
       MIOPEN_CHECK(miopenSetRNNDescriptor(mut_desc(), hidden_size, num_layers, input_mode, direction, rnn_mode, bias_mode, algorithm, datatype));
+    }
+
+    void setWithDropout(DropoutDescriptor& dropout_desc, int64_t hidden_size, int64_t num_layers, miopenRNNInputMode_t input_mode, miopenRNNDirectionMode_t direction,
+                        miopenRNNMode_t rnn_mode, miopenRNNBiasMode_t bias_mode, miopenRNNAlgo_t algorithm, miopenDataType_t datatype) {
+      MIOPEN_CHECK(miopenSetRNNDescriptor_V2(mut_desc(), hidden_size, num_layers, dropout_desc.mut_desc(), input_mode, direction, rnn_mode, bias_mode, algorithm, datatype));
     }
 };
 

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3913,7 +3913,8 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         hidden_c_shape = update_shape(correct_hidden_c_shape, 0, bad_size)
         test(input_shape, hidden_h_shape, hidden_c_shape)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
+    @unittest.skipIf(not TEST_MULTIGPU, "single-GPU not supported")
+    @unittest.skipIf(TEST_MULTIGPU, "multi-GPU not supported")
     def test_rnn_check_device(self):
         import copy
         input_size = 3

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -3913,8 +3913,7 @@ tensor(..., device='meta', size=(1,), requires_grad=True)""")
         hidden_c_shape = update_shape(correct_hidden_c_shape, 0, bad_size)
         test(input_shape, hidden_h_shape, hidden_c_shape)
 
-    @unittest.skipIf(not TEST_MULTIGPU, "single-GPU not supported")
-    @unittest.skipIf(TEST_MULTIGPU, "multi-GPU not supported")
+    @unittest.skipIf(not TEST_MULTIGPU, "multi-GPU not supported")
     def test_rnn_check_device(self):
         import copy
         input_size = 3


### PR DESCRIPTION
This PR has fixes for P1 Jira https://ontrack-internal.amd.com/browse/SWDEV-542659.
In this Jira, there are 3 test files with failing tests.
1) distributed.test_distributed_spawn
2) test_binary_ufuncs
3) test_nn 

The test files **distributed.test_distributed_spawn** & **test_binary_ufuncs** are passing with latest mainline build-
 **registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16426_ubuntu22.04_py3.10_pytorch_lw_release-2.7_fe3d37a9**.

The test file **test_nn** has 2 failing tests- **test_batchnorm_3D_train_NCHW_vs_native_mixed_float16** & **test_RNN_dropout_state**. 
The **test_batchnorm_3D_train_NCHW_vs_native_mixed_float16** test is skipped from PR https://github.com/ROCm/pytorch/pull/2370.
The **test_RNN_dropout_state** is fixed by cherry picking upstream commit 1aa971a.

Tested on MI200 with docker image-
 **registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16426_ubuntu22.04_py3.10_pytorch_lw_release-2.7_fe3d37a9**.
