### PR TITLE
[CI] Parity: discover job topology from workflow YAML

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -388,8 +388,8 @@ def derive_shard_count(wf, job_prefix, test_config, fallback):
         print(f"WARNING: could not read shard count from workflow YAML: {error}")
     return fallback
 
-def resolve_job_prefix(wf, test_config, configured_prefix, arch=None):
-    """Return the '<prefix>' upstream actually uses for this arch's
+def resolve_job_prefix(wf, test_config, configured_prefix):
+    """Return the '<prefix>' upstream actually uses for this workflow's
     <test_config> test jobs, so a drifted configured prefix self-heals instead
     of silently matching nothing.
 
@@ -398,10 +398,10 @@ def resolve_job_prefix(wf, test_config, configured_prefix, arch=None):
     'gfx942' -> 'mi350' rename, or py3.10 -> py3.12), which used to require a
     manual config edit each time. Candidates are gathered from the run's jobs
     API and check-runs scoped to that run and its nested reusable workflows.
-    Only ROCm prefixes for the requested architecture are eligible, so another
-    workflow on the same commit cannot be selected accidentally. If the
-    configured prefix is present we keep it unchanged; otherwise we pick the
-    eligible candidate most similar to it. If nothing matches we return the
+    Only ROCm prefixes scoped to this workflow run and its nested reusable runs
+    are eligible, so another workflow on the same commit cannot be selected.
+    If the configured prefix is present we keep it unchanged; otherwise we pick
+    the eligible candidate most similar to it. If nothing matches we return the
     configured value untouched.
     """
     names = []
@@ -420,7 +420,7 @@ def resolve_job_prefix(wf, test_config, configured_prefix, arch=None):
         except Exception:
             pass
     best = choose_fuzzy_job_prefix(
-        names, test_config, configured_prefix, arch=arch
+        names, test_config, configured_prefix
     )
     if best != configured_prefix:
         print(f"NOTE: configured job prefix '{configured_prefix}' not found for "
@@ -1010,7 +1010,7 @@ def main():
         else:
             dist_job_prefix = rocm_job_prefix['distributed']
         dist_job_prefix = resolve_job_prefix(
-            periodic_wf, "distributed", dist_job_prefix, arch=arch
+            periodic_wf, "distributed", dist_job_prefix
         )
 
         folder_list = get_or_create_test_folder(periodic_wf)
@@ -1086,7 +1086,7 @@ def main():
         # If logs aren't found you might want to check the HUD for the correct tags
         # HUD link: https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=rocm
         rocm_job_prefix['default'] = resolve_job_prefix(
-            rocm_wf, "default", rocm_job_prefix['default'], arch=arch
+            rocm_wf, "default", rocm_job_prefix['default']
         )
         default_shards = derive_shard_count(
             rocm_wf, rocm_job_prefix['default'], "default", rocm_shards["default"]
@@ -1153,7 +1153,7 @@ def main():
             else:
                 inductor_job_prefix = rocm_job_prefix['inductor']
             inductor_job_prefix = resolve_job_prefix(
-                inductor_wf_rocm, "inductor", inductor_job_prefix, arch=arch
+                inductor_wf_rocm, "inductor", inductor_job_prefix
             )
             inductor_shards = derive_shard_count(
                 inductor_wf_rocm, inductor_job_prefix, "inductor",
@@ -1351,8 +1351,7 @@ def main():
                 )
                 print(f"Baseline default workflow '{ROCmWorkflowNames['default']}' id: {baseline_default_wf['id']}")
                 baseline_default_prefix = resolve_job_prefix(
-                    baseline_default_wf, "default", rocm_job_prefix['default'],
-                    arch=arch
+                    baseline_default_wf, "default", rocm_job_prefix['default']
                 )
                 default_shards = derive_shard_count(
                     baseline_default_wf, baseline_default_prefix, "default",
@@ -1391,7 +1390,7 @@ def main():
                 print(f"Baseline distributed workflow '{ROCmWorkflowNames['distributed']}' id: {baseline_dist_wf['id']}")
                 baseline_dist_prefix = resolve_job_prefix(
                     baseline_dist_wf, "distributed",
-                    rocm_job_prefix['distributed'], arch=arch
+                    rocm_job_prefix['distributed']
                 )
                 dist_shards = derive_shard_count(
                     baseline_dist_wf, baseline_dist_prefix, "distributed",
@@ -1430,7 +1429,7 @@ def main():
                 print(f"Baseline inductor workflow '{ROCmWorkflowNames['inductor']}' id: {baseline_inductor_wf['id']}")
                 baseline_inductor_prefix = resolve_job_prefix(
                     baseline_inductor_wf, "inductor",
-                    rocm_job_prefix['inductor'], arch=arch
+                    rocm_job_prefix['inductor']
                 )
                 inductor_shards = derive_shard_count(
                     baseline_inductor_wf, baseline_inductor_prefix, "inductor",

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -331,7 +331,7 @@ def resolve_job_prefix(wf, test_config, configured_prefix):
     of silently matching nothing.
 
     The job-name prefix in parity_job_config.json drifts whenever upstream
-    bumps the OS/python/compiler or renames a runner tag (e.g. the nightly
+    bumps the OS/python/compiler or renames a runner tag (e.g. the Preview
     'gfx942' -> 'mi350' rename, or py3.10 -> py3.12), which used to require a
     manual config edit each time. Candidates are gathered from the run's jobs
     API and the commit check-runs API (ROCm arch shards run in a reusable
@@ -740,7 +740,7 @@ def parse_args():
     parser.add_argument('--no_rocm', action='store_true')
     parser.add_argument('--no_cuda', action='store_true')
     parser.add_argument('--pr_id', type=int, help='The pull request ID')
-    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'nightly'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, or nightly, default: mi350)')
+    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'preview'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, or preview, default: mi350)')
     parser.add_argument('--include_inductor_periodic', action='store_true', help='Also download inductor-periodic benchmark artifacts (into a separate directory, not included in parity CSV)')
     parser.add_argument('--baseline_sha', type=str, help='Baseline commit SHA to compare against. Downloads the same ROCm workflows for this commit into baseline_xml/.')
     return parser.parse_args()
@@ -829,7 +829,7 @@ def main():
     # in, job-name prefixes, shard counts and fallbacks) comes from
     # parity_job_config.json - see PARITY_CONFIG at the top of this file.
     global ROCmWorkflowNames
-    arch = args.arch  # 'mi200', 'mi300', 'mi350', 'navi31', or 'nightly'
+    arch = args.arch  # 'mi200', 'mi300', 'mi350', 'navi31', or 'preview'
     arch_config = PARITY_CONFIG["rocm"][arch]
 
     ROCmWorkflowNames, rocm_job_prefix, arch_fallbacks = parity_config_views(arch_config)

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -186,13 +186,8 @@ def get_workflow_jobs(wf, all_attempts=False):
             jobs += page_json["jobs"]
     return jobs
 
-def get_check_runs_for_commit(sha, prefix):
-    """Get check runs for a commit filtered by name prefix.
-
-    The workflow jobs API does not return jobs from reusable workflows
-    (workflow_call). The check-runs API returns all jobs regardless of
-    workflow nesting, so we use it as a fallback.
-    """
+def get_all_check_runs_for_commit(sha):
+    """Return every check run on a commit (paginated)."""
     check_runs = []
     page = 1
     while True:
@@ -203,11 +198,113 @@ def get_check_runs_for_commit(sha, prefix):
         )
         data = response.json()
         runs = data.get('check_runs', [])
-        check_runs.extend([cr for cr in runs if prefix in cr.get('name', '')])
+        check_runs.extend(runs)
         if len(runs) < 100:
             break
         page += 1
     return check_runs
+
+def get_check_runs_for_commit(sha, prefix):
+    """Get check runs for a commit filtered by name prefix.
+
+    The workflow jobs API does not return jobs from reusable workflows
+    (workflow_call). The check-runs API returns all jobs regardless of
+    workflow nesting, so we use it as a fallback.
+    """
+    return [
+        check_run for check_run in get_all_check_runs_for_commit(sha)
+        if prefix in check_run.get('name', '')
+    ]
+
+def _workflow_runs_for_commit(sha):
+    """Return all workflow runs for a commit, including reusable workflows."""
+    workflow_runs = []
+    page = 1
+    while True:
+        response = requests.get(
+            "https://api.github.com/repos/pytorch/pytorch/actions/runs",
+            headers=authentication_headers,
+            params={'head_sha': sha, 'per_page': 100, 'page': page},
+        )
+        runs = response.json().get('workflow_runs', [])
+        workflow_runs.extend(runs)
+        if len(runs) < 100:
+            break
+        page += 1
+    return workflow_runs
+
+def _collect_scoped_run_ids(wf):
+    """Collect this workflow run and its nested reusable-workflow run IDs."""
+    run_ids = {int(wf['id'])}
+    sha = wf.get('head_sha')
+    if not sha:
+        return run_ids
+
+    runs_by_path = {}
+    for run in _workflow_runs_for_commit(sha):
+        path = (run.get('path') or '').lstrip('/')
+        if path:
+            runs_by_path.setdefault(path, []).append(run)
+
+    pending = [wf]
+    inspected = set()
+    while pending:
+        current = pending.pop()
+        current_id = int(current['id'])
+        if current_id in inspected:
+            continue
+        inspected.add(current_id)
+        response = requests.get(
+            f"https://api.github.com/repos/pytorch/pytorch/actions/runs/{current_id}",
+            headers=authentication_headers,
+        )
+        if response.status_code != 200:
+            continue
+        for referenced in response.json().get('referenced_workflows') or []:
+            referenced_path = (referenced.get('path') or '').lstrip('/')
+            if not referenced_path:
+                continue
+            for path, runs in runs_by_path.items():
+                if path == referenced_path or path.endswith(referenced_path):
+                    for run in runs:
+                        run_id = int(run['id'])
+                        if run_id not in run_ids:
+                            run_ids.add(run_id)
+                            pending.append(run)
+    return run_ids
+
+def get_check_runs_for_workflow_runs(sha, run_ids):
+    """Return check runs whose details URL belongs to a scoped run ID."""
+    run_markers = tuple(f"/runs/{run_id}/" for run_id in run_ids)
+    return [
+        check_run for check_run in get_all_check_runs_for_commit(sha)
+        if any(marker in (check_run.get('details_url') or '')
+               for marker in run_markers)
+    ]
+
+_ARCH_PREFIX_TOKENS = {
+    'mi200': ('mi200', 'mi210'),
+    'mi300': ('mi300',),
+    'mi350': ('mi350',),
+    'navi31': ('navi31',),
+    'preview': ('rocm-preview',),
+}
+
+def _is_rocm_job_prefix(prefix):
+    prefix_lower = prefix.lower()
+    return 'rocm' in prefix_lower and 'cuda' not in prefix_lower
+
+def _prefix_matches_arch(arch, prefix, configured_prefix):
+    prefix_lower = prefix.lower()
+    tokens = _ARCH_PREFIX_TOKENS.get(arch, ())
+    if any(token in prefix_lower for token in tokens):
+        return True
+    if prefix == configured_prefix:
+        return True
+    configured_lower = configured_prefix.lower()
+    if not any(token in configured_lower for token in tokens):
+        return _is_rocm_job_prefix(prefix)
+    return False
 
 def get_job_ids_by_prefix(wf, prefix):
     """Get job IDs (as strings) for jobs whose name contains the given prefix."""
@@ -325,7 +422,7 @@ def _candidate_job_prefixes(names, test_config):
             out[m.group(1)] = out.get(m.group(1), 0) + 1
     return out
 
-def resolve_job_prefix(wf, test_config, configured_prefix):
+def resolve_job_prefix(wf, test_config, configured_prefix, arch=None):
     """Return the '<prefix>' upstream actually uses for this arch's
     <test_config> test jobs, so a drifted configured prefix self-heals instead
     of silently matching nothing.
