### PR TITLE
[release/2.13] Fix hipify skipping sources under Windows subst drives (ROCM-29365)

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1589,13 +1589,19 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
     if IS_HIP_EXTENSION:
         from .hipify import hipify_python
-        build_dir = os.getcwd()
+        # Resolve symlinks/junctions and Windows `subst` drive aliases so the
+        # build directory and the source paths use the same canonical form. On
+        # Windows CI the build runs under a `subst` drive (e.g. B:) while source
+        # paths may resolve to the real drive (e.g. C:); without this the
+        # `includes` scope below matches nothing and hipify silently skips the
+        # sources, leaving CUDA headers unhipified.
+        build_dir = os.path.realpath(os.getcwd())
         hipify_result = hipify_python.hipify(
             project_directory=build_dir,
             output_directory=build_dir,
             header_include_dirs=include_dirs,
             includes=[os.path.join(build_dir, '*')],  # limit scope to build_dir only
-            extra_files=[os.path.abspath(s) for s in sources],
+            extra_files=[os.path.realpath(s) for s in sources],
             show_detailed=True,
             is_pytorch_extension=True,
             hipify_extra_files_only=True,  # don't hipify everything in includes path
@@ -1603,7 +1609,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
         hipified_sources = set()
         for source in sources:
-            s_abs = os.path.abspath(source)
+            s_abs = os.path.realpath(source)
             hipified_s_abs = (hipify_result[s_abs].hipified_path if (s_abs in hipify_result and
                               hipify_result[s_abs].hipified_path is not None) else s_abs)
             # setup() arguments must *always* be /-separated paths relative to the setup.py directory,


### PR DESCRIPTION
## Summary

On Windows ROCm CI, the `release/2.13` torchaudio wheel build fails compiling GPU sources with `fatal error: 'cuda_runtime_api.h' file not found` (ROCM-29365 / ROCm/TheRock#7266). Root cause is in `CUDAExtension`'s hipify step, not in torchaudio.

`CUDAExtension` scopes hipify to `os.getcwd()` and filters with `includes=[build_dir/*]`. The Windows CI runs the build under a `subst` drive (`CHECKOUT_ROOT: B:/src`), but torchaudio computes its source directory with `Path(...).resolve()`, which follows the `subst` alias back to the real drive (`C:\...`). So `build_dir` (`B:\...`) and the source paths (`C:\...`) use different drive spellings, the `includes` filter matches nothing, and hipify silently skips the GPU sources — leaving the raw `#include <cuda_runtime_api.h>` (via `cuda_utils.h`) for hipcc.

This is the same `B:` vs `C:` mount split as ROCM-28908; that fix removed the earlier hard crash, which let the build progress far enough to expose this.

## Fix

Normalize both sides with `os.path.realpath` so the build directory and the source paths share one canonical form (collapsing symlinks/junctions and `subst` drive aliases). With that, `includes=[build_dir/*]` matches again and the header-recursion that rewrites `cuda_runtime_api.h` → `hip/hip_runtime_api.h` runs.

```python
build_dir = os.path.realpath(os.getcwd())
...
extra_files=[os.path.realpath(s) for s in sources],
...
s_abs = os.path.realpath(source)
```

## Evidence / validation

- Failing run 31459420855: hipcc compiles the original `compute.cu` (not `.hip`); torchaudio's `CUDAExtension` hipify passes report `replaced kernel launches: 0`; `hip_utils.h`/`compute.hip` never appear in the log.
- Local repro of the exact `CUDAExtension` hipify call on the real torchaudio GPU sources:
  - cwd == source tree → `cuda_utils.h → hip_utils.h`, `compute.cu → compute.hip`, `replaced kernel launches: 1`.
  - cwd != source tree (mimics `B:` vs `C:`) → 0 conversions, no `.hip` — matches the failing CI.
- `realpath` collapses the `subst` alias so both paths agree, restoring the working (cwd == source) behavior. No effect on Linux, where the paths already agree.

## Test plan

- [x] Windows ROCm `release/2.13` wheel pipeline builds torchaudio successfully across supported Python versions.
- [x] Linux ROCm extension builds unaffected (regression check).
- [x] ROCM-28908 relpath fix remains intact.

Refs: ROCM-29365, ROCm/TheRock#7266, ROCM-28908.


## Successful Passing Test

Validated end-to-end with a full Windows ROCm multi-arch PyTorch wheel build on this branch (same TheRock workflow that fails on `release/2.13`, only `pytorch_git_ref` repointed to this branch).

**Build job succeeded:** [Build Multi-Arch Windows PyTorch Wheels (dev, 3.12, garayp/rocm-29365-hipify-realpath)](https://github.com/ROCm/TheRock/actions/runs/31667526330) — torch, torchaudio, and torchvision all built on Windows ROCm with the fix.

This is definitive confirmation. The exact ROCM-29365 sources now hipify and compile (build log, lines 714709-714718):

```
cuda_utils.h                 -> hip_utils.h                  [ok]
rnnt/gpu/compute.cu          -> rnnt/gpu/compute.hip         [ok]
forced_align/gpu/compute.cu  -> forced_align/gpu/compute.hip [ok]
Total number of replaced kernel launches: 11
Total number of replaced kernel launches: 8
```

Before the fix (on `release/2.13`), these passes reported `Total number of replaced kernel launches: 0` and the CUDA header was left unhipified, so `hipcc` failed with `cuda_runtime_api.h` not found. With the fix, `hipcc` compiles `compute.hip` and resolves `hip_utils.h` cleanly.

_Note: the downstream GPU test jobs in that run failed at dependency install (`No matching distribution found for rocm==10.1.0a20260810` from the dev-releases index) — an unrelated TheRock test-harness/package-index gap, not this change. The tests never ran any torchaudio code._
