### PR TITLE
[ROCm6.4_internal_testing] Using c10d.barrier() in test_extra_cuda_context test in test_c10d_nccl.py

### DIFF
--- a/test/distributed/test_c10d_nccl.py
+++ b/test/distributed/test_c10d_nccl.py
@@ -589,15 +589,17 @@ class ProcessGroupNCCLGroupTest(MultiProcessTestCase):
         """
         device = torch.device("cuda:%d" % self.rank)
         x = torch.empty((1,), device=device)
+
+        # We need this barrier to ensure that all nodes have completed init_process_group
+        # If rank=0 gets a mem snapshot before other nodes have finished init_process_group,
+        # then we artificially see a bump in memory usage. As per the following comment,
+        # we are going to be moving away from this function:
+        # https://github.com/pytorch/pytorch/pull/154174#discussion_r2105065931
+        c10d.barrier()
+
         # Rank 0 takes a snapshot before collective -- this snapshot should have
         # included rank 0's own context.
         if self.rank == 0:
-            # We need this extra sleep for NAVI_ARCH because rccl_init inside init_process_group 
-            # is happening in a separate process and it is taking longer to finish on NAVI_ARCH. 
-            # Sleeping here ensures that the init is competed successfully and mem_get_info can 
-            # get stable numbers.
-            if is_arch(NAVI_ARCH):
-                time.sleep(5)
             free, total = torch.cuda.mem_get_info(device)
             used_before = float(total - free)
 


### PR DESCRIPTION
In this PR, I have removed a change made in commit 71a21d9 for test_extra_cuda_context test in test_c10d_nccl.py. Instead using c10d.barrier() to ensure that all nodes have completed init_process_group.

We need this barrier to ensure that all nodes have completed init_process_group if rank=0 gets a mem snapshot before other nodes have finished init_process_group, then we artificially see a bump in memory usage. As per the following comment, we are going to be moving away from this function: https://github.com/pytorch/pytorch/pull/154174#discussion_r2105065931

Tested by building pytorch and running test_extra_cuda_context test with docker image: compute-**artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-rel-6.4:125_ubuntu24.04_py3.12_pytorch_rocm6.4_internal_testing_71a21d9**