@@ -334,10 +431,11 @@ def resolve_job_prefix(wf, test_config, configured_prefix):
     bumps the OS/python/compiler or renames a runner tag (e.g. the Preview
     'gfx942' -> 'mi350' rename, or py3.10 -> py3.12), which used to require a
     manual config edit each time. Candidates are gathered from the run's jobs
-    API and the commit check-runs API (ROCm arch shards run in a reusable
-    workflow, so they only appear in check-runs). If the configured prefix is
-    present we keep it unchanged; otherwise we pick the candidate most similar
-    to it (shared os/py/arch tokens); if nothing matches we return the
+    API and check-runs scoped to that run and its nested reusable workflows.
+    Only ROCm prefixes for the requested architecture are eligible, so another
+    workflow on the same commit cannot be selected accidentally. If the
+    configured prefix is present we keep it unchanged; otherwise we pick the
+    eligible candidate most similar to it. If nothing matches we return the
     configured value untouched.
     """
     names = []
@@ -348,10 +446,21 @@ def resolve_job_prefix(wf, test_config, configured_prefix):
     sha = wf.get("head_sha") if isinstance(wf, dict) else None
     if sha:
         try:
-            names += [cr.get("name", "") for cr in get_check_runs_for_commit(sha, "")]
+            run_ids = _collect_scoped_run_ids(wf)
+            names += [
+                check_run.get("name", "")
+                for check_run in get_check_runs_for_workflow_runs(sha, run_ids)
+            ]
         except Exception:
             pass
     candidates = _candidate_job_prefixes(names, test_config)
+    candidates = {
+        prefix: count for prefix, count in candidates.items()
+        if _is_rocm_job_prefix(prefix)
+        and (arch is None or _prefix_matches_arch(
+            arch, prefix, configured_prefix
+        ))
+    }
     if not candidates or configured_prefix in candidates:
         return configured_prefix
     import difflib
@@ -948,7 +1057,9 @@ def main():
             dist_job_prefix = periodic_fallbacks[arch][1]
         else:
             dist_job_prefix = rocm_job_prefix['distributed']
-        dist_job_prefix = resolve_job_prefix(periodic_wf, "distributed", dist_job_prefix)
+        dist_job_prefix = resolve_job_prefix(
+            periodic_wf, "distributed", dist_job_prefix, arch=arch
+        )
 
         folder_list = get_or_create_test_folder(periodic_wf)
 
@@ -1022,7 +1133,9 @@ def main():
         # Download logs
         # If logs aren't found you might want to check the HUD for the correct tags
         # HUD link: https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=rocm
-        rocm_job_prefix['default'] = resolve_job_prefix(rocm_wf, "default", rocm_job_prefix['default'])
+        rocm_job_prefix['default'] = resolve_job_prefix(
+            rocm_wf, "default", rocm_job_prefix['default'], arch=arch
+        )
         default_shards = derive_shard_count(
             rocm_wf, rocm_job_prefix['default'], "default", rocm_shards["default"]
         )
@@ -1087,7 +1200,9 @@ def main():
                 inductor_job_prefix = inductor_fallbacks[arch][1]
             else:
                 inductor_job_prefix = rocm_job_prefix['inductor']
-            inductor_job_prefix = resolve_job_prefix(inductor_wf_rocm, "inductor", inductor_job_prefix)
+            inductor_job_prefix = resolve_job_prefix(
+                inductor_wf_rocm, "inductor", inductor_job_prefix, arch=arch
+            )
             inductor_shards = derive_shard_count(
                 inductor_wf_rocm, inductor_job_prefix, "inductor",
                 rocm_shards["inductor"]
@@ -1283,7 +1398,10 @@ def main():
                     error_msg=f"Baseline default workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline default workflow '{ROCmWorkflowNames['default']}' id: {baseline_default_wf['id']}")
-                baseline_default_prefix = resolve_job_prefix(baseline_default_wf, "default", rocm_job_prefix['default'])
+                baseline_default_prefix = resolve_job_prefix(
+                    baseline_default_wf, "default", rocm_job_prefix['default'],
+                    arch=arch
+                )
                 default_shards = derive_shard_count(
                     baseline_default_wf, baseline_default_prefix, "default",
                     rocm_shards["default"]
@@ -1319,7 +1437,10 @@ def main():
                     error_msg=f"Baseline distributed workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline distributed workflow '{ROCmWorkflowNames['distributed']}' id: {baseline_dist_wf['id']}")
-                baseline_dist_prefix = resolve_job_prefix(baseline_dist_wf, "distributed", rocm_job_prefix['distributed'])
+                baseline_dist_prefix = resolve_job_prefix(
+                    baseline_dist_wf, "distributed",
+                    rocm_job_prefix['distributed'], arch=arch
+                )
                 dist_shards = derive_shard_count(
                     baseline_dist_wf, baseline_dist_prefix, "distributed",
                     rocm_shards["distributed"]
@@ -1355,7 +1476,10 @@ def main():
                     error_msg=f"Baseline inductor workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline inductor workflow '{ROCmWorkflowNames['inductor']}' id: {baseline_inductor_wf['id']}")
-                baseline_inductor_prefix = resolve_job_prefix(baseline_inductor_wf, "inductor", rocm_job_prefix['inductor'])
+                baseline_inductor_prefix = resolve_job_prefix(
+                    baseline_inductor_wf, "inductor",
+                    rocm_job_prefix['inductor'], arch=arch
+                )
                 inductor_shards = derive_shard_count(
                     baseline_inductor_wf, baseline_inductor_prefix, "inductor",
                     rocm_shards["inductor"]

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -9,6 +9,7 @@ try:
     import requests
     import re
     import sys
+    import yaml
     from upload_stats_lib import unzip
     from upload_test_stats import download_gha_artifacts, download_s3_artifacts
 except ImportError:
@@ -216,6 +217,219 @@ def get_job_ids_by_prefix(wf, prefix):
 def matches_job_prefix(job_name, prefix):
     """Match the exact CUDA job family without also matching -debug/-sm86 jobs."""
     return job_name.startswith(f"{prefix} / ")
+
+def _download_workflow_yaml(sha, path):
+    """Download a workflow file from the exact commit used by a workflow run."""
+    path = path.removeprefix("./").lstrip("/")
+    url = f"https://raw.githubusercontent.com/pytorch/pytorch/{sha}/{path}"
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    return yaml.safe_load(response.text), path
+
+
+def _literal_test_matrix(jobs, job_key, seen=None):
+    """Resolve a job's literal test matrix, following needs.<job>.outputs."""
+    seen = set() if seen is None else seen
+    if job_key in seen:
+        return None
+    seen.add(job_key)
+    job = jobs.get(job_key, {})
+    matrix = job.get("with", {}).get("test-matrix")
+    if not isinstance(matrix, str):
+        return None
+    if "num_shards" in matrix:
+        return matrix
+    dependency = re.search(r"needs\.([A-Za-z0-9_-]+)\.outputs\.test-matrix", matrix)
+    if dependency:
+        return _literal_test_matrix(jobs, dependency.group(1), seen)
+    return None
+
+
+def _matrix_for_job_prefix(sha, path, job_prefix):
+    """Find the matrix behind a possibly nested reusable-workflow job prefix."""
+    workflow, path = _download_workflow_yaml(sha, path)
+    parts = [part.strip() for part in job_prefix.split(" / ")]
+    for index, part in enumerate(parts):
+        jobs = workflow.get("jobs", {})
+        candidates = [
+            (key, job) for key, job in jobs.items()
+            if job.get("name", key) == part or key == part
+        ]
+        if index < len(parts) - 1:
+            reusable = next(
+                (
+                    job.get("uses") for _, job in candidates
+                    if isinstance(job.get("uses"), str)
+                    and job["uses"].startswith("./.github/workflows/")
+                ),
+                None,
+            )
+            if not reusable:
+                return None
+            workflow, path = _download_workflow_yaml(sha, reusable)
+            continue
+        for key, _ in candidates:
+            matrix = _literal_test_matrix(jobs, key)
+            if matrix:
+                return matrix
+    return None
+
+
+def _shard_total_from_matrix(matrix, test_config):
+    if not matrix:
+        return None
+    match = re.search(
+        r"\{\s*config:\s*[\"']?" + re.escape(test_config)
+        + r"[\"']?\s*,.*?\bnum_shards:\s*(\d+)",
+        matrix,
+        re.DOTALL,
+    )
+    return int(match.group(1)) if match else None
+
+def derive_shard_count(wf, job_prefix, test_config, fallback):
+    """Read the shard total from the workflow YAML at the run's exact commit.
+
+    pytorch/pytorch reshards its matrices without notice (CUDA default 5 -> 14,
+    distributed 3 -> 10; mi300 default 6 -> 8, inductor 2 -> 4). A stale
+    hardcoded count makes the constructed "(default, i, 6)" keys and
+    "test-reports-...-6" prefixes miss the real jobs, so nothing downloads and
+    the run fails / is flagged incomplete.
+
+    Downloading the source YAML avoids inferring totals from incomplete jobs or
+    check-run API results. Nested reusable workflows (for example
+    inductor.yml -> inductor-unittest.yml) and test matrices exposed through a
+    build job's outputs are followed. The configured count remains a fallback
+    for unavailable or unparseable workflow source.
+    """
+    try:
+        sha = wf["head_sha"]
+        path = wf.get("path") or f".github/workflows/{wf['name']}.yml"
+        total = _shard_total_from_matrix(
+            _matrix_for_job_prefix(sha, path, job_prefix), test_config
+        )
+        if total is not None:
+            print(f"Read {test_config} shard count {total} from {path}@{sha}")
+            return total
+    except Exception as error:
+        print(f"WARNING: could not read shard count from workflow YAML: {error}")
+    return fallback
+
+def _candidate_job_prefixes(names, test_config):
+    """Map each distinct '<prefix>' -> count from names shaped like
+    '<prefix> / <kind> (<test_config>, <idx>, <total>, ...)'."""
+    pat = re.compile(r"^(.+?) / \S+ \(" + re.escape(test_config) + r", \d+, \d+")
+    out = {}
+    for name in names:
+        m = pat.match(name)
+        if m:
+            out[m.group(1)] = out.get(m.group(1), 0) + 1
+    return out
+
+def resolve_job_prefix(wf, test_config, configured_prefix):
+    """Return the '<prefix>' upstream actually uses for this arch's
+    <test_config> test jobs, so a drifted configured prefix self-heals instead
+    of silently matching nothing.
+
+    The job-name prefix in parity_job_config.json drifts whenever upstream
+    bumps the OS/python/compiler or renames a runner tag (e.g. the nightly
+    'gfx942' -> 'mi350' rename, or py3.10 -> py3.12), which used to require a
+    manual config edit each time. Candidates are gathered from the run's jobs
+    API and the commit check-runs API (ROCm arch shards run in a reusable
+    workflow, so they only appear in check-runs). If the configured prefix is
+    present we keep it unchanged; otherwise we pick the candidate most similar
+    to it (shared os/py/arch tokens); if nothing matches we return the
+    configured value untouched.
+    """
+    names = []
+    try:
+        names += [j.get("name", "") for j in get_workflow_jobs(wf)]
+    except Exception:
+        pass
+    sha = wf.get("head_sha") if isinstance(wf, dict) else None
+    if sha:
+        try:
+            names += [cr.get("name", "") for cr in get_check_runs_for_commit(sha, "")]
+        except Exception:
+            pass
+    candidates = _candidate_job_prefixes(names, test_config)
+    if not candidates or configured_prefix in candidates:
+        return configured_prefix
+    import difflib
+    best = max(
+        candidates,
+        key=lambda p: (
+            difflib.SequenceMatcher(None, p, configured_prefix).ratio(),
+            candidates[p],
+        ),
+    )
+    print(f"NOTE: configured job prefix '{configured_prefix}' not found for "
+          f"'{test_config}'; using detected prefix '{best}'")
+    return best
+
+def get_run_by_id(run_id):
+    """Fetch a single workflow-run object by id (for its run_attempt/name)."""
+    try:
+        r = requests.get(
+            f"https://api.github.com/repos/pytorch/pytorch/actions/runs/{run_id}",
+            headers=authentication_headers,
+        )
+        if r.status_code == 200:
+            return r.json()
+    except Exception:
+        pass
+    return None
+
+def resolve_artifact_download(wf, job_prefix, test_config, default_substrings):
+    """Redirect artifact download to the run that ACTUALLY ran this config's
+    shards, when it differs from the resolved caller run.
+
+    The standalone ROCm arch workflows (rocm-mi300, rocm-mi200, periodic-rocm-*,
+    inductor-rocm-*) are thin callers: on scheduled commits their sharded test
+    jobs execute under a DIFFERENT run (e.g. trunk-rocm-sandbox), and the
+    test-report artifacts live there - so downloading from the caller run finds
+    nothing and the job is flagged an incomplete download. The check-run's
+    details_url points at the run (and job) that really ran each shard, so we
+    read the hosting run id from there.
+
+    Returns (download_wf, allowed_substrings). When the shards ran in the
+    resolved run already, returns (wf, default_substrings) unchanged. When
+    redirecting, filters by the exact job ids so arches that share a
+    trunk-rocm-sandbox run don't pull each other's shards.
+    """
+    sha = wf.get("head_sha") if isinstance(wf, dict) else None
+    if not sha:
+        return wf, default_substrings
+    try:
+        check_runs = get_check_runs_for_commit(sha, job_prefix)
+    except Exception:
+        return wf, default_substrings
+    pat = re.compile(
+        re.escape(job_prefix) + r" / \S+ \(" + re.escape(test_config) + r","
+    )
+    runs = {}
+    jobs_by_run = {}
+    for cr in check_runs:
+        if not pat.search(cr.get("name", "")):
+            continue
+        m = re.search(r"/runs/(\d+)/job/(\d+)", cr.get("details_url", "") or "")
+        if not m:
+            continue
+        run_id, job_id = m.group(1), m.group(2)
+        runs[run_id] = runs.get(run_id, 0) + 1
+        jobs_by_run.setdefault(run_id, []).append(job_id)
+    if not runs:
+        return wf, default_substrings
+    best = sorted(runs.items(), key=lambda kv: -kv[1])[0][0]
+    if str(best) == str(wf.get("id")):
+        return wf, default_substrings
+    host = get_run_by_id(best)
+    if not host:
+        return wf, default_substrings
+    substrings = [f"_{jid}" for jid in jobs_by_run[best]]
+    print(f"NOTE: {test_config} shards for '{job_prefix}' ran in run {best} "
+          f"({host.get('name')}), not the resolved caller run {wf.get('id')}; "
+          f"downloading artifacts from there ({len(substrings)} jobs)")
+    return host, substrings
 
 # CUDA test jobs are named "test-osdc" on main but plain "test" on PRs, so we
 # probe both spellings (in priority order) from the shared config.
