### PR TITLE
Remove unnecessary threadfence in reduction

### DIFF
--- a/aten/src/ATen/native/cuda/Reduce.cuh
+++ b/aten/src/ATen/native/cuda/Reduce.cuh
@@ -799,7 +799,6 @@ struct ReduceOp {
       reduce_buffer[offset] = value;
     }
 
-    __threadfence(); // make sure writes are globally visible
     __syncthreads(); // if multiple warps in this block wrote to staging, make sure they're all done
     bool is_last_block_done = mark_block_finished();
 


### PR DESCRIPTION
cherry-pick of https://github.com/pytorch/pytorch/pull/160979

* The global reduction path in reduction kernel currently has two threadfence operation
* The first threadfence is executed by all threads in all the blocks, whereas the second threadfence is only run by threads in a single block
* The first threadfence is unnecessary, since we need the memory ordering to be enforced only after we pick the thread block for global reduction
* For AMD gpus, threadfence is a heavy weight operation, esp. when run by all the threads in the system
* So, removing the first threadfence gives significant performance boost for AMD gpus.
* The perf boost for Nvidia gpus is minimal, since threadfence is a light weight operation

Co-author: @amd-hhashemi

**Reproducer**:
```import time
import torch

shapes = [(2, 896, 59, 91),
]

dims = [(2, 3),
]

for i, shape in enumerate(shapes):
    x = torch.randn(shape, device='cuda', dtype=torch.bfloat16)
    x = x.to(memory_format=torch.channels_last)
    for _ in range(20):
        _ = torch.sum(x, dims[i], keepdim=True, dtype=torch.bfloat16)
    torch.cuda.synchronize()

    start_evt = torch.cuda.Event(enable_timing=True)
    end_evt = torch.cuda.Event(enable_timing=True)
    start_evt.record()
    for _ in range(100):
        _ = torch.sum(x, dims[i], keepdim=True, dtype=torch.bfloat16)
    end_evt.record()
    torch.cuda.synchronize()
    print(f"Avg time for shape {shape}: {start_evt.elapsed_time(end_evt) / 100 * 1e3:.2f} us")
```

**Results (MI300X)**:
```
Before:
Avg time for shape (2, 896, 59, 91): 85.35 us

After:
Avg time for shape (2, 896, 59, 91): 50.85 us
```

Fixes SWDEV-545710
