### PR TITLE
[Test][Easy] Use float16 dtype in test_sort_large (#159939)

### DIFF
--- a/test/test_sort_and_select.py
+++ b/test/test_sort_and_select.py
@@ -215,7 +215,7 @@ class TestSortAndSelect(TestCase):
             )
 
     @onlyCUDA
-    @dtypes(torch.uint8)
+    @dtypes(torch.float16)
     @largeTensorTest("200GB")  # Unfortunately 80GB A100 is not large enough
     def test_sort_large(self, device, dtype):
         t0 = torch.randperm(8192, device=device).to(dtype)


### PR DESCRIPTION
The test fails with:
>RuntimeError: var_mean only support floating point and complex dtypes

Fixes SWDEV-526432