@@ -734,6 +948,7 @@ def main():
             dist_job_prefix = periodic_fallbacks[arch][1]
         else:
             dist_job_prefix = rocm_job_prefix['distributed']
+        dist_job_prefix = resolve_job_prefix(periodic_wf, "distributed", dist_job_prefix)
 
         folder_list = get_or_create_test_folder(periodic_wf)
 
@@ -742,10 +957,9 @@ def main():
         # HUD link: https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=rocm
         # Make sure "Hide unstable jobs" is unselected, in case ROCm jobs are marked as unstable
     
-        if arch == "mi350":
-            dist_shards = 3 if not periodic_fallback_used else rocm_shards["distributed"]
-        else:
-            dist_shards = rocm_shards["distributed"]
+        dist_shards = derive_shard_count(
+            periodic_wf, dist_job_prefix, "distributed", rocm_shards["distributed"]
+        )
         print(f"Using final ROCm shard count {dist_shards} for distributed")
 
         if not args.artifacts_only:
@@ -760,11 +974,14 @@ def main():
             f"test-reports-test-distributed-{i}-{dist_shards}"
             for i in range(1, dist_shards + 1)
         ]
+        dist_dl_wf, dist_dl_subs = resolve_artifact_download(
+            periodic_wf, dist_job_prefix, "distributed", rocm_artifact_substrings
+        )
         download_artifacts(
-            periodic_wf,
+            dist_dl_wf,
             test_artifacts_list_rocm_distributed,
             folder_list[2],
-            allowed_substrings=rocm_artifact_substrings,
+            allowed_substrings=dist_dl_subs,
         )
         os.chdir("..")
 
