### PR TITLE
[DO NOT MERGE] [ROCm] device sync on pytorch module exit

### DIFF
--- a/torch/csrc/cuda/Module.cpp
+++ b/torch/csrc/cuda/Module.cpp
@@ -2285,6 +2285,16 @@ void initModule(PyObject* module) {
   registerCudaDeviceProperties(module);
   registerCudaPluggableAllocator(module);
   initCudaMethodBindings(module);
+#if defined(USE_ROCM)
+  // ROCm 7.x: drain the current device before C++ static destructors run.
+  // C++ std::atexit is too late; Python atexit matches torch.cuda.synchronize().
+  auto atexit_mod = py::module_::import("atexit");
+  atexit_mod.attr("register")(py::cpp_function([]() {
+    if (c10::cuda::device_count() > 0) {
+      c10::cuda::device_synchronize();
+    }
+  }));
+#endif
 }
 
 } // namespace torch::cuda


### PR DESCRIPTION
Failed test `test_cuda.py::TestBlockStateAbsorption::test_no_triton_on_import`

Failed in release/2.12 and upstream/main with "Segmentation fault (core dumped)"

Reproducer:
```
python -c "import torch; t=torch.eye(2, device='cuda'); print('ok')"

ok
Segmentation fault (core dumped)
```

This PR was made to save the solution found. It may not be needed.