### PR TITLE
[release/2.7] Skip CompileTest in `test_c10d_functional_native.py`

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -691,6 +691,7 @@ class PyWorkTest(TestCase):
         self.assertEqual(pg.dels, 4)
 
 
+@skipIfRocm
 class CompileTest(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
These UTs are working in future releases (rocm7.1_internal_testing)
Fixes SWDEV-535015
