### PR TITLE
Reset dynamo state in test_memory_compile_regions

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -4653,6 +4653,7 @@ class TestCudaAllocator(TestCase):
                 return x
 
         try:
+            torch._dynamo.reset()
             torch.cuda.memory.empty_cache()
             input_tensor = torch.randn(1, 10, device="cuda")
             # Create an instance of the model


### PR DESCRIPTION
https://github.com/ROCm/TheRock/issues/6173

## Motivation

`test_memory_compile_regions` in `test/test_cuda.py` asserts on Dynamo compile-region counts. When the test runs in the same process as other compile tests (e.g. a full `test_cuda.py` run), compiled artifacts cached by earlier tests leak into this test, making the asserted counts non-deterministic and the test flaky. This PR isolates the test from prior Dynamo state.

[CI fail](https://github.com/ROCm/rockrel/actions/runs/29136499759/job/86510474617)

## Technical Details

Added `torch._dynamo.reset()` at the start of `test_memory_compile_regions`, before `torch.cuda.memory.empty_cache()`, so the test starts from a clean Dynamo cache regardless of what ran before it.

## Test Plan

Reproduced locally with a small prelude test that runs `torch.compile(...)` on CUDA before the affected test, in the same process:

python -m pytest <prelude>.py test_cuda.py -k "<prelude_test> or test_memory_compile_regions" -v

## Test Result

Before fix:
    - standalone:                        PASSED
    - with a compiling test first: FAILED

After fix:
    - standalone:                        PASSED
    - with a compiling test first: PASSED

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