@@ -805,10 +1022,10 @@ def main():
         # Download logs
         # If logs aren't found you might want to check the HUD for the correct tags
         # HUD link: https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=rocm
-        if arch == "mi350":
-            default_shards = 6 if default_fallback_used else rocm_shards["default"]
-        else:
-            default_shards = rocm_shards["default"]
+        rocm_job_prefix['default'] = resolve_job_prefix(rocm_wf, "default", rocm_job_prefix['default'])
+        default_shards = derive_shard_count(
+            rocm_wf, rocm_job_prefix['default'], "default", rocm_shards["default"]
+        )
         print(f"Using final ROCm shard count {default_shards} for default")
 
         if not args.artifacts_only:
@@ -824,11 +1041,14 @@ def main():
           for i in range(1, default_shards + 1)
         ]
         if not args.exclude_default:
+            default_dl_wf, default_dl_subs = resolve_artifact_download(
+                rocm_wf, rocm_job_prefix['default'], "default", rocm_artifact_substrings
+            )
             download_artifacts(
-                rocm_wf,
+                default_dl_wf,
                 test_artifacts_list_rocm_default,
                 test_folder=folder_list[2],
-                allowed_substrings=rocm_artifact_substrings,
+                allowed_substrings=default_dl_subs,
             )
         os.chdir("..")
 
@@ -863,12 +1083,16 @@ def main():
 
             folder_list = get_or_create_test_folder(inductor_wf_rocm)
 
-            inductor_shards = rocm_shards["inductor"]
-            print(f"Using final ROCm shard count {inductor_shards} for inductor")
             if inductor_fallback_used and arch in inductor_fallbacks:
                 inductor_job_prefix = inductor_fallbacks[arch][1]
             else:
                 inductor_job_prefix = rocm_job_prefix['inductor']
+            inductor_job_prefix = resolve_job_prefix(inductor_wf_rocm, "inductor", inductor_job_prefix)
+            inductor_shards = derive_shard_count(
+                inductor_wf_rocm, inductor_job_prefix, "inductor",
+                rocm_shards["inductor"]
+            )
+            print(f"Using final ROCm shard count {inductor_shards} for inductor")
     
             # Download logs
             if not args.artifacts_only:
@@ -883,11 +1107,14 @@ def main():
               f"test-reports-test-inductor-{i}-{inductor_shards}"
               for i in range(1, inductor_shards + 1)
             ]
+            inductor_dl_wf, inductor_dl_subs = resolve_artifact_download(
+                inductor_wf_rocm, inductor_job_prefix, "inductor", rocm_artifact_substrings
+            )
             download_artifacts(
-                inductor_wf_rocm,
+                inductor_dl_wf,
                 test_artifacts_list_rocm_inductor,
                 test_folder=folder_list[2],
-                allowed_substrings=rocm_artifact_substrings,
+                allowed_substrings=inductor_dl_subs,
             )
             os.chdir("..")
 
@@ -925,8 +1152,17 @@ def main():
 
         folder_list = get_or_create_test_folder(trunk_wf)
 
-        cuda_default_shards = cuda_shards["default"]
-        cuda_dist_shards = cuda_shards["distributed"]
+        # Read the shard totals upstream actually used from the resolved run
+        # instead of trusting the hardcoded config, which drifts whenever
+        # pytorch/pytorch reshards its matrix (see derive_shard_count).
+        cuda_default_shards = derive_shard_count(
+            trunk_wf, cuda_job_prefix, "default", cuda_shards["default"]
+        )
+        cuda_dist_shards = derive_shard_count(
+            trunk_wf, cuda_job_prefix, "distributed", cuda_shards["distributed"]
+        )
+        print(f"Using final CUDA shard counts: default={cuda_default_shards}, "
+              f"distributed={cuda_dist_shards}")
 
         # Download logs
         if not args.artifacts_only:
@@ -995,7 +1231,11 @@ def main():
             folder_list = get_or_create_test_folder(inductor_wf_cuda)
 
             cuda_inductor_prefix = CUDA_JOB_PREFIXES["inductor"]
-            cuda_inductor_shards = cuda_shards["inductor"]
+            cuda_inductor_shards = derive_shard_count(
+                inductor_wf_cuda, cuda_inductor_prefix, "inductor",
+                cuda_shards["inductor"],
+            )
+            print(f"Using final CUDA inductor shard count {cuda_inductor_shards}")
 
             # Download logs
             if not args.artifacts_only:
@@ -1043,11 +1283,15 @@ def main():
                     error_msg=f"Baseline default workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline default workflow '{ROCmWorkflowNames['default']}' id: {baseline_default_wf['id']}")
-                default_shards = rocm_shards["default"]
+                baseline_default_prefix = resolve_job_prefix(baseline_default_wf, "default", rocm_job_prefix['default'])
+                default_shards = derive_shard_count(
+                    baseline_default_wf, baseline_default_prefix, "default",
+                    rocm_shards["default"]
+                )
 
                 if not args.artifacts_only:
                     baseline_default_logs = [
-                        [f"{baseline_prefix}rocm{i}.txt", f"{rocm_job_prefix['default']} / test (default, {i}, {default_shards}"]
+                        [f"{baseline_prefix}rocm{i}.txt", f"{baseline_default_prefix} / test (default, {i}, {default_shards}"]
                         for i in range(1, default_shards + 1)
                     ]
                     download_logs(baseline_default_wf, baseline_default_logs, test_folder)
