### PR TITLE
[Release/2.7][SWDEV-544125] update test buffer fudge factor for hipblaslt for test_fully_shard_training_memory test

### DIFF
--- a/test/distributed/_composable/fsdp/test_fully_shard_memory.py
+++ b/test/distributed/_composable/fsdp/test_fully_shard_memory.py
@@ -117,6 +117,9 @@ class TestFullyShardMemory(FSDPTest):
         # number is kept much smaller than the actual memory usage, which is on
         # the order of 100-200+ MB)
         buffer_mb = 16
+        # The default workspace for hipblaslt is larger than for cublas/cublaslt
+        # which requires a slight increase to this buffer value.
+        buffer_mb = 16 if torch.version.cuda else 18
         if reshard_after_forward:
             # 3x max unsharded block parameters (current all-gather + copy-out
             # and next all-gather), non-block parameters, and other


### PR DESCRIPTION
In this PR, I cherry picked upstream commit https://github.com/ROCm/pytorch/commit/78300c82054e7c54dd67aa780fa45b594785a19e.
This fixes the test_fully_shard_training_memory test under /distributed/_composable/fsdp/test_fully_shard_memory.py.
It was a failing test in Jira https://ontrack-internal.amd.com/browse/SWDEV-544125