### PR TITLE
[AUTOGENERATED] [release/2.8] [release/2.7] Skip CompileTest in `test_c10d_functional_native.py`

### DIFF
--- a/test/distributed/test_c10d_functional_native.py
+++ b/test/distributed/test_c10d_functional_native.py
@@ -713,6 +713,7 @@ class PyWorkTest(TestCase):
         self.assertEqual(pg.dels, 4)
 
 
+@skipIfRocm
 class CompileTest(TestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
Cherry-pick of https://github.com/ROCm/pytorch/pull/2523 