@@ -1075,11 +1319,15 @@ def main():
                     error_msg=f"Baseline distributed workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline distributed workflow '{ROCmWorkflowNames['distributed']}' id: {baseline_dist_wf['id']}")
-                dist_shards = rocm_shards["distributed"]
+                baseline_dist_prefix = resolve_job_prefix(baseline_dist_wf, "distributed", rocm_job_prefix['distributed'])
+                dist_shards = derive_shard_count(
+                    baseline_dist_wf, baseline_dist_prefix, "distributed",
+                    rocm_shards["distributed"]
+                )
 
                 if not args.artifacts_only:
                     baseline_dist_logs = [
-                        [f"{baseline_prefix}rocm_dist{i}.txt", f"{rocm_job_prefix['distributed']} / test (distributed, {i}, {dist_shards}"]
+                        [f"{baseline_prefix}rocm_dist{i}.txt", f"{baseline_dist_prefix} / test (distributed, {i}, {dist_shards}"]
                         for i in range(1, dist_shards + 1)
                     ]
                     download_logs(baseline_dist_wf, baseline_dist_logs, test_folder)
@@ -1107,11 +1355,15 @@ def main():
                     error_msg=f"Baseline inductor workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline inductor workflow '{ROCmWorkflowNames['inductor']}' id: {baseline_inductor_wf['id']}")
-                inductor_shards = rocm_shards["inductor"]
+                baseline_inductor_prefix = resolve_job_prefix(baseline_inductor_wf, "inductor", rocm_job_prefix['inductor'])
+                inductor_shards = derive_shard_count(
+                    baseline_inductor_wf, baseline_inductor_prefix, "inductor",
+                    rocm_shards["inductor"]
+                )
 
                 if not args.artifacts_only:
                     baseline_inductor_logs = [
-                        [f"{baseline_prefix}rocm_inductor{i}.txt", f"{rocm_job_prefix['inductor']} / test (inductor, {i}, {inductor_shards}"]
+                        [f"{baseline_prefix}rocm_inductor{i}.txt", f"{baseline_inductor_prefix} / test (inductor, {i}, {inductor_shards}"]
                         for i in range(1, inductor_shards + 1)
                     ]
                     download_logs(baseline_inductor_wf, baseline_inductor_logs, test_folder)

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -186,13 +186,8 @@ def get_workflow_jobs(wf, all_attempts=False):
             jobs += page_json["jobs"]
     return jobs
 
-def get_check_runs_for_commit(sha, prefix):
-    """Get check runs for a commit filtered by name prefix.
-
-    The workflow jobs API does not return jobs from reusable workflows
-    (workflow_call). The check-runs API returns all jobs regardless of
-    workflow nesting, so we use it as a fallback.
-    """
+def get_all_check_runs_for_commit(sha):
+    """Return every check run on a commit (paginated)."""
     check_runs = []
     page = 1
     while True:
@@ -203,11 +198,113 @@ def get_check_runs_for_commit(sha, prefix):
         )
         data = response.json()
         runs = data.get('check_runs', [])
-        check_runs.extend([cr for cr in runs if prefix in cr.get('name', '')])
+        check_runs.extend(runs)
         if len(runs) < 100:
             break
         page += 1
     return check_runs
+
+def get_check_runs_for_commit(sha, prefix):
+    """Get check runs for a commit filtered by name prefix.
+
+    The workflow jobs API does not return jobs from reusable workflows
+    (workflow_call). The check-runs API returns all jobs regardless of
+    workflow nesting, so we use it as a fallback.
+    """
+    return [
+        check_run for check_run in get_all_check_runs_for_commit(sha)
+        if prefix in check_run.get('name', '')
+    ]
+
+def _workflow_runs_for_commit(sha):
+    """Return all workflow runs for a commit, including reusable workflows."""
+    workflow_runs = []
+    page = 1
+    while True:
+        response = requests.get(
+            "https://api.github.com/repos/pytorch/pytorch/actions/runs",
+            headers=authentication_headers,
+            params={'head_sha': sha, 'per_page': 100, 'page': page},
+        )
+        runs = response.json().get('workflow_runs', [])
+        workflow_runs.extend(runs)
+        if len(runs) < 100:
+            break
+        page += 1
+    return workflow_runs
+
+def _collect_scoped_run_ids(wf):
+    """Collect this workflow run and its nested reusable-workflow run IDs."""
+    run_ids = {int(wf['id'])}
+    sha = wf.get('head_sha')
+    if not sha:
+        return run_ids
+
+    runs_by_path = {}
+    for run in _workflow_runs_for_commit(sha):
+        path = (run.get('path') or '').lstrip('/')
+        if path:
+            runs_by_path.setdefault(path, []).append(run)
+
+    pending = [wf]
+    inspected = set()
+    while pending:
+        current = pending.pop()
+        current_id = int(current['id'])
+        if current_id in inspected:
+            continue
+        inspected.add(current_id)
+        response = requests.get(
+            f"https://api.github.com/repos/pytorch/pytorch/actions/runs/{current_id}",
+            headers=authentication_headers,
+        )
+        if response.status_code != 200:
+            continue
+        for referenced in response.json().get('referenced_workflows') or []:
+            referenced_path = (referenced.get('path') or '').lstrip('/')
+            if not referenced_path:
+                continue
+            for path, runs in runs_by_path.items():
+                if path == referenced_path or path.endswith(referenced_path):
+                    for run in runs:
+                        run_id = int(run['id'])
+                        if run_id not in run_ids:
+                            run_ids.add(run_id)
+                            pending.append(run)
+    return run_ids
+
+def get_check_runs_for_workflow_runs(sha, run_ids):
+    """Return check runs whose details URL belongs to a scoped run ID."""
+    run_markers = tuple(f"/runs/{run_id}/" for run_id in run_ids)
+    return [
+        check_run for check_run in get_all_check_runs_for_commit(sha)
+        if any(marker in (check_run.get('details_url') or '')
+               for marker in run_markers)
+    ]
+
+_ARCH_PREFIX_TOKENS = {
+    'mi200': ('mi200', 'mi210'),
+    'mi300': ('mi300',),
+    'mi350': ('mi350',),
+    'navi31': ('navi31',),
+    'preview': ('rocm-preview',),
+}
+
+def _is_rocm_job_prefix(prefix):
+    prefix_lower = prefix.lower()
+    return 'rocm' in prefix_lower and 'cuda' not in prefix_lower
+
+def _prefix_matches_arch(arch, prefix, configured_prefix):
+    prefix_lower = prefix.lower()
+    tokens = _ARCH_PREFIX_TOKENS.get(arch, ())
+    if any(token in prefix_lower for token in tokens):
+        return True
+    if prefix == configured_prefix:
+        return True
+    configured_lower = configured_prefix.lower()
+    if not any(token in configured_lower for token in tokens):
+        return _is_rocm_job_prefix(prefix)
+    return False
 
 def get_job_ids_by_prefix(wf, prefix):
     """Get job IDs (as strings) for jobs whose name contains the given prefix."""
@@ -325,7 +422,7 @@ def _candidate_job_prefixes(names, test_config):
             out[m.group(1)] = out.get(m.group(1), 0) + 1
     return out
 
-def resolve_job_prefix(wf, test_config, configured_prefix):
+def resolve_job_prefix(wf, test_config, configured_prefix, arch=None):
     """Return the '<prefix>' upstream actually uses for this arch's
     <test_config> test jobs, so a drifted configured prefix self-heals instead
     of silently matching nothing.
@@ -334,10 +431,11 @@ def resolve_job_prefix(wf, test_config, configured_prefix):
     bumps the OS/python/compiler or renames a runner tag (e.g. the nightly
     'gfx942' -> 'mi350' rename, or py3.10 -> py3.12), which used to require a
     manual config edit each time. Candidates are gathered from the run's jobs
-    API and the commit check-runs API (ROCm arch shards run in a reusable
-    workflow, so they only appear in check-runs). If the configured prefix is
-    present we keep it unchanged; otherwise we pick the candidate most similar
-    to it (shared os/py/arch tokens); if nothing matches we return the
+    API and check-runs scoped to that run and its nested reusable workflows.
+    Only ROCm prefixes for the requested architecture are eligible, so another
+    workflow on the same commit cannot be selected accidentally. If the
+    configured prefix is present we keep it unchanged; otherwise we pick the
+    eligible candidate most similar to it. If nothing matches we return the
     configured value untouched.
     """
     names = []
