### PR TITLE
[release/2.13] Update pwlf to restore SAC tests

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -367,9 +367,9 @@ parameterized==0.8.1
 #Pinned versions: 1.24.0
 #test that import: test_sac_estimator.py
 
-pwlf==2.2.1
+pwlf==2.6.0
 #Description: required for testing torch/distributed/_tools/sac_estimator.py
-#Pinned versions: 2.2.1
+#Pinned versions: 2.6.0
 #test that import: test_sac_estimator.py
 
 # To build PyTorch itself


### PR DESCRIPTION
## Summary
- update the SAC estimator test dependency from `pwlf==2.2.1` to `pwlf==2.6.0`
- avoid the incompatible `pyDOE 1.3.0` module rename by using a pwlf release that relies on SciPy's Latin-hypercube implementation
- restore SAC estimator and SAC ILP test imports on Python 3.14

Fixes ROCM-29177.

## Test plan
- [x] Validate `pwlf==2.6.0` installation with Python 3.14, NumPy 2.3.4, and SciPy 1.16.2
- [x] Exercise `PiecewiseLinFit.fit`, `predict`, and `calc_slopes`
- [ ] Build Python 3.14 / gfx1200 release/2.13 wheels: [TheRock run 31429574049](https://github.com/ROCm/TheRock/actions/runs/31429574049) (queued)

