### PR TITLE
[release/2.12] Ensure sdpa backend gets set to default after tests (#182852)

### DIFF
--- a/test/test_transformers.py
+++ b/test/test_transformers.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_utils import (
     NOTEST_CPU,
     TEST_WITH_TORCHDYNAMO,
     TEST_XPU,
+    setSdpaBackendsToDefaultFinally,
 )
 from torch._dynamo.testing import CompileCounterWithBackend
 
@@ -3977,6 +3978,7 @@ class TestSDPACudaOnly(NNTestCase):
         "Does not support SDPA or pre-SM80 hardware",
     )
     @unittest.skipIf(IS_JETSON, "causing sigkill on Jetson")
+    @setSdpaBackendsToDefaultFinally
     @parametrize("batch_size", [1, 8])
     @parametrize("seq_len_q", [4, 143, 2048])
     @parametrize("seq_len_k", [4, 127, 579, 2048])

--- a/test/test_varlen_attention.py
+++ b/test/test_varlen_attention.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     decorateIf,
     parametrize,
     run_tests,
+    setSdpaBackendsToDefaultFinally,
     TEST_WITH_ROCM,
 )
 from torch.utils._python_dispatch import TorchDispatchMode
@@ -292,6 +293,7 @@ class TestVarlenAttention(NNTestCase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
+    @setSdpaBackendsToDefaultFinally
     @parametrize("dtype", [torch.bfloat16, torch.float16])
     @parametrize(
         "sdpa_backend",
@@ -370,6 +372,7 @@ class TestVarlenAttention(NNTestCase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
+    @setSdpaBackendsToDefaultFinally
     @parametrize(
         "sdpa_backend",
         ["aotriton", "ck"] if PLATFORM_SUPPORTS_CK_SDPA else ["aotriton"],
@@ -451,6 +454,7 @@ class TestVarlenAttention(NNTestCase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
+    @setSdpaBackendsToDefaultFinally
     @parametrize(
         "sdpa_backend",
         ["aotriton", "ck"] if PLATFORM_SUPPORTS_CK_SDPA else ["aotriton"],
@@ -521,6 +525,7 @@ class TestVarlenAttention(NNTestCase):
     @unittest.skipIf(
         not PLATFORM_SUPPORTS_FLASH_ATTENTION, "Flash Attention not supported"
     )
+    @setSdpaBackendsToDefaultFinally
     @parametrize(
         "sdpa_backend",
         ["aotriton", "ck"] if PLATFORM_SUPPORTS_CK_SDPA else ["aotriton"],
@@ -836,6 +841,7 @@ class TestVarlenAttention(NNTestCase):
         lambda params: params["backend"] != "fa2"
         and any(kv_len < 128 for kv_len in params["actual_kv_lens"]),
     )
+    @setSdpaBackendsToDefaultFinally
     @parametrize(
         "sdpa_backend",
         ["aotriton", "ck"] if PLATFORM_SUPPORTS_CK_SDPA else ["aotriton"],

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2311,6 +2311,15 @@ def setBlasBackendsToDefaultFinally(fn):
             torch.backends.cuda.preferred_blas_library(_preferred_backend)
     return _fn
 
+def setSdpaBackendsToDefaultFinally(fn):
+    @wraps(fn)
+    def _fn(*args, **kwargs):
+        _preferred_backend = torch.backends.cuda.preferred_rocm_fa_library()
+        try:
+            fn(*args, **kwargs)
+        finally:
+            torch.backends.cuda.preferred_rocm_fa_library(_preferred_backend)
+    return _fn
 
 # Context manager for setting deterministic flag and automatically
 # resetting it to its original value


### PR DESCRIPTION
On ROCm, tests that call `torch.backends.cuda.preferred_rocm_fa_library("ck")` leave a process-global CK preference set. Later tests that do not reset it still route flash attention through CK, which can cause unrelated failures - for example, test_flash_attention_vs_math_ref_grads_nestedtensor with head_dim=160 hitting the CK varlen backward limit of 128.

This commit adds a test helper, `setSdpaBackendsToDefaultFinally`, that saves the current preferred ROCm FA backend before a test runs and restores it in a finally block. It is applied to tests that explicitly switch between AOTriton and CK:

test_flash_attention_vs_math_ref_grads in test/test_transformers.py
Five varlen attention tests in test/test_varlen_attention.py
This prevents SDPA backend preference from leaking between parametrized test runs and across tests in the same process.

Fixed tests:
- test_transformers.py::TestSDPACudaOnlyCUDA::test_flash_attention_vs_math_ref_grads_nestedtensor_batch_size_32_max_seq_len_q_256_max_seq_len_kv_256_head_dim_160_dropout_p_0_0_float16_scale0_is_causal_False_cuda_float16

(cherry picked from commit 019d919cb7d8c8ccf9d3c538fad2d333779062fb)