### PR TITLE
[release/2.7] repin requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 # Python dependencies required for development
 astunparse==1.6.3
-cmake==4.0.3
+cmake>=3.31.4
 expecttest==0.3.0
 filelock==3.18.0
 fsspec==2025.7.0
 hypothesis==5.35.1
-jinja2
+jinja2==3.1.6
 lintrunner==0.12.7 ; platform_machine != "s390x"
 networkx==2.8.8
 ninja==1.11.1.4
@@ -14,7 +14,7 @@ numpy==2.1.2 ; python_version > "3.9"
 optree==0.13.0
 packaging==25.0
 psutil==7.0.0
-pyyaml
+pyyaml==6.0.2
 requests==2.32.4
 # issue on Windows after >= 75.8.2 - https://github.com/pytorch/pytorch/issues/148877
 setuptools==75.8.2


### PR DESCRIPTION
docker image used: registry-sc-harbor.amd.com/framework/compute-rocm-dkms-no-npi-hipclang:16480_ubuntu22.04_py3.10_pytorch_lw_release-2.7_6c845c6c

lowering requirement for cmake as it is compatible with cmake<4