### PR TITLE
[release/2.12] Skip test_cholesky_solve_batched_many_batches on ROCm 7.14

### DIFF
--- a/test/test_linalg.py
+++ b/test/test_linalg.py
@@ -27,7 +27,7 @@ from torch.testing._internal.common_utils import \
      TEST_WITH_ROCM, IS_FBCODE, IS_REMOTE_GPU, iter_indices,
      make_fullrank_matrices_with_distinct_singular_values,
      freeze_rng_state, IS_ARM64, IS_SANDCASTLE, TEST_OPT_EINSUM, isRocmArchAnyOf, parametrize, skipIfTorchDynamo,
-     skipIfRocmArch, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest,
+     skipIfRocmArch, skipIfRocmVersionAtLeast, setBlasBackendsToDefaultFinally, setLinalgBackendsToDefaultFinally, serialTest,
      runOnRocmArch, MI200_ARCH, MI300_ARCH, MI350_ARCH, NAVI_ARCH, TEST_CUDA)
 from torch.testing._internal.common_device_type import \
     (instantiate_device_type_tests, dtypes, has_cusolver, onlyCPU, skipIf, skipCUDAIfNoMagma, skipCPUIfNoLapack, precisionOverride,
@@ -3256,6 +3256,7 @@ class TestLinalg(TestCase):
 
     @skipCUDAIfNoCusolver
     @skipCPUIfNoLapack
+    @skipIfRocmVersionAtLeast([7, 14])
     @dtypes(*floating_and_complex_types())
     @precisionOverride({torch.float32: 1e-3, torch.complex64: 1e-3,
                         torch.float64: 1e-8, torch.complex128: 1e-8})

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2227,6 +2227,25 @@ def skipIfRocmVersionLessThan(version=None):
         return wrap_fn
     return dec_fn
 
+# Skips a test on ROCm if the version is at least the given major.minor tuple.
+def skipIfRocmVersionAtLeast(version=None):
+    def dec_fn(fn):
+        @wraps(fn)
+        def wrap_fn(self, *args, **kwargs):
+            if TEST_WITH_ROCM:
+                rocm_version_tuple = getRocmVersion()
+                if (
+                    rocm_version_tuple is not None
+                    and version is not None
+                    and rocm_version_tuple >= tuple(version)
+                ):
+                    raise unittest.SkipTest(
+                        f"ROCm version at least {version}: known failure"
+                    )
+            return fn(self, *args, **kwargs)
+        return wrap_fn
+    return dec_fn
+
 def skipIfNotMiopenSuggestNHWC(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
Add `skipIfRocmVersionAtLeast` decorator and skip the known-failure cholesky batched many-batches linalg test on ROCm 7.14+.

Skipped tests:
- test_linalg.py::test_linalg::test_cholesky_solve_batched_many_batches_cuda_complex128
- test_linalg.py::test_linalg::test_cholesky_solve_batched_many_batches_cuda_complex64
- test_linalg.py::test_linalg::test_cholesky_solve_batched_many_batches_cuda_float64
- test_linalg.py::test_linalg::test_cholesky_solve_batched_many_batches_cuda_float32

Partial cherry-pick of https://github.com/ROCm/pytorch/commit/6296fc45c2ed2efbdfa4ef773b6edde7e0e5bf5b

Co-authored-by: chinmaydk99 <ChinmayDattanand.Kuchinad@amd.com>