### PR TITLE
[rocm7.0_internal_testing] Define uint32 t when ROCM_VERSION >= 70000 

### DIFF
--- a/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
@@ -267,6 +267,10 @@ constexpr auto bfloat16_support_literal =
 #define __align__(x) __attribute__((aligned(x)))
 #endif
 
+#if ROCM_VERSION >= 70000
+typedef unsigned int uint32_t;
+#endif
+
 typedef struct __align__(2) {
   unsigned short x;
 }


### PR DESCRIPTION
Fixes SWDEV-543698 (https://ontrack-internal.amd.com/browse/SWDEV-543698)

This PR fixes the errors like below:

```
[rank3]: RuntimeError: The following operation failed in the TorchScript interpreter.
[rank3]: Traceback of TorchScript (most recent call last):
[rank3]: RuntimeError: /tmp/comgr-28f951/input/CompileSourceACC062:67:7: error: unknown type name 'uint32_t'; did you mean '__hip_internal::uint32_t'?
[rank3]:    67 |       uint32_t int32;
[rank3]:       |       ^~~~~~~~
[rank3]:       |       __hip_internal::uint32_t
```

Earlier uint32_t was defined in HIP headers in std namespace. Now it is moved to __hip_internal namespace in hip headers. This change is made in ROCm 7.0.