### PR TITLE
Reverted of rocprof-sdk integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -87,7 +87,7 @@
 	url = https://github.com/NVIDIA/cudnn-frontend.git
 [submodule "third_party/kineto"]
     path = third_party/kineto
-    url = https://github.com/ROCm/kineto.git
+    url = https://github.com/pytorch/kineto
 [submodule "third_party/pocketfft"]
 	path = third_party/pocketfft
 	url = https://github.com/mreineck/pocketfft


### PR DESCRIPTION
This PR:
Fixes SWDEV-534327
Reverted rocprof-sdk from rocm/kineto to pytorch/kineto; pointing pytorch/kineto commit (https://github.com/pytorch/kineto/tree/5fa4bd8c8fb581a621f72957d0cb11431cc4714f) from https://github.com/ROCm/pytorch/tree/7886773808bda86ee7d47c4eaa39c98c43744872/third_party, which (78867738) is the commit right before rocprof-sdk change in rocm7.0_internal_testing branch.