### PR TITLE
release/2.14 bringup: pin requirements files

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -15,7 +15,7 @@ build==1.3.0
 #Pinned versions: 1.3.0
 #test that import:
 
-click
+click==8.3.3
 #Description: Command Line Interface Creation Kit
 #Pinned versions:
 #test that import:
@@ -42,8 +42,10 @@ expecttest==0.3.0
 #Pinned versions: 0.3.0
 #test that import:
 
-fbscribelogger==0.1.7
+fbscribelogger==0.1.7 ; python_version < "3.14"
 #Description: write to scribe from authenticated jobs on CI
+#fbscribelogger caps thriftpy2<0.6.0, which has no cp314 wheel; skip on 3.14
+#(no-op on OSS/ROCm CI anyway) to avoid a source build in the compiler-less test image
 #Pinned versions: 0.1.6
 #test that import:
 
@@ -68,7 +70,7 @@ lark==0.12.0
 #Pinned versions: 0.12.0
 #test that import:
 
-librosa>=0.6.2 ; python_version < "3.11" and platform_machine != "s390x" and platform_machine != "riscv64"
+librosa==0.11.0 ; python_version < "3.11" and platform_machine != "s390x" and platform_machine != "riscv64"
 librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x" and platform_machine != "riscv64"
 #Description: A python package for music and audio analysis
 #Pinned versions: >=0.6.2
@@ -105,7 +107,9 @@ mypy==1.16.0 ; platform_system == "Linux"
 #Pinned versions: 1.16.0
 #test that import: test_typing.py, test_type_hints.py
 
-networkx==2.8.8
+networkx==2.8.8 ; python_version < "3.13"
+networkx==3.6.1 ; python_version >= "3.13"
+#scikit-image>=0.26 (pinned below for 3.13+) requires networkx>=3.0
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
 #Pinned versions: 2.8.8
@@ -179,7 +183,7 @@ protobuf==6.33.5
 #Pinned versions: 6.33.2
 #test that import: test_tensorboard.py, test/onnx/*
 
-psutil
+psutil==7.2.2
 #Description: information on running processes and system utilization
 #Pinned versions:
 #test that import: test_profiler.py, test_openmp.py, test_dataloader.py
@@ -199,7 +203,7 @@ pytest-flakefinder==1.1.0
 #Pinned versions: 1.1.0
 #test that import:
 
-pytest-rerunfailures>=10.3
+pytest-rerunfailures==14.0
 #Description: plugin for rerunning failure tests in pytest
 #Pinned versions:
 #test that import:
@@ -244,8 +248,10 @@ pygments==2.20.0
 #Pinned versions: 14.1.0
 #test that import:
 
-scikit-image==0.22.0
+scikit-image==0.22.0 ; python_version < "3.13"
+scikit-image==0.26.0 ; python_version >= "3.13"
 #Description: image processing routines
+#0.22.0 has no cp313/cp314 wheel; 0.26.0 ships wheels for 3.13/3.14
 #Pinned versions: 0.22.0
 #test that import: test_nn.py
 
@@ -281,7 +287,7 @@ typing-extensions==4.15.0 ; python_version >= "3.14"
 #Pinned versions:
 #test that import:
 
-unittest-xml-reporting<=3.2.0,>=2.0.0
+unittest-xml-reporting==3.2.0
 #Description: saves unit test results to xml
 #Pinned versions:
 #test that import:
@@ -298,7 +304,7 @@ spin==0.17
 #Pinned versions: 0.17
 #test that import:
 
-redis>=4.0.0
+redis==8.1.0
 #Description: redis database
 #test that import: anything that tests OSS caching/mocking (inductor/test_codecache.py, inductor/test_max_autotune.py)
 
@@ -329,9 +335,11 @@ tensorboard==2.18.0 ; python_version >= "3.13"
 #test that import: test_tensorboard
 
 pywavelets==1.4.1 ; python_version < "3.12"
-pywavelets==1.7.0 ; python_version >= "3.12"
+pywavelets==1.7.0 ; python_version >= "3.12" and python_version < "3.14"
+pywavelets==1.9.0 ; python_version >= "3.14"
 #Description: This is a requirement of scikit-image, we need to pin
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
+# 1.7.0 has no cp314 wheel; 1.9.0 ships wheels for 3.14
 #Pinned versions: 1.4.1
 #test that import:
 
