### PR TITLE
[release/2.12] Pin torchaudio to ROCm/audio release/2.11.0.1

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,3 +1,3 @@
 ubuntu|pytorch|apex|release/1.12.0|ad1376f20dc0ac107040b6077c96aed52bd14298|https://github.com/ROCm/apex
 ubuntu|pytorch|torchvision|release/0.27|b3d5b111f54044b216013162706ca107aa7a4ec4|https://github.com/ROCm/vision
-ubuntu|pytorch|torchaudio|release/2.11|34c52a67e8941bbd8e6adaca0eb0b9eabec11d78|https://github.com/pytorch/audio
+ubuntu|pytorch|torchaudio|release/2.11.0.1|a0da46b30d93b3c3b9676d049797cac496563195|https://github.com/ethanwee1/audio


### PR DESCRIPTION
https://amd-hub.atlassian.net/browse/ROCM-24803

## Summary

Rebased onto current `release/2.12`. Pins `related_commits` to the **source-only ROCm GPU port** for torchaudio 2.11.0.1 ([ROCm/audio#17](https://github.com/ROCm/audio/pull/17) @ `a0da46b3`).

The Windows `CUDAExtension` cross-drive HIPIFY fix is **split out** to [ROCm/pytorch#3562](https://github.com/ROCm/pytorch/pull/3562) per review feedback.

## related_commits

Uses `ethanwee1/audio` fork URL until #17 merges; then flip origin to `https://github.com/ROCm/audio`.

## Validation

TheRock Windows gfx110X-all build dispatched on combined branch `ew/rocm-24803-validation` (this pin + #3562).

## Companion PRs

- [ROCm/audio#17](https://github.com/ROCm/audio/pull/17) — source-only HIP port (`cuda_compat.h`, guard widening, hipcub)
- [ROCm/pytorch#3562](https://github.com/ROCm/pytorch/pull/3562) — `cpp_extension.py` realpath fix
