### PR TITLE
[release/2.11] Bump AOTriton pin 0.12.50tp2 -> 0.13b to fix GCC build break

### DIFF
--- a/cmake/External/aotriton.cmake
+++ b/cmake/External/aotriton.cmake
@@ -9,13 +9,14 @@ if(NOT __AOTRITON_INCLUDED)
   # Replaces .ci/docker/aotriton_version.txt
   # Note packages information may have versions skipped (due to no ABI breaks)
   # But they must be listed from lower version to higher version
-  set(__AOTRITON_VER "0.12.50tp2")
+  set(__AOTRITON_VER "0.13b")
   set(__AOTRITON_MANYLINUX_LIST
       "manylinux_2_28"  # rocm6.4
       "manylinux_2_28"  # rocm7.0
       "manylinux_2_28"  # rocm7.1
       "manylinux_2_28"  # rocm7.2
       "manylinux_2_28"  # rocm7.14
+      "manylinux_2_28"  # rocm7.15
       )
   set(__AOTRITON_ROCM_LIST
       "rocm6.4"
@@ -23,18 +24,20 @@ if(NOT __AOTRITON_INCLUDED)
       "rocm7.1"
       "rocm7.2"
       "rocm7.14"
+      "rocm7.15"
       )
   if(DEFINED ENV{PYTORCH_AOTRITON_COMMIT})
     set(__AOTRITON_CI_COMMIT "$ENV{PYTORCH_AOTRITON_COMMIT}")
   else()
-    set(__AOTRITON_CI_COMMIT "05f26c2d8fbdcf8dd6d95b9544d04f7a39fc9920")
+    set(__AOTRITON_CI_COMMIT "6e00ef3e335b45dfb49065259533b59c68995bfe")
   endif()
   set(__AOTRITON_SHA256_LIST
-      "70020f5938d84e2dbb7cd98a4ca9cb46c4c0a61b683611c61dac20e99c1ee377"  # rocm6.4
-      "2a334e29f316e5a40766dbcf0b3075f7c73cce57f5044b39b7c3a7b33a7826bd"  # rocm7.0
-      "cc5894fed1dd44464a6187cafb82e61d9e4034b3035257c0fdfa93d4f0e906cc"  # rocm7.1
-      "af4ca6c5889c7ba302659115051ea1bfe6a09fb89f311dae214a6f942e93f605"  # rocm7.2
-      "21895066db0c0e2079f5483d07fbfde659f8de906c589bbfbc774bb9b4565e11"  # rocm7.14
+      "2fafa80953d9a49bd20e794bb8c0e1646e8aa815be2fb161deaa849a47547b17"  # rocm6.4
+      "7409f7c974cc79be731a419818bdb2ed6b8a3640fd40665baa76ec3c2a537204"  # rocm7.0
+      "f061a997679d8529a7b196b0ffb39912145ede217e515e1ee9ef5673b56d9e41"  # rocm7.1
+      "1cdeebb7ef61ab691fba1d81da919b9db5d8bef28269c892a30bd13a0495b7a0"  # rocm7.2
+      "7a139797c16b002fd5d9bcd706d36dc9819bb108877150f8186da21d0590eaa6"  # rocm7.14
+      "f024225d8b6063f7d95974e5957cb20893a1579a9a73b22b60426441331bc021"  # rocm7.15
       )
   set(__AOTRITON_IMAGE_LIST
       "amd-gfx90a"
@@ -46,13 +49,13 @@ if(NOT __AOTRITON_INCLUDED)
       "amd-gfx1250"
      )
   set(__AOTRITON_IMAGE_SHA256_LIST
-     "bb8bf2237b77fc503bc2967ea0d99d6ca419126c479e951ea42b712737128086" # amd-gfx90a
-     "f08edacf83c9ccf1c4bdcb51f1cab052d1680abea31c9e035f3f9fadb2f13ba4" # amd-gfx942
-     "307a37d729cda3a2120449909e5192cd71c2badccbd37f0222786098e69c7a91" # amd-gfx950
-     "c9cac7cf6f277168e1659ac2f04706f8823580b7c7e3e895f5a5503ed6bdd55f" # amd-gfx110x
-     "3177387a15c678b30057f4584d1fc1b8f8db56163890cb5c98f27450209f5a7b" # amd-gfx115x
-     "68572511ce6487a83f9014bd255bd69c8943f87d0c93bd57b2daac5fbc6c79c1" # amd-gfx120x
-     "c6ed084f1dce1c963c17055e38bcbc41d8e0fc48390d8fff6e11782454b26dbc" # amd-gfx1250
+     "a3d1a6868ce290ba8118618207093e785252eff4e18a64f495752cb5a03ffed6" # amd-gfx90a
+     "ccdbc7e3d96839be4895ee004f21531cc55d590c9018937b9e314bba363b3927" # amd-gfx942
+     "518fd072eb05948fc0a6c25a20832591c6406df865e3b691a2aeff3fd4c5ce1d" # amd-gfx950
+     "efe773e7a2c8adc995d90ecd0daca2db801285445ee10432df2b29c67d5b11d2" # amd-gfx110x
+     "1bc50e8aa8b6bda3410e92886ccca8fd45df3e60a6cbda9ffc58b2c541efd5c2" # amd-gfx115x
+     "6a465dbc03148bba8a2d78c4c2a3cb83155eca00f4f7f749e676402d7660968c" # amd-gfx120x
+     "4aaf71d6e510549d593757e5f88598df1e4a29cbcd91f70750ee8a76f65c027f" # amd-gfx1250
      )
   set(__AOTRITON_BASE_URL "$ENV{PYTORCH_AOTRITON_BASE_URL}")
   if(NOT __AOTRITON_BASE_URL)


