### PR TITLE
[CI] Parity: resolve sha=latest on current develop

### DIFF
--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -654,17 +654,37 @@ def main():
     token = os.getenv('GITHUB_TOKEN', '...')
     global authentication_headers
     authentication_headers = {'Authorization': f'token {token}'}
-    if (args.pr_id and args.sha1) or (not args.pr_id and not args.sha1):
-        error_msg = "Error: Please provide either pr_id or sha!"
+    status = "success"
+    # An empty --sha1 (or the literal "latest") means "use the latest green
+    # run on main" rather than a specific commit. download_workflow_run()
+    # already resolves that when given no head_sha, so treat these as unset.
+    sha_is_latest = (not args.sha1) or (str(args.sha1).strip().lower() == "latest")
+    if args.pr_id and not sha_is_latest:
+        error_msg = "Error: Please provide either pr_id or sha (not both)!"
         print(error_msg)
         sys.exit(1)
     if args.pr_id:
         pr_id = args.pr_id
-        sha = get_latest_commit_sha(pr_id, token)        
-    else:
+        sha = get_latest_commit_sha(pr_id, token)
+    elif not sha_is_latest:
         sha = args.sha1
         pr_id = None
-    status = "success"
+    else:
+        # No pr_id and no explicit sha: resolve the latest green ROCm run on
+        # main and use its head commit as the target sha.
+        pr_id = None
+        print("No sha or pr_id given; resolving latest green ROCm run on main...")
+        latest_wf = download_workflow_run(
+            created=args.created,
+            max_pages=args.max_pages,
+            workflow=ROCmWorkflowNames["default"],
+            sha=None,
+            ignore_status=args.ignore_status,
+            status=status,
+            error_msg="Error: could not find a latest green ROCm run on main",
+        )
+        sha = latest_wf["head_sha"]
+        print(f"Resolved 'latest' to sha: {sha}")
     print(f"sha: {sha}")
 
     # When comparing two commits, prefix log filenames with short SHAs

--- a/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
+++ b/.automation_scripts/pytorch-unit-test-scripts/download_testlogs
@@ -526,7 +526,7 @@ def parse_args():
     parser.add_argument('--no_rocm', action='store_true')
     parser.add_argument('--no_cuda', action='store_true')
     parser.add_argument('--pr_id', type=int, help='The pull request ID')
-    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'nightly'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, or nightly, default: mi350)')
+    parser.add_argument('--arch', type=str, choices=['mi200', 'mi300', 'mi350', 'navi31', 'preview'], default='mi350', help='ROCm GPU architecture (mi200, mi300, mi350, navi31, or preview, default: mi350)')
     parser.add_argument('--include_inductor_periodic', action='store_true', help='Also download inductor-periodic benchmark artifacts (into a separate directory, not included in parity CSV)')
     parser.add_argument('--baseline_sha', type=str, help='Baseline commit SHA to compare against. Downloads the same ROCm workflows for this commit into baseline_xml/.')
     return parser.parse_args()
@@ -615,7 +615,7 @@ def main():
     # in, job-name prefixes, shard counts and fallbacks) comes from
     # parity_job_config.json - see PARITY_CONFIG at the top of this file.
     global ROCmWorkflowNames
-    arch = args.arch  # 'mi200', 'mi300', 'mi350', 'navi31', or 'nightly'
+    arch = args.arch  # 'mi200', 'mi300', 'mi350', 'navi31', or 'preview'
     arch_config = PARITY_CONFIG["rocm"][arch]
 
     ROCmWorkflowNames, rocm_job_prefix, arch_fallbacks = parity_config_views(arch_config)

--- a/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
+++ b/.automation_scripts/pytorch-unit-test-scripts/parity_job_config.json
@@ -64,12 +64,12 @@
       "shard_counts": { "default": 2, "distributed": 3, "inductor": 2 },
       "checkrun_regex": "rocm.*navi31.*/ test [(]default,"
     },
-    "nightly": {
-      "default": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
-      "distributed": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
-      "inductor": [{ "workflow": "rocm-nightly", "job_prefix": "linux-noble-rocm-nightly-py3.12-mi350" }],
-      "shard_counts": { "default": 6, "distributed": 3, "inductor": 2 },
-      "checkrun_regex": "rocm-nightly.*/ test [(](default|distributed|inductor),"
+    "preview": {
+      "default": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "distributed": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "inductor": [{ "workflow": "rocm-preview", "job_prefix": "linux-noble-rocm-preview-py3.12-mi350" }],
+      "shard_counts": { "default": 8, "distributed": 3, "inductor": 2 },
+      "checkrun_regex": "linux-noble-rocm-preview-py3[.]12-mi350 / test [(](default|distributed|inductor),"
     }
   }
 }

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       arch:
-        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, nightly, navi31. Example: "nightly, mi350" or "mi300"'
+        description: 'ROCm architectures, comma or space separated. Options: mi350, mi300, mi200, navi31, preview. Example: "preview, mi350" or "mi300"'
         required: false
         default: 'mi350, mi300, mi200'
         type: string
@@ -72,7 +72,7 @@ on:
         type: boolean
       # summarize_xml_testreports flags
       set1_name:
-        description: 'Label for ROCm columns in output CSV. Examples: rocm, nightly, mi300. Default: rocm'
+        description: 'Label for ROCm columns in output CSV. Examples: rocm, preview, mi300. Default: rocm'
         required: false
         default: 'rocm'
         type: string


### PR DESCRIPTION
## Summary
Resolve an omitted or literal `latest` SHA to the latest green ROCm run on main while preserving explicit SHA and PR behavior.

Clean replacement for #3393 on current `develop`, stacked on #3554 for the Preview topology.

## Test plan
- [x] Compile `download_testlogs`
- [x] Verify the diff above #3554 is limited to latest-SHA resolution
- [ ] Exercise `--sha1 latest`, explicit SHA, and PR inputs in a workflow run

Made with [Cursor](https://cursor.com)

## Alignment landing order

Depends on #3554 only for branch stacking. Land before #3555 so manual and automated entry points share stable SHA resolution.

## Parity stack merge order

All open parity PRs are targeted to `develop`. Merge in this order:

1. ✅ #3523 — skip classifier consolidation (merged)
2. ✅ #3554 — Preview topology root (merged)
3. #3535 — dynamic workflow/job topology discovery
4. #3536 — per-job run-ID mapping and upstream links
5. #3559 — canonical full-trunk ROCm Inductor selection
6. #3558 — missing-config handling
7. #3557 — partial-report preservation and final failure
8. #3560 — authoritative flaky-test attribution
9. #3555 — multi-architecture auto-trigger with per-config readiness
10. #3556 — latest complete-config SHA selection (hold until corrected)

#3259 is a separate follow-up: reconstruct FrameworkWeb ingestion after the operational stack lands.