### PR TITLE
Typing_extensions requirements.txt fix for 2.7 release with python 3.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,4 @@ requests==2.32.4
 setuptools==75.8.2
 sympy==1.13.3
 types-dataclasses==0.6.6
-typing-extensions==4.10.0
+typing-extensions>=4.10.0


### PR DESCRIPTION
- When typing_extensions==4.10.0 is installed with  rocm/pytorch/2.7 release, 'import torch' will fail
   when python 3.13 is used. This is fixed by allowing to install a never typing_extensions available. After the fix applied, my pytorch build installed the  typing_extensions version 4.14.1 and Pytorch started to work again on on python 3.13.5/ubuntu 22.04/MI300 environment.

- Exact error message from stacktrace:
    
```
    Traceback (most recent call last):
      File "torch_gpu_hello_world.py", line 1, in <module>
        import torch
      File ".venv_sdk/lib/python3.13/site-packages/torch/__init__.py", line 48, in <module>
        from torch._utils import (
        ...<3 lines>...
        )
      File ".venv_sdk/lib/python3.13/site-packages/torch/_utils.py", line 1011, in <module>
        P = ParamSpec("P")
      File ".venv_sdk/lib/python3.13/site-packages/typing_extensions.py", line 1549, in __new__
        _set_default(paramspec, default)
        ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
      File ".venv_sdk/lib/python3.13/site-packages/typing_extensions.py", line 1412, in _set_default
        type_param.__default__ = None
        ^^^^^^^^^^^^^^^^^^^^^^
    AttributeError: attribute '__default__' of 'typing.ParamSpec' objects is not writable

```
Fixes #2474