### PR DESCRIPTION
> Part of the release/2.11 wheel-build fix stack tracked by #3477 (all pieces validated together in one combined green build). Jira: AIPYTORCH-827

## Why

The manylinux wheel build fails compiling `torch_hip` against the AOTriton `0.12.50tp2` headers under GCC 11 (`gcc-toolset-11`):
https://rocm-ci.amd.com/blue/organizations/jenkins/pytorch-manylinux-wheel-builder_rel-7.2/detail/pytorch-manylinux-wheel-builder_rel-7.2/526/pipeline/556/
```
In file included from /pytorch/torch/include/aotriton/flash.h:7,
                 from .../ATen/native/transformers/hip/sdp_utils.cpp:31:
/pytorch/torch/include/aotriton/config.h:27:22: error: expected identifier before '__attribute__'
   27 | #define AOTRITON_API __attribute__ ((visibility ("default")))
/pytorch/torch/include/aotriton/v2/cpp_tune.h:26:104: error: expected initializer before ':' token
   26 | enum [[deprecated(...)]] AOTRITON_API CppTuneSpecialKernelIndex : int {
ninja: build stopped: subcommand failed.
```

The `0.12.50tp2` preview package applies the `AOTRITON_API` visibility attribute (`__attribute__((visibility("default")))`) to `enum`/`struct` declarations in the deprecated V2 API headers. GCC does not accept a visibility attribute in that position on an enum with a fixed underlying type, so the build fails (clang tolerates it). The `0.13b` package used by `release/2.12` and `main` builds cleanly with the same toolchain.

## Fix
Validation build: https://rocm-ci.amd.com/blue/organizations/jenkins/pytorch-manylinux-wheel-builder_rel-7.2/detail/pytorch-manylinux-wheel-builder_rel-7.2/528/pipeline
http://compute-artifactory.amd.com/artifactory/compute-pytorch-rocm/compute-rocm-rel-7.2/93/
Bump the AOTriton pin `0.12.50tp2` -> `0.13b` (matching `release/2.12` and `main`), updating `__AOTRITON_VER`, `__AOTRITON_CI_COMMIT`, and the runtime/image `SHA256` lists.

