### PR TITLE
[CI] Nightly: publish pytorch-nightly multi-arch image (torch + source)

### DIFF
--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -58,6 +58,7 @@ jobs:
           ARG PYTORCH_SHA
 
           ENV DEBIAN_FRONTEND=noninteractive
+          ENV PIP_NO_CACHE_DIR=1
 
           RUN apt-get update && apt-get install -y --no-install-recommends \
                 ca-certificates \
@@ -73,7 +74,7 @@ jobs:
 
           # Install the nightly PyTorch wheel plus the ROCm multi-arch runtime/devel/device packages.
           # device-all pulls kernels for every supported gfx target from the whl-multi-arch index.
-          RUN python3 -m pip install --break-system-packages \
+          RUN python3 -m pip install --break-system-packages --no-cache-dir \
                 --index-url "${PACKAGE_INDEX_URL}" \
                 "rocm[libraries,devel,device-all]" \
                 torch torchvision torchaudio
@@ -110,7 +111,7 @@ jobs:
         run: |
           primary="${REGISTRY}/${IMAGE_NAME}:${{ steps.tags.outputs.primary }}"
           dated="${REGISTRY}/${IMAGE_NAME}:${{ steps.tags.outputs.dated }}"
-          docker build \
+          docker build --progress=plain \
             --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
             --build-arg "PACKAGE_INDEX_URL=${PACKAGE_INDEX_URL}" \
             --build-arg "PYTORCH_REPO=${PYTORCH_REPO}" \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -86,17 +86,8 @@ jobs:
                 "rocm[libraries,device-all]" \
                 torch torchvision torchaudio
 
-          RUN ROCM_HOME="$(python - <<'PY'
-          import pathlib
-          import site
-          roots = []
-          for site_dir in site.getsitepackages():
-              roots.extend(sorted(pathlib.Path(site_dir).glob("_rocm_sdk_*")))
-          if not roots:
-              raise SystemExit("Could not locate _rocm_sdk_* under site-packages")
-          print(roots[0])
-          PY
-          )" \
+          RUN ROCM_HOME="$(python -c 'import pathlib, site; roots=[]; [roots.extend(sorted(pathlib.Path(d).glob("_rocm_sdk_*"))) for d in site.getsitepackages()]; print(roots[0] if roots else "")')" \
+              && test -n "${ROCM_HOME}" \
               && ROCM_BIN="${ROCM_HOME}/bin" \
               && { \
                 echo '# ROCm paths discovered from rocm-sdk.'; \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -59,6 +59,8 @@ jobs:
 
           ENV DEBIAN_FRONTEND=noninteractive
           ENV PIP_NO_CACHE_DIR=1
+          # install_rocm.sh uses bash printf %q; Docker's default /bin/sh (dash) rejects it.
+          SHELL ["/bin/bash", "-c"]
 
           RUN apt-get update && apt-get install -y --no-install-recommends \
                 ca-certificates \
@@ -89,7 +91,8 @@ jobs:
                 printf 'export CMAKE_PREFIX_PATH=%q:${CMAKE_PREFIX_PATH:-}\n' "${ROCM_HOME}"; \
                 printf 'export LD_LIBRARY_PATH=%q:${LD_LIBRARY_PATH:-}\n' "${ROCM_HOME}/lib"; \
               } > /etc/rocm_env.sh \
-              && echo "source /etc/rocm_env.sh" >> /etc/bash.bashrc
+              && echo "source /etc/rocm_env.sh" >> /etc/bash.bashrc \
+              && if [[ -e /etc/bashrc ]]; then echo "source /etc/rocm_env.sh" >> /etc/bashrc; fi
 
           RUN mkdir -p /var/lib/jenkins \
               && git clone --filter=blob:none --branch "${PYTORCH_BRANCH}" \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -69,6 +69,7 @@ jobs:
                 ca-certificates \
                 git \
                 kmod \
