### PR TITLE
Fixed gfx1250_preferred_backend test

### DIFF
--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -840,6 +840,8 @@ print(t.is_pinned())
                     archs.append("gfx950")
                 if ROCM_VERSION >= (7, 13):
                     archs.extend(["gfx1100", "gfx1101", "gfx1151"])
+                if ROCM_VERSION >= (7, 14):
+                    archs.extend(["gfx1250"])
                 gcn_arch_name = torch.cuda.get_device_properties(0).gcnArchName
                 hipblaslt_preferred = any(arch in gcn_arch_name for arch in archs)
                 if hipblaslt_preferred:


### PR DESCRIPTION
Fixes https://amd-hub.atlassian.net/browse/ROCM-29096. Once merged, will cherry-pick to other branches.
test_cuda.py::TestCuda::test_preferred_blas_library_settings


Cherry-picked to release/2.11 branch via https://github.com/ROCm/pytorch/pull/3589