### PR TITLE
[release/2.6] Change triton package name depending on rocm version

### DIFF
--- a/.github/scripts/build_triton_wheel.py
+++ b/.github/scripts/build_triton_wheel.py
@@ -98,8 +98,12 @@ def build_triton(
         triton_pythondir = triton_basedir / "python"
         triton_repo = "https://github.com/openai/triton"
         if device == "rocm":
-            triton_pkg_name = "pytorch-triton-rocm"
             triton_repo = "https://github.com/ROCm/triton"
+            rocm_version = get_rocm_version()  # e.g., "7.0.1"
+            if tuple(map(int, rocm_version.split("."))) > (7, 0, 0):
+                triton_pkg_name = "triton"
+            else:
+                triton_pkg_name = "pytorch-triton-rocm"
         elif device == "xpu":
             triton_pkg_name = "pytorch-triton-xpu"
             triton_repo = "https://github.com/intel/intel-xpu-backend-for-triton"


### PR DESCRIPTION
Relates to https://github.com/ROCm/builder/pull/91

Release 7.0: http://rocm-ci.amd.com/job/pytorch2.6-manylinux-wheels_rel-7.0/40/
`pytorch_triton_rocm-3.2.0+rocm7.0.0.git20943800-cp313-cp313-linux_x86_64.whl pushed to http://compute-artifactory.amd.com/artifactory/compute-pytorch-rocm/compute-rocm-rel-7.0/6/triton_main_conditionalize/pytorch_triton_rocm-3.2.0+rocm7.0.0.git20943800-cp313-cp313-linux_x86_64.whl`
Mainline: http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels/244/
`triton-3.2.0+rocm7.1.0.git20943800-cp313-cp313-linux_x86_64.whl pushed to http://compute-artifactory.amd.com/artifactory/compute-pytorch-rocm/compute-rocm-dkms-no-npi-hipclang/16516/triton_main_conditionalize/triton-3.2.0+rocm7.1.0.git20943800-cp313-cp313-linux_x86_64.whl`