+                libatomic1 \
                 libgomp1 \
                 libnuma-dev \
                 libc++1 \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -66,6 +66,7 @@ jobs:
                 ca-certificates \
                 git \
                 kmod \
+                libgomp1 \
                 libnuma-dev \
                 libc++1 \
                 libc++abi1 \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -86,8 +86,18 @@ jobs:
                 "rocm[libraries,device-all]" \
                 torch torchvision torchaudio
 
-          RUN ROCM_HOME="$(rocm-sdk path --root)" \
-              && ROCM_BIN="$(rocm-sdk path --bin)" \
+          RUN ROCM_HOME="$(python - <<'PY'
+          import pathlib
+          import site
+          roots = []
+          for site_dir in site.getsitepackages():
+              roots.extend(sorted(pathlib.Path(site_dir).glob("_rocm_sdk_*")))
+          if not roots:
+              raise SystemExit("Could not locate _rocm_sdk_* under site-packages")
+          print(roots[0])
+          PY
+          )" \
+              && ROCM_BIN="${ROCM_HOME}/bin" \
               && { \
                 echo '# ROCm paths discovered from rocm-sdk.'; \
                 printf 'export ROCM_PATH=%q\n' "${ROCM_HOME}"; \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -12,7 +12,7 @@ on:
       package_index_url:
         description: "Python wheel index for torch + ROCm multi-arch packages"
         type: string
-        default: "https://rocm.nightlies.amd.com/whl-multi-arch/"
+        default: "https://download.pytorch.org/whl/nightly/rocm7.14/"
       push_tag:
         description: "Primary Docker Hub tag"
         type: string
@@ -26,7 +26,7 @@ env:
   IMAGE_NAME: rocm/pytorch-nightly
   PYTORCH_REPO: pytorch/pytorch
   PYTORCH_BRANCH: ${{ inputs.pytorch_branch || 'nightly' }}
-  PACKAGE_INDEX_URL: ${{ inputs.package_index_url || 'https://rocm.nightlies.amd.com/whl-multi-arch/' }}
+  PACKAGE_INDEX_URL: ${{ inputs.package_index_url || 'https://download.pytorch.org/whl/nightly/rocm7.14/' }}
   PUSH_TAG: ${{ inputs.push_tag || 'latest' }}
   BASE_IMAGE: ubuntu:24.04
 