@@ -348,10 +446,21 @@ def resolve_job_prefix(wf, test_config, configured_prefix):
     sha = wf.get("head_sha") if isinstance(wf, dict) else None
     if sha:
         try:
-            names += [cr.get("name", "") for cr in get_check_runs_for_commit(sha, "")]
+            run_ids = _collect_scoped_run_ids(wf)
+            names += [
+                check_run.get("name", "")
+                for check_run in get_check_runs_for_workflow_runs(sha, run_ids)
+            ]
         except Exception:
             pass
     candidates = _candidate_job_prefixes(names, test_config)
+    candidates = {
+        prefix: count for prefix, count in candidates.items()
+        if _is_rocm_job_prefix(prefix)
+        and (arch is None or _prefix_matches_arch(
+            arch, prefix, configured_prefix
+        ))
+    }
     if not candidates or configured_prefix in candidates:
         return configured_prefix
     import difflib
@@ -948,7 +1057,9 @@ def main():
             dist_job_prefix = periodic_fallbacks[arch][1]
         else:
             dist_job_prefix = rocm_job_prefix['distributed']
-        dist_job_prefix = resolve_job_prefix(periodic_wf, "distributed", dist_job_prefix)
+        dist_job_prefix = resolve_job_prefix(
+            periodic_wf, "distributed", dist_job_prefix, arch=arch
+        )
 
         folder_list = get_or_create_test_folder(periodic_wf)
 
@@ -1022,7 +1133,9 @@ def main():
         # Download logs
         # If logs aren't found you might want to check the HUD for the correct tags
         # HUD link: https://hud.pytorch.org/hud/pytorch/pytorch/main/1?per_page=50&name_filter=rocm
-        rocm_job_prefix['default'] = resolve_job_prefix(rocm_wf, "default", rocm_job_prefix['default'])
+        rocm_job_prefix['default'] = resolve_job_prefix(
+            rocm_wf, "default", rocm_job_prefix['default'], arch=arch
+        )
         default_shards = derive_shard_count(
             rocm_wf, rocm_job_prefix['default'], "default", rocm_shards["default"]
         )
@@ -1087,7 +1200,9 @@ def main():
                 inductor_job_prefix = inductor_fallbacks[arch][1]
             else:
                 inductor_job_prefix = rocm_job_prefix['inductor']
-            inductor_job_prefix = resolve_job_prefix(inductor_wf_rocm, "inductor", inductor_job_prefix)
+            inductor_job_prefix = resolve_job_prefix(
+                inductor_wf_rocm, "inductor", inductor_job_prefix, arch=arch
+            )
             inductor_shards = derive_shard_count(
                 inductor_wf_rocm, inductor_job_prefix, "inductor",
                 rocm_shards["inductor"]
@@ -1283,7 +1398,10 @@ def main():
                     error_msg=f"Baseline default workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline default workflow '{ROCmWorkflowNames['default']}' id: {baseline_default_wf['id']}")
-                baseline_default_prefix = resolve_job_prefix(baseline_default_wf, "default", rocm_job_prefix['default'])
+                baseline_default_prefix = resolve_job_prefix(
+                    baseline_default_wf, "default", rocm_job_prefix['default'],
+                    arch=arch
+                )
                 default_shards = derive_shard_count(
                     baseline_default_wf, baseline_default_prefix, "default",
                     rocm_shards["default"]
@@ -1319,7 +1437,10 @@ def main():
                     error_msg=f"Baseline distributed workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline distributed workflow '{ROCmWorkflowNames['distributed']}' id: {baseline_dist_wf['id']}")
-                baseline_dist_prefix = resolve_job_prefix(baseline_dist_wf, "distributed", rocm_job_prefix['distributed'])
+                baseline_dist_prefix = resolve_job_prefix(
+                    baseline_dist_wf, "distributed",
+                    rocm_job_prefix['distributed'], arch=arch
+                )
                 dist_shards = derive_shard_count(
                     baseline_dist_wf, baseline_dist_prefix, "distributed",
                     rocm_shards["distributed"]
@@ -1355,7 +1476,10 @@ def main():
                     error_msg=f"Baseline inductor workflow not found for {baseline_sha}",
                 )
                 print(f"Baseline inductor workflow '{ROCmWorkflowNames['inductor']}' id: {baseline_inductor_wf['id']}")
-                baseline_inductor_prefix = resolve_job_prefix(baseline_inductor_wf, "inductor", rocm_job_prefix['inductor'])
+                baseline_inductor_prefix = resolve_job_prefix(
+                    baseline_inductor_wf, "inductor",
+                    rocm_job_prefix['inductor'], arch=arch
+                )
                 inductor_shards = derive_shard_count(
                     baseline_inductor_wf, baseline_inductor_prefix, "inductor",
                     rocm_shards["inductor"]

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -10,6 +10,7 @@ try:
     import re
     import sys
     import yaml
+    from job_name_match import choose_fuzzy_job_prefix
     from upload_stats_lib import unzip
     from upload_test_stats import download_gha_artifacts, download_s3_artifacts
 except ImportError:
@@ -282,30 +283,6 @@ def get_check_runs_for_workflow_runs(sha, run_ids):
                for marker in run_markers)
     ]
 
-_ARCH_PREFIX_TOKENS = {
-    'mi200': ('mi200', 'mi210'),
-    'mi300': ('mi300',),
-    'mi350': ('mi350',),
-    'navi31': ('navi31',),
-    'preview': ('rocm-preview',),
-}
-
-def _is_rocm_job_prefix(prefix):
-    prefix_lower = prefix.lower()
-    return 'rocm' in prefix_lower and 'cuda' not in prefix_lower
-
-def _prefix_matches_arch(arch, prefix, configured_prefix):
-    prefix_lower = prefix.lower()
-    tokens = _ARCH_PREFIX_TOKENS.get(arch, ())
-    if any(token in prefix_lower for token in tokens):
-        return True
-    if prefix == configured_prefix:
-        return True
-    configured_lower = configured_prefix.lower()
-    if not any(token in configured_lower for token in tokens):
-        return _is_rocm_job_prefix(prefix)
-    return False
-
 def get_job_ids_by_prefix(wf, prefix):
     """Get job IDs (as strings) for jobs whose name contains the given prefix."""
     jobs = get_workflow_jobs(wf)
@@ -411,17 +388,6 @@ def derive_shard_count(wf, job_prefix, test_config, fallback):
         print(f"WARNING: could not read shard count from workflow YAML: {error}")
     return fallback
 
