### PR TITLE
[release/2.10] add mkl

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,6 +1,9 @@
 # Build System requirements
 setuptools==79.0.1
 cmake==4.0.0
+mkl==2024.2.0
+mkl-include==2024.2.0
+mkl-static==2024.2.0
 ninja==1.11.1.4
 numpy==2.1.2
 packaging==25.0


### PR DESCRIPTION
Using the same pinned version as upstream: https://github.com/pytorch/pytorch/blob/main/.ci/docker/common/install_conda.sh#L72

Mkl is required as the LAPACK backend for CPU linalg ops