@@ -78,12 +78,12 @@ jobs:
                 python3-venv \
               && rm -rf /var/lib/apt/lists/*
 
-          # Install the nightly PyTorch wheel plus the ROCm multi-arch runtime/devel/device packages.
+          # Install the nightly PyTorch wheel plus ROCm multi-arch runtime/device packages.
           # device-all pulls kernels for every supported gfx target from the whl-multi-arch index.
           RUN python3 -m venv "${VIRTUAL_ENV}" \
               && python -m pip install --no-cache-dir \
                 --index-url "${PACKAGE_INDEX_URL}" \
-                "rocm[libraries,devel,device-all]" \
+                "rocm[libraries,device-all]" \
                 torch torchvision torchaudio
 
           RUN ROCM_HOME="$(rocm-sdk path --root)" \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -16,7 +16,7 @@ on:
       push_tag:
         description: "Primary Docker Hub tag"
         type: string
-        default: "nightly"
+        default: "latest"
 
 permissions:
   contents: read
@@ -27,7 +27,7 @@ env:
   PYTORCH_REPO: pytorch/pytorch
   PYTORCH_BRANCH: ${{ inputs.pytorch_branch || 'nightly' }}
   PACKAGE_INDEX_URL: ${{ inputs.package_index_url || 'https://rocm.nightlies.amd.com/whl-multi-arch/' }}
-  PUSH_TAG: ${{ inputs.push_tag || 'nightly' }}
+  PUSH_TAG: ${{ inputs.push_tag || 'latest' }}
   BASE_IMAGE: ubuntu:24.04
 
 jobs:
@@ -59,6 +59,9 @@ jobs:
 
           ENV DEBIAN_FRONTEND=noninteractive
           ENV PIP_NO_CACHE_DIR=1
+          ENV VIRTUAL_ENV=/opt/venv
+          ENV PATH="/opt/venv/bin:${PATH}"
+          ENV PYTORCH_SRC_DIR=/root/pytorch
           # install_rocm.sh uses bash printf %q; Docker's default /bin/sh (dash) rejects it.
           SHELL ["/bin/bash", "-c"]
 
@@ -77,7 +80,8 @@ jobs:
 
           # Install the nightly PyTorch wheel plus the ROCm multi-arch runtime/devel/device packages.
           # device-all pulls kernels for every supported gfx target from the whl-multi-arch index.
-          RUN python3 -m pip install --break-system-packages --no-cache-dir \
+          RUN python3 -m venv "${VIRTUAL_ENV}" \
+              && python -m pip install --no-cache-dir \
                 --index-url "${PACKAGE_INDEX_URL}" \
                 "rocm[libraries,devel,device-all]" \
                 torch torchvision torchaudio
@@ -95,13 +99,14 @@ jobs:
               && echo "source /etc/rocm_env.sh" >> /etc/bash.bashrc \
               && if [[ -e /etc/bashrc ]]; then echo "source /etc/rocm_env.sh" >> /etc/bashrc; fi
 
-          RUN mkdir -p /var/lib/jenkins \
+          # Use the expanded form of ~/pytorch inside the image.
+          RUN mkdir -p "$(dirname "${PYTORCH_SRC_DIR}")" \
               && git clone --filter=blob:none --branch "${PYTORCH_BRANCH}" \
-                   "https://github.com/${PYTORCH_REPO}.git" /var/lib/jenkins/pytorch \
-              && cd /var/lib/jenkins/pytorch \
+                   "https://github.com/${PYTORCH_REPO}.git" "${PYTORCH_SRC_DIR}" \
+              && cd "${PYTORCH_SRC_DIR}" \
               && git checkout --detach "${PYTORCH_SHA}"
 
-          WORKDIR /var/lib/jenkins/pytorch
+          WORKDIR /root/pytorch
           EOF
 
       - name: Generate tags
@@ -109,7 +114,7 @@ jobs:
         run: |
           date="$(date -u +%Y%m%d)"
           echo "primary=${PUSH_TAG}" >> "$GITHUB_OUTPUT"
-          echo "dated=nightly-${date}-${{ steps.resolve.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
+          echo "dated=${date}-${{ steps.resolve.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
 
       - name: Build Docker image
         run: |
@@ -141,14 +146,14 @@ jobs:
           print("torch", torch.__version__)
           print("hip", torch.version.hip)
           PY
-            test "$(git -C /var/lib/jenkins/pytorch rev-parse HEAD)" = "${{ steps.resolve.outputs.sha }}"
+            test "$(git -C /root/pytorch rev-parse HEAD)" = "${{ steps.resolve.outputs.sha }}"
           '
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKERUSERNAME }}
-          password: ${{ secrets.DOCKERTOKEN || secrets.DCKRPAT }}
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Push Docker image
         run: |

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -71,8 +71,6 @@ jobs:
                 python3-venv \
               && rm -rf /var/lib/apt/lists/*
 
-          RUN python3 -m pip install --break-system-packages --upgrade pip
-
           # Install the nightly PyTorch wheel plus the ROCm multi-arch runtime/devel/device packages.
           # device-all pulls kernels for every supported gfx target from the whl-multi-arch index.
           RUN python3 -m pip install --break-system-packages \

--- a/.github/workflows/publish-pytorch-private-nightly.yml
+++ b/.github/workflows/publish-pytorch-private-nightly.yml
@@ -1,0 +1,167 @@
+name: Publish pytorch-nightly multi-arch image
+
+on:
+  schedule:
+    - cron: "0 7 * * *"   # daily at 07:00 UTC
+  workflow_dispatch:
+    inputs:
+      pytorch_branch:
+        description: "pytorch/pytorch branch to clone into the image"
+        type: string
+        default: "nightly"
+      package_index_url:
+        description: "Python wheel index for torch + ROCm multi-arch packages"
+        type: string
+        default: "https://rocm.nightlies.amd.com/whl-multi-arch/"
+      push_tag:
+        description: "Primary Docker Hub tag"
+        type: string
+        default: "nightly"
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: docker.io
+  IMAGE_NAME: rocm/pytorch-nightly
+  PYTORCH_REPO: pytorch/pytorch
+  PYTORCH_BRANCH: ${{ inputs.pytorch_branch || 'nightly' }}
+  PACKAGE_INDEX_URL: ${{ inputs.package_index_url || 'https://rocm.nightlies.amd.com/whl-multi-arch/' }}
+  PUSH_TAG: ${{ inputs.push_tag || 'nightly' }}
+  BASE_IMAGE: ubuntu:24.04
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PyTorch nightly branch head
+        id: resolve
+        run: |
+          sha="$(git ls-remote "https://github.com/${PYTORCH_REPO}.git" "refs/heads/${PYTORCH_BRANCH}" | awk '{print $1}')"
+          if [[ -z "${sha}" ]]; then
+            echo "Could not resolve ${PYTORCH_REPO}:${PYTORCH_BRANCH}" >&2
+            exit 1
+          fi
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${sha:0:7}" >> "$GITHUB_OUTPUT"
+          echo "Resolved ${PYTORCH_REPO}:${PYTORCH_BRANCH} -> ${sha}"
+
+      - name: Generate Dockerfile
+        run: |
+          cat > Dockerfile <<'EOF'
+          ARG BASE_IMAGE=ubuntu:24.04
+          FROM ${BASE_IMAGE}
+
+          ARG PACKAGE_INDEX_URL
+          ARG PYTORCH_REPO
+          ARG PYTORCH_BRANCH
+          ARG PYTORCH_SHA
+
+          ENV DEBIAN_FRONTEND=noninteractive
+
+          RUN apt-get update && apt-get install -y --no-install-recommends \
+                ca-certificates \
+                git \
+                kmod \
+                libnuma-dev \
+                libc++1 \
+                libc++abi1 \
+                python3 \
+                python3-pip \
+                python3-venv \
+              && rm -rf /var/lib/apt/lists/*
+
+          RUN python3 -m pip install --break-system-packages --upgrade pip
+
+          # Install the nightly PyTorch wheel plus the ROCm multi-arch runtime/devel/device packages.
+          # device-all pulls kernels for every supported gfx target from the whl-multi-arch index.
+          RUN python3 -m pip install --break-system-packages \
+                --index-url "${PACKAGE_INDEX_URL}" \
+                "rocm[libraries,devel,device-all]" \
+                torch torchvision torchaudio
+
+          RUN ROCM_HOME="$(rocm-sdk path --root)" \
+              && ROCM_BIN="$(rocm-sdk path --bin)" \
+              && { \
+                echo '# ROCm paths discovered from rocm-sdk.'; \
+                printf 'export ROCM_PATH=%q\n' "${ROCM_HOME}"; \
+                printf 'export ROCM_HOME=%q\n' "${ROCM_HOME}"; \
+                printf 'export PATH=%q:${PATH}\n' "${ROCM_BIN}"; \
+                printf 'export CMAKE_PREFIX_PATH=%q:${CMAKE_PREFIX_PATH:-}\n' "${ROCM_HOME}"; \
+                printf 'export LD_LIBRARY_PATH=%q:${LD_LIBRARY_PATH:-}\n' "${ROCM_HOME}/lib"; \
+              } > /etc/rocm_env.sh \
+              && echo "source /etc/rocm_env.sh" >> /etc/bash.bashrc
+
+          RUN mkdir -p /var/lib/jenkins \
+              && git clone --filter=blob:none --branch "${PYTORCH_BRANCH}" \
+                   "https://github.com/${PYTORCH_REPO}.git" /var/lib/jenkins/pytorch \
+              && cd /var/lib/jenkins/pytorch \
+              && git checkout --detach "${PYTORCH_SHA}"
+
+          WORKDIR /var/lib/jenkins/pytorch
+          EOF
+
+      - name: Generate tags
+        id: tags
+        run: |
+          date="$(date -u +%Y%m%d)"
+          echo "primary=${PUSH_TAG}" >> "$GITHUB_OUTPUT"
+          echo "dated=nightly-${date}-${{ steps.resolve.outputs.short_sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        run: |
+          primary="${REGISTRY}/${IMAGE_NAME}:${{ steps.tags.outputs.primary }}"
+          dated="${REGISTRY}/${IMAGE_NAME}:${{ steps.tags.outputs.dated }}"
+          docker build \
+            --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
+            --build-arg "PACKAGE_INDEX_URL=${PACKAGE_INDEX_URL}" \
+            --build-arg "PYTORCH_REPO=${PYTORCH_REPO}" \
+            --build-arg "PYTORCH_BRANCH=${PYTORCH_BRANCH}" \
+            --build-arg "PYTORCH_SHA=${{ steps.resolve.outputs.sha }}" \
+            --label "pytorch.repo=${PYTORCH_REPO}" \
+            --label "pytorch.branch=${PYTORCH_BRANCH}" \
+            --label "pytorch.commit=${{ steps.resolve.outputs.sha }}" \
+            --label "rocm.package_index=${PACKAGE_INDEX_URL}" \
+            --tag "${primary}" \
+            --tag "${dated}" \
+            .
+
+      - name: Validate image
+        run: |
+          primary="${REGISTRY}/${IMAGE_NAME}:${{ steps.tags.outputs.primary }}"
+          docker run --rm "${primary}" bash -lc '
+            set -e
+            source /etc/rocm_env.sh
+            cd /tmp
+            python3 - <<PY
+          import torch
+          print("torch", torch.__version__)
+          print("hip", torch.version.hip)
+          PY
+            test "$(git -C /var/lib/jenkins/pytorch rev-parse HEAD)" = "${{ steps.resolve.outputs.sha }}"
+          '
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERUSERNAME }}
+          password: ${{ secrets.DOCKERTOKEN || secrets.DCKRPAT }}
+
+      - name: Push Docker image
+        run: |
+          docker push "${REGISTRY}/${IMAGE_NAME}:${{ steps.tags.outputs.primary }}"
+          docker push "${REGISTRY}/${IMAGE_NAME}:${{ steps.tags.outputs.dated }}"
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "## pytorch-nightly multi-arch publish"
+            echo ""
+            echo "| field | value |"
+            echo "|---|---|"
+            echo "| pytorch source | \`${PYTORCH_REPO}:${PYTORCH_BRANCH}\` |"
+            echo "| source commit | \`${{ steps.resolve.outputs.sha }}\` |"
+            echo "| package index | \`${PACKAGE_INDEX_URL}\` |"
+            echo "| pushed tags | \`${{ steps.tags.outputs.primary }}\`, \`${{ steps.tags.outputs.dated }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## What

Adds a nightly/manual workflow that publishes `docker.io/rocm/pytorch-nightly` from the **actual head of `pytorch/pytorch:nightly`**.

The workflow resolves the nightly branch ref directly and records that exact source SHA in Docker image labels and the workflow summary.

## How

The workflow builds a Docker image from `ubuntu:24.04`. It uses one `rocm_version` input (default `10.0`) and two derived package indexes:

```text
TORCH_PACKAGE_INDEX_URL = https://download.pytorch.org/whl/nightly/rocm${ROCM_VERSION}/
ROCM_PACKAGE_INDEX_URL = https://stable.repo.amd.com/rocm/whl-next/
```

All ROCm packages now come from `repo.amd.com`, including libraries, devel files, and all device packages:

```bash
python -m pip install --no-cache-dir   --index-url "${ROCM_PACKAGE_INDEX_URL}"   "rocm[libraries,devel,device-all]==${ROCM_VERSION}.*"
```

PyTorch packages come from `download.pytorch.org`:

```bash
python -m pip install --no-cache-dir   --index-url "${TORCH_PACKAGE_INDEX_URL}"   torch torchvision torchaudio
```

After `rocm[devel]` is installed, `/etc/rocm_env.sh` is generated from the devel package using `rocm-sdk path --root` and `rocm-sdk path --bin`, so `ROCM_HOME`/`ROCM_BIN` point at the devel package location.

The workflow also clones the source into the image at expanded `~/pytorch` (`/root/pytorch` via `PYTORCH_SRC_DIR`):

```bash
git clone --filter=blob:none --branch nightly https://github.com/pytorch/pytorch.git "$PYTORCH_SRC_DIR"
git -C "$PYTORCH_SRC_DIR" checkout --detach <resolved-nightly-branch-head>
```

So the published image contains installed nightly PyTorch wheels, ROCm runtime/devel/device wheels from repo.amd.com, and source code from the actual `pytorch/pytorch:nightly` branch head at build time.

## Tags & secrets

- Docker Hub target: `docker.io/rocm/pytorch-nightly`.
- Primary tag defaults to `latest`.
- Dated tag format is `<YYYYMMDD>-<shortsha>`.
- Docker Hub login uses `secrets.DOCKER_USERNAME` and `secrets.DOCKER_TOKEN`.
- Manual `workflow_dispatch` runs build and validate only; they do **not** log in or push to `rocm/pytorch-nightly`.
- Scheduled runs are the only runs that push `latest` and `<YYYYMMDD>-<shortsha>`.

## Triggers & config

- `schedule`: daily at 07:00 UTC.
- `workflow_dispatch` inputs (manual runs do not publish):
  - `pytorch_branch` (default `nightly`)
  - `rocm_version` (default `10.0`; derives both torch and ROCm package indexes)
  - `push_tag` (default `latest`)

## Validation

Local validation for the new devel install:

```bash
python3 -m pip install --dry-run --no-cache-dir --ignore-installed   --index-url https://stable.repo.amd.com/rocm/whl-next/   'rocm[devel]==10.0.*'
```

The dry-run resolves `rocm-10.0.0`, `rocm-sdk-core-10.0.0`, and `rocm-sdk-devel-10.0.0`.

Previous image validation on the Docker Hub `latest` tag confirmed the pulled image has `/root/pytorch`, imports torch, and includes ROCm device packages. A new workflow run should be used to validate the 10.0/devel update end-to-end, including `rocm-sdk path` after devel installation.



Validation now prints `torch.version.hip` and `torch.version.rocm`.

### Latest validation run

Manual fork validation for current PR workflow (`1f7db8b96d`) passed: https://github.com/ethanwee1/pytorch/actions/runs/35229609533

This run used `rocm_version=10.0` and manual `workflow_dispatch`, so it built and validated only; Docker Hub login/push were skipped as expected.

Validated output:

- Source: `pytorch/pytorch:nightly` -> `f3c0cf56a7577d677c37718c4edc41b8fc7fb51a`
- ROCm package index: `https://stable.repo.amd.com/rocm/whl-next/`
- ROCm packages: `rocm[libraries,devel,device-all]==10.0.*` resolved to 10.0.0 packages, including `rocm-sdk-devel`, libraries, and device packages (`gfx908`, `gfx942`, `gfx950`, etc.)
- Torch package index: `https://download.pytorch.org/whl/nightly/rocm10.0/`
- Import validation: `torch 2.15.0.dev20260916+rocm10.0`, `torch.version.hip 7.15.26333`, `torch.version.rocm 10.0.0`
- `ROCM_HOME`/`ROCM_BIN` were generated from `rocm-sdk path` after devel installation.
