### PR TITLE
[release/2.6] Remove tb-nightly

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -312,7 +312,7 @@ z3-solver==4.12.2.0
 #Pinned versions:
 #test that import:
 
-tensorboard==2.18.0
+tensorboard==2.19.0
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -256,11 +256,6 @@ scipy==1.14.1 ; python_version > "3.9"
 #Pinned versions:
 #test that import:
 
-tb-nightly==2.13.0a20230426
-#Description: TensorBoard
-#Pinned versions:
-#test that import:
-
 tlparse==0.3.25
 #Description: parse logs produced by torch.compile
 #Pinned versions:
@@ -312,7 +307,7 @@ z3-solver==4.12.2.0
 #Pinned versions:
 #test that import:
 
-tensorboard==2.19.0
+tensorboard==2.18.0
 #Description: Also included in .ci/docker/requirements-docs.txt
 #Pinned versions:
 #test that import: test_tensorboard


### PR DESCRIPTION
Fixes https://ontrack-internal.amd.com/browse/SWDEV-541809
test runs:
```
root@rocm-framework-47:/var/lib/jenkins/pytorch/test# python test_monitor.py -m 'not serial' --shard-id=1 --num-shards=1 -v -vv -rfEX -p no:xdist --use-pytest -x --import-slow-tests --import-disabled-tests
/opt/venv/lib/python3.10/site-packages/torch/testing/_internal/common_utils.py:1221: UserWarning: disabled test file provided but not found: .pytorch-disabled-tests.json
  warnings.warn(f'disabled test file provided but not found: {DISABLED_TESTS_FILE}')
============================================================================================ test session starts =============================================================================================
platform linux -- Python 3.10.12, pytest-7.3.2, pluggy-1.6.0 -- /opt/venv/bin/python
cachedir: .pytest_cache
hypothesis profile 'dev' -> database=None, max_examples=10, suppress_health_check=[HealthCheck.too_slow]
rootdir: /var/lib/jenkins/pytorch
configfile: pytest.ini
plugins: flakefinder-1.1.0, hypothesis-5.35.1, xdoctest-1.1.0, subtests-0.13.1, rerunfailures-14.0, cpp-2.3.0, xdist-3.3.1, typeguard-4.3.0
collected 6 items
Running 6 items in this shard

test_monitor.py::TestMonitor::test_event_handler PASSED [0.4558s]                                                                                                                                      [ 16%]
test_monitor.py::TestMonitor::test_fixed_count_stat PASSED [0.0029s]                                                                                                                                   [ 33%]
test_monitor.py::TestMonitor::test_interval_stat PASSED [0.0030s]                                                                                                                                      [ 50%]
test_monitor.py::TestMonitor::test_log_event PASSED [0.0019s]                                                                                                                                          [ 66%]
test_monitor.py::TestMonitor::test_wait_counter PASSED [0.0018s]                                                                                                                                       [ 83%]
test_monitor.py::TestMonitorTensorboard::test_event_handler PASSED [0.1933s]                                                                                                                           [100%]

============================================================================================= 6 passed in 0.70s ==============================================================================================
root@rocm-framework-47:/var/lib/jenkins/pytorch/test#

```

http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels/254/

http://rocm-ci.amd.com/job/mainline-pytorch2.6-manylinux-wheels/255/