@@ -378,10 +386,11 @@ pwlf==2.2.1
 # To build PyTorch itself
 pip==26.1.2
 pyyaml==6.0.3
-pyzstd
+pyzstd==0.16.2 ; python_version < "3.13"
+pyzstd==0.19.1 ; python_version >= "3.13"
 setuptools==78.1.1
 packaging==24.2
-six
+six==1.17.0
 
 scons==4.5.2 ; platform_machine == "aarch64"
 
@@ -404,11 +413,11 @@ tlparse==0.4.0
 filelock==3.20.3
 #Description: required for inductor testing
 
-cuda-bindings>=13.0,<14.0 ; platform_machine != "s390x" and platform_machine != "riscv64" and platform_system != "Darwin"
+cuda-bindings==13.3.1 ; platform_machine != "s390x" and platform_machine != "riscv64" and platform_system != "Darwin"
 #Description: required for testing CUDAGraph::raw_cuda_graph(). See https://nvidia.github.io/cuda-python/cuda-bindings/latest/support.html for how this version was chosen. PyTorch CI CUDA builds use CUDA 13, so depend on the matching cuda-bindings major while allowing minor updates within that major.
 #test that import: test_cuda.py
 
-cupti-python>13.0 ; platform_system == "Linux" and (platform_machine == "x86_64" or platform_machine == "aarch64") and python_version < "3.14"
+cupti-python==13.3.1 ; platform_system == "Linux" and (platform_machine == "x86_64" or platform_machine == "aarch64") and python_version < "3.14"
 #Description: required for the experimental CUPTI monitor (torch.profiler._cupti_monitor). >13.0 to match CUDA 13.x toolkits. cupti-python only ships Linux x86_64/aarch64 CPython wheels (no 3.14/free-threaded yet), so guard to those.
 #test that import: test_profiler.py
 
@@ -422,7 +431,7 @@ pyre-extensions==0.0.32
 tabulate==0.9.0
 #Description: These package are needed to build FBGEMM and torchrec on PyTorch CI
 
-tqdm>=4.66.0
+tqdm==4.70.0
 #Description: progress bar library required for dynamo benchmarks
 #test that import: benchmarks/dynamo/*
 
@@ -434,7 +443,7 @@ spin==0.17
 #Pinned versions: 0.17
 #test that import: spincli/test_spin.py
 
-uv
+uv==0.12.5
 #Description: required for running spin commands via uvx
 #Pinned version:
 #test that import:

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,15 +1,17 @@
 # Build System requirements
 # 1.0 is required for [[tool.dynamic-metadata]] and the env table; see
 # pyproject.toml for the rationale on this lower bound.
-scikit-build-core>=1.0
-setuptools>=77.0.0,<82  # 77.0 is the first release with PEP 639 license-files support
-spin
-cmake>=3.27
-ninja
-numpy
-packaging>=24.2  # required by setuptools>=77 to validate PEP 639 license expressions
-pyyaml
-requests
-six  # dependency chain: NNPACK -> PeachPy -> six
-typing-extensions>=4.15.0
-pip  # not technically needed, but this makes setup.py invocation work
+scikit-build-core==1.0.3
+setuptools==81.0.0  # 77.0 is the first release with PEP 639 license-files support (constraint was >=77.0.0,<82)
+spin==0.18
+cmake==4.4.2
+ninja==1.13.0
+numpy==2.2.6 ; python_version < "3.11"
+numpy==2.4.6 ; python_version == "3.11"
+numpy==2.5.2 ; python_version >= "3.12"
+packaging==26.3  # required by setuptools>=77 to validate PEP 639 license expressions
+pyyaml==6.0.3
+requests==2.34.2
+six==1.17.0  # dependency chain: NNPACK -> PeachPy -> six
+typing-extensions==4.16.0
+pip==26.1.2  # not technically needed, but this makes setup.py invocation work

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,16 +4,17 @@
 -r requirements-build.txt
 
 # Install / Development extra requirements
