### PR TITLE
[release/2.6] Suppress Python UserWarnings to fix compiler logs test

### DIFF
--- a/test/dynamo/test_logging.py
+++ b/test/dynamo/test_logging.py
@@ -796,6 +796,7 @@ TRACE FX call mul from test_logging.py:N in fn (LoggingTests.test_trace_call_pre
             env = dict(os.environ)
             env["TORCH_LOGS"] = "dynamo"
             env["TORCH_LOGS_OUT"] = file_path
+            env["PYTHONWARNINGS"] = "ignore"
             stdout, stderr = self.run_process_no_exception(
                 """\
 import torch


### PR DESCRIPTION
PR to fix
- dynamo/test_logging.py::LoggingTests::test_logs_out

Test compares a console log with the dynamo output log file.
It failed due to unrelated python UserWarning messages in the console log:
```
/opt/conda/envs/py_3.10/lib/python3.10/site-packages/redis/connection.py:77: UserWarning: redis-py works best with hiredis. Please consider installing
  warnings.warn(msg)
/opt/conda/envs/py_3.10/lib/python3.10/site-packages/z3/z3core.py:5: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
  ```

This PR adds the environment variable `PYTHONWARNINGS="ignore"` when starting the test subprocess to suppress UserWarnings in the output

Fixes SWDEV-526475