### PR TITLE
Fix issues with merge conflicts

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -81,7 +81,8 @@
 [submodule "third_party/tensorpipe"]
     ignore = dirty
     path = third_party/tensorpipe
-    url = https://github.com/pytorch/tensorpipe.git
+    url = https://github.com/ROCm/tensorpipe.git
+    branch = tp_rocm_60
 [submodule "third_party/cudnn_frontend"]
 	path = third_party/cudnn_frontend
 	url = https://github.com/NVIDIA/cudnn-frontend.git

--- a/aten/src/ATen/native/cuda/Blas.cpp
+++ b/aten/src/ATen/native/cuda/Blas.cpp
@@ -1205,7 +1205,6 @@ std::pair<ScalingType, ScalingType> get_joint_scaling(
 
 } // namespace
 
-
 // Computes matrix multiply + bias while applying scaling to input and output matrices
 // Scales are only applicable when matrices are of Float8 type and assumed to be equal to 1.0 by default.
 // If output matrix type is 16 or 32-bit type, scale_result is not applied.
@@ -1362,25 +1361,9 @@ _scaled_mm_out_cuda(const Tensor& mat1, const Tensor& mat2,
     else {
       TORCH_CHECK(b.dtype() == at::kFloat8_e4m3fn);
     }
-    // Until more than bf16 is supported
+    // Until more than bf16 is supported.
     TORCH_CHECK(out.scalar_type() == ScalarType::BFloat16,
-         "hipblaslt rowwise _scaled_mm only supports BFloat16 output");
-  }
-  else if (scaling_choice == ScalingType::BlockWise) {
-#if ROCM_VERSION >= 70000
-    TORCH_CHECK(at::detail::getCUDAHooks().isGPUArch({"gfx950"}),
-               "Block-wise scaling for Float8_e8m0fnu is only supported on gfx950");
-
-    TORCH_CHECK(mat1.size(0) % 32 == 0 && mat1.size(1) % 32 == 0 &&
-               mat2.size(0) % 32 == 0 && mat2.size(1) % 32 == 0,
-               "Matrix dimensions must be multiples of 32 for block-wise scaling");
-
-    TORCH_CHECK(out.scalar_type() == ScalarType::BFloat16 ||
-                out.scalar_type() == ScalarType::Half,
-                "Block-wise scaling only supports BFloat16 or Half output types");
-#else
-    TORCH_CHECK(false, "Block-wise scaling for Float8_e8m0fnu requires ROCm 7.0 or later");
-#endif
+         "hipblaslt rowwise _scaled_mm only supports BFloat16 output but got ", out.scalar_type());
   }
 #endif
 

--- a/aten/src/ATen/test/cuda_vectorized_test.cu
+++ b/aten/src/ATen/test/cuda_vectorized_test.cu
@@ -27,23 +27,6 @@ void reset_buffers() {
   }
 }
 
-#if defined(USE_ROCM) && !defined(_WIN32)
-TEST(TestLoops, HasSameArgTypes) {
-  // This is a compile-time unit test. If this file compiles without error,
-  // then the test passes and during runtime, we just need to return.
-  using namespace at::native::modern::detail;
-  using func1_t = int (*)(float, float);
-  using func2_t = int (*)(bool, float, float);
-  using func3_t = int (*)(float);
-  using func4_t = int (*)();
-  static_assert(has_same_arg_types<func1_t>::value, "func1_t has the same argument types");
-  static_assert(!has_same_arg_types<func2_t>::value, "func2_t does not have the same argument types");
-  static_assert(has_same_arg_types<func3_t>::value, "func3_t has the same argument types");
-  static_assert(has_same_arg_types<func4_t>::value, "func4_t has the same argument types");
-  return;
-}
-#endif
-
 TEST(TestVectorizedMemoryAccess, CanVectorizeUpTo) {
   char *ptr = reinterpret_cast<char *>(buffer1);
 

--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -81,7 +81,7 @@ if(NOT __AOTRITON_INCLUDED)
     list(GET __AOTRITON_MANYLINUX_LIST ${__AOTRITON_ROCM_INDEX} __AOTRITON_MANYLINUX)
     set(__AOTRITON_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
     string(CONCAT __AOTRITON_FILE "aotriton-"
-                                  "${__AOTRITON_VER_WITH_COMMIT}-${__AOTRITON_MANYLINUX}"
+                                  "${__AOTRITON_VER}-${__AOTRITON_MANYLINUX}"
                                   "_${__AOTRITON_ARCH}-rocm${__AOTRITON_ROCM}"
                                   "-shared.tar.${__AOTRITON_Z}")
     string(CONCAT __AOTRITON_URL "https://github.com/ROCm/aotriton/releases/download/"  # @lint-ignore

--- a/torch/headeronly/macros/Export.h
+++ b/torch/headeronly/macros/Export.h
@@ -100,10 +100,10 @@
 #define TORCH_API C10_IMPORT
 #endif
 
-// You may be wondering why we have TORCH_CUDA_CPP_API and TORCH_CUDA_CU_API
+// You may be wondering why we have TORCH_HIP_CPP_API and TORCH_HIP_API
 // belonging to the same library instead of just one TORCH_CUDA_API. Well, it
-// can indeed just be one TORCH_CUDA_API (and used to be)! TORCH_CUDA_CPP_API
-// and TORCH_CUDA_CU_API are artifacts of when we needed a split build to
+// can indeed just be one TORCH_CUDA_API (and used to be)! TORCH_HIP_CPP_API
+// and TORCH_HIP_API are artifacts of when we needed a split build to
 // avoid relocation marker linking errors. The context is as follows:
 //
 // Once upon a time, there _was_ only TORCH_CUDA_API. All was happy until we
@@ -130,14 +130,6 @@
 #define TORCH_CUDA_CU_API C10_IMPORT
 #endif
 
-#if defined(TORCH_HIP_BUILD_MAIN_LIB)
-#define TORCH_HIP_CPP_API C10_EXPORT
-#define TORCH_HIP_API C10_EXPORT
-#else
-#define TORCH_HIP_CPP_API C10_IMPORT
-#define TORCH_HIP_API C10_IMPORT
-#endif
-
 #if defined(TORCH_XPU_BUILD_MAIN_LIB)
 #define TORCH_XPU_API C10_EXPORT
 #else
@@ -145,7 +137,7 @@
 #endif
 
 // Enums only need to be exported on windows for non-CUDA files
-#if defined(_WIN32) && defined(__CUDACC__)
+#if defined(_WIN32) && defined(__HIPCC__)
 #define C10_API_ENUM C10_API
 #else
 #define C10_API_ENUM


### PR DESCRIPTION
- Fix the tensorpipe branch for ROCm
- External/aotriton.cmake: remove use of __AOTRITON_VER_WITH_COMMIT
- macros/Export.h: remove TORCH_HIP_CPP_API/TORCH_HIP_API as CUDA ones get hipified and converted correctly (need to upstream this)
- CUDALoops.cuh: Bad merge
- Blas.cpp: remove MX patch
- cuda_vectorized_test.cu: remove ROCmloops specific test, this was removed in rocm7.0_internal_testing branch. I had incorrectly addressed the merge conflicts when merging with upstream

Fixes #ISSUE_NUMBER
