### PR TITLE
Converted input to contiguous input in mkl fft

### DIFF
--- a/aten/src/ATen/native/mkl/SpectralOps.cpp
+++ b/aten/src/ATen/native/mkl/SpectralOps.cpp
@@ -479,6 +479,7 @@ static Tensor& _exec_fft(Tensor& out, const Tensor& self, IntArrayRef out_sizes,
   const auto value_type = c10::toRealValueType(input.scalar_type());
   out.resize_(batched_out_sizes, MemoryFormat::Contiguous);
 
+  input = input.contiguous();
   auto descriptor = _plan_mkl_fft(
       input.strides(), out.strides(), signal_size, input.is_complex(),
       out.is_complex(), normalization, forward, value_type);


### PR DESCRIPTION
Fixes functorch/test_ops.py failures in rocm7.0_internal_testing branch
RuntimeError: MKL FFT error: Intel oneMKL DFTI ERROR: Inconsistent configuration parameters
test_grad_fft_fft2_cpu_float32
test_grad_fft_fft_cpu_float32
test_grad_fft_fftn_cpu_float32
test_grad_fft_hfft2_cpu_float32
test_grad_fft_hfft_cpu_float32
test_grad_fft_hfftn_cpu_float32
test_grad_fft_ifft2_cpu_float32
test_grad_fft_ifftn_cpu_float32
test_grad_fft_ihfft2_cpu_float32
test_grad_fft_ihfftn_cpu_float32
test_grad_fft_irfft2_cpu_float32
test_grad_fft_irfft_cpu_float32
test_grad_fft_irfftn_cpu_float32
test_grad_stft_cpu_float32

Inspired by un-merged upstream PR: https://github.com/pytorch/pytorch/pull/143894
Rebuilt PyTorch and tested locally: all tests run fine after the fix.