-build[uv]  # for building sdist and wheel
-expecttest>=0.3.0
-filelock
-fsspec>=0.8.5
-hypothesis
-jinja2
-lintrunner ; platform_machine != "s390x"
-networkx>=2.5.1
-optree>=0.13.0
-psutil
-spin
-sympy>=1.13.3
-wheel
+build[uv]==1.5.0  # for building sdist and wheel
+expecttest==0.3.0
+filelock==3.32.3
+fsspec==2026.7.0
+hypothesis==6.165.10
+jinja2==3.1.6
+lintrunner==0.13.1 ; platform_machine != "s390x"
+networkx==3.4.2 ; python_version < "3.11"
+networkx==3.6.1 ; python_version >= "3.11"
+optree==0.19.1
+psutil==7.2.2
+spin==0.18
+sympy==1.14.0
+wheel==0.48.0


### PR DESCRIPTION
## Summary

Pin Python dependencies for the `release/2.14` bringup so CI and builds are reproducible, and make everything resolve cleanly on Python **3.10 / 3.11 / 3.12 / 3.13 / 3.14**. Mirrors the 2.13 bringup (#3445), plus the extra version-conditional bumps needed for 3.13/3.14.

Three commits, one per file:

- `requirements.txt` — pin all direct dev/install deps (with a `python_version` split for `networkx`).
- `requirements-build.txt` — pin all build-system deps (with a `python_version` split for `numpy`).
- `.ci/docker/requirements-ci.txt` — pin the previously-loose entries (`click`, `psutil`, `pytest-rerunfailures`, `unittest-xml-reporting`, `redis`, `pyzstd` split, `six`, `cuda-bindings`, `cupti-python`, `tqdm`, `uv`, `librosa`) and add `python_version` conditionals for 3.13/3.14.

## Per-version splits (dev/build)

- **numpy** (build): `2.2.6` (<3.11), `2.4.6` (==3.11), `2.5.2` (>=3.12).
- **networkx** (dev): `3.4.2` (<3.11), `3.6.1` (>=3.11).

Every other dev/build dep resolved identically across 3.10–3.14, so those are flat-pinned.

## 3.13 / 3.14 conditional bumps in requirements-ci.txt (new vs 2.13)

- **scikit-image**: `0.22.0` for `< 3.13`, `0.26.0` for `>= 3.13` (0.22.0 has no cp313/cp314 wheel).
- **networkx**: `2.8.8` for `< 3.13`, `3.6.1` for `>= 3.13` (scikit-image 0.26 requires networkx>=3.0; keeping 2.8.8 forced pip to backtrack to a wheelless scikit-image).
- **pywavelets**: adds `1.9.0` for `>= 3.14` (1.7.0 has no cp314 wheel).
- **fbscribelogger**: guarded to `< 3.14` (its `thriftpy2` dep has no cp314 wheel and would source-build in the compiler-less test image) — mirrors 2.13.

## How versions were resolved

Per the documented process (AIPYTORCH-748): installed each requirements file in a fresh venv inside an `ubuntu:24.04` container (deadsnakes for the non-native Python versions) and pinned the `pip freeze` output. Verified all files install on **3.10–3.14** with no new compiler-dependent source builds (only pre-existing `coremltools` for <3.12 and pure-Python `pwlf`).

## Test plan

TheRock CI `multi_arch_build_portable_linux_pytorch_wheels.yml` (gfx94X-dcgpu, ROCm 7.15.0a20260712, `pytorch_git_ref` = the pinned integration branch). The **Build job passed for every Python version** — torch + torchaudio + torchvision + triton + apex all built against the pinned requirements:

- [x] Python 3.10 — build ✅ [run 32165499080](https://github.com/ROCm/TheRock/actions/runs/32165499080)
- [x] Python 3.11 — build ✅ [run 32165508608](https://github.com/ROCm/TheRock/actions/runs/32165508608)
- [x] Python 3.12 — build ✅ [run 32165519879](https://github.com/ROCm/TheRock/actions/runs/32165519879)
- [x] Python 3.13 — build ✅ [run 32165528430](https://github.com/ROCm/TheRock/actions/runs/32165528430)
- [x] Python 3.14 — build ✅ [run 32165536568](https://github.com/ROCm/TheRock/actions/runs/32165536568)

> Note: the downstream GPU **Test** job hit a transient 30-min git-clone timeout in its "Checkout PyTorch Source Repos" step (infra/network, unrelated to these pins). The build — which is what exercises the requirements files — is green across all five versions.
