### PR TITLE
[release/2.12] CI UT fixes

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5045,12 +5045,16 @@ class TestCudaAllocator(TestCase):
             # preemptively rejected with OutOfMemoryError.
             # Both settings must go through _accelerator_setAllocatorSettings so
             # they are read from CUDAAllocatorConfig.
+            fraction = 0.005
             torch._C._accelerator_setAllocatorSettings(
-                "throw_on_cudamalloc_oom:True,per_process_memory_fraction:0.01"
+                f"throw_on_cudamalloc_oom:True,per_process_memory_fraction:{fraction}"
             )
 
+            total_mem = torch.cuda.get_device_properties(0).total_memory
+            # Allocate the allowed threshold + 1 MiB to guarantee rejection
+            alloc_bytes = int(total_mem * fraction) + 1024 * 1024
             with self.assertRaises(torch.cuda.OutOfMemoryError):
-                torch.empty(1024 * 1024 * 1024, dtype=torch.int8, device="cuda")
+                torch.empty(alloc_bytes, dtype=torch.int8, device="cuda")
 
             # Check that rejection counter was incremented
             stats = torch.cuda.memory_stats()

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -3639,6 +3639,7 @@ exit(2)
             model_graphed({"x": real_inputs[0]}), model_control({"x": real_inputs[0]})
         )
 
+    @skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/179961")
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"
     )

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4665,6 +4665,9 @@ class TestCudaAllocator(TestCase):
             pass
         finally:
             torch.cuda.memory._record_memory_history(None)
+            # This test requires to run gc.collec() to fix other memory tests
+            torch.cuda.synchronize()
+            gc.collect()
 
     @unittest.skipIf(
         TEST_CUDAMALLOCASYNC, "setContextRecorder not supported by CUDAMallocAsync"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -65,6 +65,7 @@ from torch.testing._internal.common_utils import (
     freeze_rng_state,
     gcIfJetson,
     get_cycles_per_ms,
+    getRocmVersion,
     instantiate_parametrized_tests,
     IS_ARM64,
     IS_FBCODE,
@@ -4197,6 +4198,9 @@ with torch.cuda.graph(g):
     @unittest.skipIf(not TEST_WITH_ROCM, "not relevant for CUDA testing")
     def test_hip_device_count(self):
         """Validate device_count works with both CUDA/HIP visible devices"""
+        if getRocmVersion() in [(7, 13), (7, 14)]:
+            self.skipTest("Failed on ROCm 7.13 and 7.14 due to rocprof-sdk issue (AIPROFSDK-840) ")
+        
         test_script = """\
 import torch
 import os

--- a/test/test_torch.py
+++ b/test/test_torch.py
@@ -826,8 +826,6 @@ class TestTorchDeviceType(TestCase):
     def test_cpp_warnings_have_python_context(self, device):
         # Creates long string in advance to avoid a too-long Python line
         s = ".+Triggered internally at.+RangeFactories.+"
-        # nvfuser deprecation warning filter
-        warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
 
         def cpp_warn_fn():
             out = torch.empty((5,))
@@ -836,6 +834,8 @@ class TestTorchDeviceType(TestCase):
 
         # Checks eager-mode cpp warning
         with warnings.catch_warnings(record=True) as w:
+            # nvfuser deprecation warning filter
+            warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
             cpp_warn_fn()
             frameinfo = inspect.getframeinfo(inspect.currentframe())
             warning = w[0]
@@ -847,11 +847,15 @@ class TestTorchDeviceType(TestCase):
             # Checks the Python features of the warning
             # Note: the eager mode warning refers to the line in the function
             # that throws the warning.
-            self.assertEqual(frameinfo.lineno - 6, warning.lineno)
+            self.assertEqual(frameinfo.lineno - 8, warning.lineno)
             self.assertEqual(len(w), 1)
 
         # Checks jitted cpp warning
         with warnings.catch_warnings(record=True) as w:
+            # nvfuser deprecation warning filter
+            warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
+            # ignore all deprecation warnings
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
             scripted_cpp_warn_fn = torch.jit.script(cpp_warn_fn)
             scripted_cpp_warn_fn()
             warning = w[0]
@@ -872,6 +876,10 @@ class TestTorchDeviceType(TestCase):
 
         # The jit mimics an eager-mode Python warning in this case
         with warnings.catch_warnings(record=True) as w:
+            # nvfuser deprecation warning filter
+            warnings.filterwarnings("ignore", "torch::jit::fuser::cuda", UserWarning)
+            # ignore all deprecation warnings
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
             scripted_warn_fn = torch.jit.script(warn_fn)
             scripted_warn_fn()
             frameinfo = inspect.getframeinfo(inspect.currentframe())
@@ -880,7 +888,7 @@ class TestTorchDeviceType(TestCase):
             self.assertTrue(re.search('Warning!', str(warning.message)) is not None)
 
             # Checks the Python features of the warning
-            self.assertEqual(frameinfo.lineno - 6, warning.lineno)
+            self.assertEqual(frameinfo.lineno - 10, warning.lineno)
             self.assertEqual(len(w), 1)
 
     # FIXME: move to test_testing

--- a/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
+++ b/torch/csrc/jit/codegen/fuser/cuda/resource_strings.h
@@ -268,8 +268,26 @@ typedef __half half;
 #define BF16_UINT32_DEF ""
 #endif
 
+// NOTE [ ROCm JIT bfloat16 symbol collision ]
+// This file is excluded from hipify (see tools/amd_build/build_amd.py), so it
+// ships its own self-contained __nv_bfloat16 type plus the
+// __float2bfloat16/__bfloat162float conversions for the runtime-compiled fuser
+// kernel. Starting with ROCm 7.x, hiprtc auto-injects a runtime header
+// (hiprtc_runtime.h) that also defines __float2bfloat16 returning
+// __hip_bfloat16. Since C++ cannot overload on return type alone, the two
+// definitions collide. Rather than gate on ROCM_VERSION (a build-time value
+// that does not reliably track whether the *runtime* hiprtc actually provides
+// these symbols), we keep PyTorch's own round-to-nearest-even implementation
+// and rename our private definitions via the preprocessor so they cannot
+// clash. hiprtc's definitions remain (parsed earlier in the translation unit)
+// but go unused. These #defines must stay in effect for the rest of the kernel
+// source -- do NOT #undef them, since the emitted kernel body calls these
+// conversions after this header is spliced in.
 constexpr auto bfloat16_support_literal =
     R"(
+#define __internal_float2bfloat16 __pt_jit_internal_float2bfloat16
+#define __float2bfloat16 __pt_jit_float2bfloat16
+#define __bfloat162float __pt_jit_bfloat162float
 #ifndef __align__
 #define __align__(x) __attribute__((aligned(x)))
 #endif


### PR DESCRIPTION
Fix for known release/2.12 issues:

- test_torch.py::TestTorchDeviceTypeCUDA::test_cpp_warnings_have_python_context_cuda - by warnings filtering
- test_cuda.py::TestCudaAllocator::test_throw_on_cudamalloc_oom - CP from upstream
- test_cuda.py::TestCuda.test_hip_device_count - skipped if rocm is 7.13 or 7.14
- test_cuda.py::TestCuda::test_graph_make_graphed_callables_same_pool - skipped due to hang
- test_cuda.py::TestCudaAllocator::test_memory_compile_regions
- test_cuda.py::TestCudaAllocator::test_memory_plots
- test_cuda.py::TestCudaAllocator::test_memory_plots_free_segment_stack
- test_cuda.py::TestCudaAllocator::test_memory_snapshot