-def _candidate_job_prefixes(names, test_config):
-    """Map each distinct '<prefix>' -> count from names shaped like
-    '<prefix> / <kind> (<test_config>, <idx>, <total>, ...)'."""
-    pat = re.compile(r"^(.+?) / \S+ \(" + re.escape(test_config) + r", \d+, \d+")
-    out = {}
-    for name in names:
-        m = pat.match(name)
-        if m:
-            out[m.group(1)] = out.get(m.group(1), 0) + 1
-    return out
-
 def resolve_job_prefix(wf, test_config, configured_prefix, arch=None):
     """Return the '<prefix>' upstream actually uses for this arch's
     <test_config> test jobs, so a drifted configured prefix self-heals instead
@@ -453,26 +419,12 @@ def resolve_job_prefix(wf, test_config, configured_prefix, arch=None):
             ]
         except Exception:
             pass
-    candidates = _candidate_job_prefixes(names, test_config)
-    candidates = {
-        prefix: count for prefix, count in candidates.items()
-        if _is_rocm_job_prefix(prefix)
-        and (arch is None or _prefix_matches_arch(
-            arch, prefix, configured_prefix
-        ))
-    }
-    if not candidates or configured_prefix in candidates:
-        return configured_prefix
-    import difflib
-    best = max(
-        candidates,
-        key=lambda p: (
-            difflib.SequenceMatcher(None, p, configured_prefix).ratio(),
-            candidates[p],
-        ),
+    best = choose_fuzzy_job_prefix(
+        names, test_config, configured_prefix, arch=arch
     )
-    print(f"NOTE: configured job prefix '{configured_prefix}' not found for "
-          f"'{test_config}'; using detected prefix '{best}'")
+    if best != configured_prefix:
+        print(f"NOTE: configured job prefix '{configured_prefix}' not found for "
+              f"'{test_config}'; using detected prefix '{best}'")
     return best
 
 def get_run_by_id(run_id):

--- a/.automation_scripts/pytorch-unit-test-scripts/job_name_match.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/job_name_match.py
@@ -1,0 +1,67 @@
+import difflib
+import re
+
+
+_ARCH_PREFIX_TOKENS = {
+    "mi200": ("mi200", "mi210"),
+    "mi300": ("mi300",),
+    "mi350": ("mi350",),
+    "navi31": ("navi31",),
+    "preview": ("rocm-preview",),
+}
+
+
+def _is_rocm_job_prefix(prefix):
+    prefix_lower = prefix.lower()
+    return "rocm" in prefix_lower and "cuda" not in prefix_lower
+
+
+def _prefix_matches_arch(arch, prefix, configured_prefix):
+    prefix_lower = prefix.lower()
+    tokens = _ARCH_PREFIX_TOKENS.get(arch, ())
+    if any(token in prefix_lower for token in tokens):
+        return True
+    if prefix == configured_prefix:
+        return True
+    configured_lower = configured_prefix.lower()
+    if not any(token in configured_lower for token in tokens):
+        return _is_rocm_job_prefix(prefix)
+    return False
+
+
+def _candidate_job_prefixes(names, test_config):
+    """Count prefixes from '<prefix> / <kind> (<config>, <idx>, <total>, ...)'."""
+    pattern = re.compile(
+        r"^(.+?) / \S+ \(" + re.escape(test_config) + r", \d+, \d+"
+    )
+    candidates = {}
+    for name in names:
+        match = pattern.match(name)
+        if match:
+            prefix = match.group(1)
+            candidates[prefix] = candidates.get(prefix, 0) + 1
+    return candidates
+
+
+def choose_fuzzy_job_prefix(names, test_config, configured_prefix, arch=None):
+    """Choose the closest eligible ROCm prefix, preserving an exact match."""
+    candidates = {
+        prefix: count
+        for prefix, count in _candidate_job_prefixes(names, test_config).items()
+        if _is_rocm_job_prefix(prefix)
+        and (
+            arch is None
+            or _prefix_matches_arch(arch, prefix, configured_prefix)
+        )
+    }
+    if not candidates or configured_prefix in candidates:
+        return configured_prefix
+    return max(
+        candidates,
+        key=lambda prefix: (
+            difflib.SequenceMatcher(
+                None, prefix, configured_prefix
+            ).ratio(),
+            candidates[prefix],
+        ),
+    )

--- a/.automation_scripts/pytorch-unit-test-scripts/job_name_match.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/job_name_match.py
@@ -2,31 +2,9 @@ import difflib
 import re
 
 
-_ARCH_PREFIX_TOKENS = {
-    "mi200": ("mi200", "mi210"),
-    "mi300": ("mi300",),
-    "mi350": ("mi350",),
-    "navi31": ("navi31",),
-    "preview": ("rocm-preview",),
-}
-
-
 def _is_rocm_job_prefix(prefix):
     prefix_lower = prefix.lower()
     return "rocm" in prefix_lower and "cuda" not in prefix_lower
-
-
-def _prefix_matches_arch(arch, prefix, configured_prefix):
-    prefix_lower = prefix.lower()
-    tokens = _ARCH_PREFIX_TOKENS.get(arch, ())
-    if any(token in prefix_lower for token in tokens):
-        return True
-    if prefix == configured_prefix:
-        return True
-    configured_lower = configured_prefix.lower()
-    if not any(token in configured_lower for token in tokens):
-        return _is_rocm_job_prefix(prefix)
-    return False
 
 
 def _candidate_job_prefixes(names, test_config):
@@ -43,16 +21,12 @@ def _candidate_job_prefixes(names, test_config):
     return candidates
 
 
-def choose_fuzzy_job_prefix(names, test_config, configured_prefix, arch=None):
-    """Choose the closest eligible ROCm prefix, preserving an exact match."""
+def choose_fuzzy_job_prefix(names, test_config, configured_prefix):
+    """Choose the closest scoped ROCm prefix, preserving an exact match."""
     candidates = {
         prefix: count
         for prefix, count in _candidate_job_prefixes(names, test_config).items()
         if _is_rocm_job_prefix(prefix)
-        and (
-            arch is None
-            or _prefix_matches_arch(arch, prefix, configured_prefix)
-        )
     }
     if not candidates or configured_prefix in candidates:
         return configured_prefix

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -15,7 +15,7 @@
     "distributed": [{ "workflow": "trunk", "job_prefix": "linux-jammy-cuda13.0-py3.10-gcc11" }],
     "inductor": [{ "workflow": "inductor", "job_prefix": "unit-test / inductor-test" }],
     "test_kinds": ["test-osdc", "test"],
-    "shard_counts": { "default": 5, "distributed": 3, "inductor": 2 },
+    "shard_counts": { "default": 14, "distributed": 10, "inductor": 2 },
     "checkrun_regex": "(linux-jammy-cuda13[.]0-py3[.]10-gcc11 / (test-osdc|test) [(](default|distributed),|unit-test / inductor-test / (test-osdc|test) [(]inductor,)"
   },
   "rocm": {

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -15,7 +15,7 @@
     "distributed": [{ "workflow": "trunk", "job_prefix": "linux-jammy-cuda13.0-py3.10-gcc11" }],
     "inductor": [{ "workflow": "inductor", "job_prefix": "unit-test / inductor-test" }],
     "test_kinds": ["test-osdc", "test"],
-    "shard_counts": { "default": 14, "distributed": 10, "inductor": 2 },
+    "shard_counts": { "default": 5, "distributed": 3, "inductor": 2 },
     "checkrun_regex": "(linux-jammy-cuda13[.]0-py3[.]10-gcc11 / (test-osdc|test) [(](default|distributed),|unit-test / inductor-test / (test-osdc|test) [(]inductor,)"
   },
   "rocm": {
@@ -38,7 +38,7 @@
       "default": [{ "workflow": "rocm-mi300", "job_prefix": "linux-noble-rocm-py3.12-mi300" }],
       "distributed": [{ "workflow": "periodic-rocm-mi300", "job_prefix": "linux-noble-rocm-py3.12-mi300" }],
       "inductor": [{ "workflow": "inductor-rocm-mi300", "job_prefix": "linux-noble-rocm-py3.12-mi300" }],
-      "shard_counts": { "default": 8, "distributed": 3, "inductor": 2 },
+      "shard_counts": { "default": 8, "distributed": 5, "inductor": 2 },
       "checkrun_regex": "rocm.*mi300.*/ test [(](default|distributed|inductor),"
     },
     "mi200": {

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -64,12 +64,12 @@
       "shard_counts": { "default": 2, "distributed": 3, "inductor": 2 },
       "checkrun_regex": "rocm.*navi31.*/ test [(]default,"
     },
-    "nightly": {
-      "default": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
-      "distributed": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
-      "inductor": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
-      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
-      "checkrun_regex": "rocm-nightly.*/ test [(](default|distributed|inductor),"
+    "preview": {
+      "default": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "distributed": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "inductor": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "shard_counts": { "default": 8, "distributed": 3, "inductor": 2 },
+      "checkrun_regex": "linux-noble-rocm-preview-py3[.]12-mi350 / test [(](default|distributed|inductor),"
     }
   }
 }

--- a/.automation_scripts/pytorch-unit-test-scripts/requirements.txt
+++ b/.automation_scripts/pytorch-unit-test-scripts/requirements.txt
@@ -2,3 +2,4 @@ pandas
 rockset
 boto3
 requests
+PyYAML

--- a/.automation_scripts/pytorch-unit-test-scripts/test_job_name_match.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/test_job_name_match.py
@@ -4,7 +4,7 @@ from job_name_match import choose_fuzzy_job_prefix
 
 
 class JobNameMatchTest(unittest.TestCase):
-    def test_fuzzy_match_selects_renamed_prefix_for_requested_arch(self):
+    def test_fuzzy_match_selects_closest_renamed_prefix(self):
         configured = "linux-jammy-rocm-py3.10-mi300"
         renamed = "linux-noble-rocm-py3.12-mi300"
         names = [
@@ -18,7 +18,7 @@ class JobNameMatchTest(unittest.TestCase):
 
         self.assertEqual(
             choose_fuzzy_job_prefix(
-                names, "default", configured, arch="mi300"
+                names, "default", configured
             ),
             renamed,
         )
@@ -33,21 +33,21 @@ class JobNameMatchTest(unittest.TestCase):
 
         self.assertEqual(
             choose_fuzzy_job_prefix(
-                names, "distributed", configured, arch="mi300"
+                names, "distributed", configured
             ),
             configured,
         )
 
-    def test_preview_does_not_select_non_preview_mi350(self):
-        configured = "linux-noble-rocm-preview-py3.12-mi350"
+    def test_cuda_candidate_is_not_eligible(self):
+        configured = "linux-noble-rocm-py3.12-mi350"
         names = [
-            "linux-noble-rocm-py3.12-mi350 / test "
-            "(inductor, 1, 2, rocm.gpu)",
+            "linux-jammy-cuda13.0-py3.10-gcc11 / test "
+            "(inductor, 1, 2, nvidia.gpu)",
         ]
 
         self.assertEqual(
             choose_fuzzy_job_prefix(
-                names, "inductor", configured, arch="preview"
+                names, "inductor", configured
             ),
             configured,
         )
@@ -61,7 +61,7 @@ class JobNameMatchTest(unittest.TestCase):
 
         self.assertEqual(
             choose_fuzzy_job_prefix(
-                names, "distributed", configured, arch="mi200"
+                names, "distributed", configured
             ),
             configured,
         )

--- a/.automation_scripts/pytorch-unit-test-scripts/test_job_name_match.py
+++ b/.automation_scripts/pytorch-unit-test-scripts/test_job_name_match.py
@@ -1,0 +1,71 @@
+import unittest
+
+from job_name_match import choose_fuzzy_job_prefix
+
+
+class JobNameMatchTest(unittest.TestCase):
+    def test_fuzzy_match_selects_renamed_prefix_for_requested_arch(self):
+        configured = "linux-jammy-rocm-py3.10-mi300"
+        renamed = "linux-noble-rocm-py3.12-mi300"
+        names = [
+            f"{renamed} / test (default, 1, 8, rocm.gpu)",
+            f"{renamed} / test (default, 2, 8, rocm.gpu)",
+            "linux-noble-rocm-py3.12-mi350 / test "
+            "(default, 1, 8, rocm.gpu)",
+            "linux-jammy-cuda13.0-py3.10-gcc11 / test "
+            "(default, 1, 14, nvidia.gpu)",
+        ]
+
+        self.assertEqual(
+            choose_fuzzy_job_prefix(
+                names, "default", configured, arch="mi300"
+            ),
+            renamed,
+        )
+
+    def test_exact_match_wins(self):
+        configured = "linux-noble-rocm-py3.12-mi300"
+        names = [
+            f"{configured} / test (distributed, 1, 5, rocm.gpu)",
+            "linux-noble-rocm-py3.13-mi300 / test "
+            "(distributed, 1, 5, rocm.gpu)",
+        ]
+
+        self.assertEqual(
+            choose_fuzzy_job_prefix(
+                names, "distributed", configured, arch="mi300"
+            ),
+            configured,
+        )
+
+    def test_preview_does_not_select_non_preview_mi350(self):
+        configured = "linux-noble-rocm-preview-py3.12-mi350"
+        names = [
+            "linux-noble-rocm-py3.12-mi350 / test "
+            "(inductor, 1, 2, rocm.gpu)",
+        ]
+
+        self.assertEqual(
+            choose_fuzzy_job_prefix(
+                names, "inductor", configured, arch="preview"
+            ),
+            configured,
+        )
+
+    def test_no_matching_config_keeps_configured_prefix(self):
+        configured = "linux-jammy-rocm-py3.10-mi200"
+        names = [
+            "linux-jammy-rocm-py3.10-mi200 / test "
+            "(default, 1, 10, rocm.gpu)",
+        ]
+
+        self.assertEqual(
+            choose_fuzzy_job_prefix(
+                names, "distributed", configured, arch="mi200"
+            ),
+            configured,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       arch:
-        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, nightly, navi31. Example: "nightly, mi350" or "mi300"'
+        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, navi31, preview. Example: "preview, mi350" or "mi300"'
         required: false
         default: 'mi350, mi300, mi200'
         type: string
@@ -72,7 +72,7 @@ on:
         type: boolean
       # summarize_xml_testreports flags
       set1_name:
-        description: 'Label for ROCm columns in output CSV. Examples: rocm, nightly, mi300. Default: rocm'
+        description: 'Label for ROCm columns in output CSV. Examples: rocm, preview, mi300. Default: rocm'
         required: false
         default: 'rocm'
         type: string

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -133,8 +133,23 @@ jobs:
           echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
           echo "Artifact prefix: $PREFIX"
 
+  parity-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Test fuzzy job-name matching
+        working-directory: .automation_scripts/pytorch-unit-test-scripts
+        run: python3 -m unittest -v test_job_name_match.py
+
   generate-parity:
-    needs: setup-matrix
+    needs: [setup-matrix, parity-unit-tests]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- download workflow YAML from raw.githubusercontent.com at the exact tested commit and read CUDA/ROCm `num_shards` values from the authoritative test matrix
- follow nested reusable workflows and build-job matrix outputs, while retaining configured counts only as a failure fallback
- self-heal renamed job prefixes and redirect artifact downloads to the workflow run that actually hosted reusable-workflow shards

## Why `parity_job_config.json` remains
The workflow YAML is now authoritative for shard counts, but the JSON still supplies information that cannot yet be discovered from one resolved workflow file: the ordered workflow candidates and architecture-specific fallbacks, seed job prefixes used to locate the right family before self-healing, CUDA test-job kinds, and check-run/workflow regexes used by `parity-auto.yml` before dispatch. Removing the file now would require moving those hardcoded values elsewhere or separately redesigning workflow discovery and gating; it would not actually remove the configuration. A follow-up can remove the JSON once those remaining consumers derive their topology dynamically.

## Test plan
- [x] Validate CUDA trunk default (14) and distributed (10) against live workflow source
- [x] Validate ROCm MI300 (8/5/2) and MI200 (10/3/4) against live workflow source
- [x] Validate nested CUDA inductor workflow resolution (2)
- [x] Run Python syntax and whitespace checks

## Preview topology update

This branch now uses `preview` only and validates topology discovery against the scheduled `rocm-preview` `mi350` 8/3/2 lane. #3554 owns the canonical Preview config; the duplicate Preview config hunks were removed while stacking on refreshed #3554. This PR remains the prerequisite for #3536 and #3555.


## Prefix safety update

Ported the fork #6 safety fix in `71e3f00d61f`: check-runs are scoped to the selected workflow and nested reusable runs, candidates are ROCm-only and scoped to the selected workflow run, and Preview uses a distinct `rocm-preview` token.

Validation covers Python compilation, live trunk/Preview YAML matrix resolution at upstream SHA `cf18dda7`, scoped check-run selection, and exclusion of non-ROCm candidates.

## Alignment landing order

Depends on #3554. Land before #3536 and before downloader resilience/automation PRs. Prefix safety includes nested reusable-run scoping and workflow-run filtering; validated against live trunk and Preview workflow YAML at `cf18dda7`.

## August 25 refresh
- Stacked on refreshed #3554 and resolved the Preview matcher conflict.

- Removed duplicate workflow changes; the focused diff is downloader discovery, config fallbacks, and PyYAML.
- Updated fallback shards to CUDA 14/10/2, MI300 8/5/2, and MI200 10/3/4, verified against current upstream workflow matrices.

- Revalidated Python compilation, JSON, and workflow YAML parsing.

## Fuzzy job-name unit gate
- Extracted fuzzy ROCm job-prefix selection into `job_name_match.py`.

- Added four unit cases covering rename recovery, exact-match priority, CUDA exclusion, and no-match fallback.
- `parity.yml` now runs the suite once in `parity-unit-tests`; `generate-parity` cannot start unless it passes.

- Local result: 4 tests passed; Python compilation and actionlint passed (excluding the workflow’s pre-existing legacy input-count warning).

## Parity stack merge order

All open parity PRs are targeted to `develop`. Merge in this order:

1. ✅ #3523 — skip classifier consolidation (merged)
2. ✅ #3554 — Preview topology root (merged)
3. #3535 — dynamic workflow/job topology discovery
4. #3536 — per-job run-ID mapping and upstream links
5. #3559 — canonical full-trunk ROCm Inductor selection
6. #3558 — missing-config handling
7. #3557 — partial-report preservation and final failure
8. #3560 — authoritative flaky-test attribution
9. #3555 — multi-architecture auto-trigger with per-config readiness
10. #3556 — latest complete-config SHA selection (hold until corrected)

#3259 is a separate follow-up: reconstruct FrameworkWeb ingestion after the operational stack lands.