### PR TITLE
[release/2.7] Added missing MI350_ARCH constant value

### DIFF
--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -104,6 +104,7 @@ except ImportError:
 
 
 MI300_ARCH = ("gfx940", "gfx941", "gfx942")
+MI350_ARCH = ("gfx950")
 NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
 NAVI3_ARCH = ("gfx1100", "gfx1101")
 NAVI4_ARCH = ("gfx1200", "gfx1201")


### PR DESCRIPTION
Fixes test/distributed/tensor/test_matrix_ops.py by defining missing constant value
