### PR TITLE
[release/2.14] [ROCm] Optimize AMD normalization backward kernel by using tiled and …

### DIFF
--- a/aten/src/ATen/native/cuda/layer_norm_kernel.cu
+++ b/aten/src/ATen/native/cuda/layer_norm_kernel.cu
@@ -988,6 +988,14 @@ void ConfigureAndLaunchGammaBetaBackwardKernel(
 
 }
 
+// We have a situation where M >> N and N is small: parallelizing gamma/beta
+// backward across the M dimension in a separate kernel (below) pays off vs.
+// the single fused-tile kernel. Shared by LaunchGammaBetaBackwardCUDAKernel's
+// internal check and its ROCm caller so the two conditions cannot diverge.
+inline bool ShouldUseHugeMGammaBetaBackwardKernel(int64_t M, int64_t N, int block_dim_x, int sm_count) {
+  return M > 64 * 1024 && N / block_dim_x < sm_count / 2;
+}
+
 // Accept block_dim_x as a template parameter so ROCm can dispatch launch
 // shapes based on runtime warp size while preserving compile-time specialization.
 template<typename T, typename T_ACC, int block_dim_x, bool rms_norm>
@@ -1002,7 +1010,7 @@ void LaunchGammaBetaBackwardCUDAKernel(
     Tensor* dbeta,
     cudaStream_t cuda_stream) {
   const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-  if (M > 64 * 1024 && N / block_dim_x < sm_count / 2) {
+  if (ShouldUseHugeMGammaBetaBackwardKernel(M, N, block_dim_x, sm_count)) {
     // We have a situation where M >> N and N is small.
     // In this case we can speed up the computation by parallelizing in the M dimension.
     // We launch multiple blocks in the y-dimension, and compute partial sums for the
@@ -1273,17 +1281,23 @@ void cuLoadWriteStridedInputs(
       if (i2<N) {
         T curr_input = static_cast<T>(input[load_idx]);
         T curr_dout = static_cast<T>(dout[load_idx]);
-        warp_buf1[write_idx] = curr_dout;
+        if constexpr (!rms_norm) {
+          warp_buf1[write_idx] = curr_dout;
+        }
         warp_buf2[write_idx] = curr_dout * (curr_input - curr_mean) * curr_rstd;
       } else {
-        warp_buf1[write_idx] = T(0);
+        if constexpr (!rms_norm) {
+          warp_buf1[write_idx] = T(0);
+        }
         warp_buf2[write_idx] = T(0);
       }
     }
   } else {
     for (int k = 0;  k < blockDim.y;  ++k) {
       int write_idx = thr_load_row_off*row_stride+thr_load_col_off+k;
-      warp_buf1[write_idx] = T(0);
+      if constexpr (!rms_norm) {
+        warp_buf1[write_idx] = T(0);
+      }
       warp_buf2[write_idx] = T(0);
     }
   }
@@ -1320,7 +1334,9 @@ void cuLoadAddStridedInputs(
       if (i2<N) {
         T_ACC curr_input = static_cast<T_ACC>(input[load_idx]);
         T_ACC curr_dout = static_cast<T_ACC>(dout[load_idx]);
-        warp_buf1[write_idx] += curr_dout;
+        if constexpr (!rms_norm) {
+          warp_buf1[write_idx] += curr_dout;
+        }
         warp_buf2[write_idx] += curr_dout * (curr_input - curr_mean) * curr_rstd;
       }
     }
@@ -1365,10 +1381,14 @@ void cuComputePartGradGammaBeta(
     for (int k = 0;  k < blockDim.y;  ++k) {
       int row1 = threadIdx.y + k*blockDim.y;
       int idx1 = row1*row_stride + threadIdx.x;
-      acc1 += warp_buf1[idx1];
+      if constexpr (!rms_norm) {
+        acc1 += warp_buf1[idx1];
+      }
       acc2 += warp_buf2[idx1];
     }
-    warp_buf1[threadIdx.y*row_stride+threadIdx.x] = acc1;
+    if constexpr (!rms_norm) {
+      warp_buf1[threadIdx.y*row_stride+threadIdx.x] = acc1;
+    }
     warp_buf2[threadIdx.y*row_stride+threadIdx.x] = acc2;
     __syncthreads();
     // sum all warps
@@ -1378,7 +1398,9 @@ void cuComputePartGradGammaBeta(
         int row2 = threadIdx.y + offset;
         int idx1 = row1*row_stride + threadIdx.x;
         int idx2 = row2*row_stride + threadIdx.x;
-        warp_buf1[idx1] += warp_buf1[idx2];
+        if constexpr (!rms_norm) {
+          warp_buf1[idx1] += warp_buf1[idx2];
+        }
         warp_buf2[idx1] += warp_buf2[idx2];
       }
       __syncthreads();
@@ -1389,7 +1411,9 @@ void cuComputePartGradGammaBeta(
       int row2 = threadIdx.y + 1;
       int idx1 = row1*row_stride + threadIdx.x;
       int idx2 = row2*row_stride + threadIdx.x;
-      part_grad_beta[blockIdx.y*N+i2] = warp_buf1[idx1] + warp_buf1[idx2];
+      if constexpr (!rms_norm) {
+        part_grad_beta[blockIdx.y*N+i2] = warp_buf1[idx1] + warp_buf1[idx2];
+      }
       part_grad_gamma[blockIdx.y*N+i2] = warp_buf2[idx1] + warp_buf2[idx2];
     }
 }
@@ -1414,7 +1438,12 @@ void cuComputeGradGammaBeta(
     T_ACC sum_gamma = T_ACC(0);
     T_ACC sum_beta = T_ACC(0);
     const T_ACC* part_grad_gamma_ptr = part_grad_gamma + threadIdx.y * num_warp_reductions * N + i2;
-    const T_ACC* part_grad_beta_ptr = part_grad_beta + threadIdx.y * num_warp_reductions * N + i2;
+    // part_grad_beta is nullptr when rms_norm (see LaunchTwoPassGammaBetaBackwardCUDAKernel),
+    // so only form the offset pointer when it will actually be dereferenced below.
+    const T_ACC* part_grad_beta_ptr = nullptr;
+    if constexpr (!rms_norm) {
+      part_grad_beta_ptr = part_grad_beta + threadIdx.y * num_warp_reductions * N + i2;
+    }
 
     if (i2 < N) {
         for (int warp_offset = 0;  warp_offset < num_warp_reductions;  ++warp_offset) {
@@ -1457,6 +1486,60 @@ void cuComputeGradGammaBeta(
           }
       }
     }
+}
+
+// Two-pass gamma/beta backward: cuComputePartGradGammaBeta reduces
+// dgamma/dbeta partial sums across part_size row-blocks, then
+// cuComputeGradGammaBeta finishes the reduction across those partial sums.
+template <typename T, typename T_ACC, bool rms_norm>
+void LaunchTwoPassGammaBetaBackwardCUDAKernel(
+    const T* dY_data,
+    const Tensor& X,
+    const T_ACC* mean_data,
+    const T_ACC* rstd_data,
+    int64_t M,
+    int64_t N,
+    int warp_size,
+    Tensor* dgamma,
+    Tensor* dbeta,
+    cudaStream_t cuda_stream) {
+  const T* X_data = X.const_data_ptr<T>();
+  T* dgamma_data = dgamma->defined() ? dgamma->template data_ptr<T>() : nullptr;
+  T* dbeta_data = dbeta->defined() ? dbeta->template data_ptr<T>() : nullptr;
+  const int part_size = warp_size;
+  const dim3 threads2(warp_size, 4, 1);
+  const dim3 blocks2((N + threads2.x - 1) / threads2.x, part_size, 1);
+  const int nshared2_a = 2 * sizeof(T_ACC) * threads2.y * threads2.y * (threads2.x + 1);
+  const int nshared2_b = threads2.x * threads2.y * sizeof(T_ACC);
+  const int nshared2 = nshared2_a > nshared2_b ? nshared2_a : nshared2_b;
+
+  const auto part_grad_dtype = at::toAccumulateType(X.scalar_type(), true);
+  Tensor part_grad_gamma = at::empty({part_size, N}, X.options().dtype(part_grad_dtype));
+  // part_grad_beta is only meaningful for the layer_norm (non-rms) backward:
+  // cuComputeGradGammaBeta discards it under if constexpr (!rms_norm), so
+  // skip allocating and writing it entirely when rms_norm is true.
+  T_ACC* part_grad_beta_data = nullptr;
+  Tensor part_grad_beta;
+  if constexpr (!rms_norm) {
+    part_grad_beta = at::native::empty_like(part_grad_gamma);
+    part_grad_beta_data = part_grad_beta.template data_ptr<T_ACC>();
+  }
+
+  cuComputePartGradGammaBeta<T, T_ACC, rms_norm><<<blocks2, threads2, nshared2, cuda_stream>>>(
+      dY_data, X_data, M, N, mean_data, rstd_data,
+      part_grad_gamma.template data_ptr<T_ACC>(),
+      part_grad_beta_data);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
+
+  const dim3 threads3(warp_size, 8, 1); // Optimization for ROCm
+  const dim3 blocks3((N + threads3.x - 1) / threads3.x, 1, 1);
+  const int nshared3 = threads3.x * threads3.y * sizeof(T_ACC);
+
+  cuComputeGradGammaBeta<T, T_ACC, rms_norm><<<blocks3, threads3, nshared3, cuda_stream>>>(
+      part_grad_gamma.template data_ptr<T_ACC>(),
+      part_grad_beta_data,
+      part_size, M, N, dgamma_data, dbeta_data);
+  C10_CUDA_KERNEL_LAUNCH_CHECK();
 }
 
 template<typename T, typename T_ACC, bool rms_norm> __global__
@@ -1694,21 +1777,37 @@ void LayerNormBackwardKernelImplInternal(
               dbeta_data);
       C10_CUDA_KERNEL_LAUNCH_CHECK();
     } else {
-      // Use the optimized tiled kernel adapted for the current warp size.
-      // This replaces the legacy two-pass cuComputePartGradGammaBeta +
-      // cuComputeGradGammaBeta approach with a single-pass tiled reduction
-      // that has coalesced memory access and adaptive tile sizing.
-      if (warp_size == 64) {
-        LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, 64, rms_norm>(
-          dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
-      } else if (warp_size == 32) {
-        LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, 32, rms_norm>(
-          dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
+      const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
+      // Hoisted above the dispatch below: an unexpected warp size must be
+      // caught regardless of which path (tiled or two-pass) M would route to.
+      TORCH_INTERNAL_ASSERT(
+          warp_size == 32 || warp_size == 64,
+          "Unexpected ROCm warp size: ",
+          warp_size);
+      // Below this M the single-pass tiled kernel still wins on ROCm; above it
+      // the two-pass kernel's M-parallel reduction more than pays for the
+      // extra launch and the part_grad round trip. Bracketed by benchmarks on
+      // MI350X: every measured tiled win is at M <= 1024, every measured
+      // two-pass win at M >= 4096.
+      constexpr int64_t kGammaBetaTwoPassMinM = 2048;
+      // LaunchGammaBetaBackwardCUDAKernel also special-cases M >> N (huge M,
+      // small N), which stays on the tiled M-parallel path regardless of the
+      // bound above.
+      const bool use_tiled_kernel = M < kGammaBetaTwoPassMinM ||
+          ShouldUseHugeMGammaBetaBackwardKernel(M, N, warp_size, sm_count);
+      if (use_tiled_kernel) {
+        // Single-pass tiled reduction with coalesced memory access and
+        // adaptive tile sizing, dispatched on the current warp size.
+        if (warp_size == 64) {
+          LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, 64, rms_norm>(
+            dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
+        } else {
+          LaunchGammaBetaBackwardCUDAKernel<T, T_ACC, 32, rms_norm>(
+            dY_data, X_data, mean_data, rstd_data, M, N, dgamma, dbeta, cuda_stream);
+        }
       } else {
-        TORCH_INTERNAL_ASSERT(
-            false,
-            "Unexpected ROCm warp size: ",
-            warp_size);
+        LaunchTwoPassGammaBetaBackwardCUDAKernel<T, T_ACC, rms_norm>(
+            dY_data, X, mean_data, rstd_data, M, N, warp_size, dgamma, dbeta, cuda_stream);
       }
     }
 #else

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -8464,6 +8464,164 @@ class TestNNDeviceType(NNTestCase):
 
         self.assertEqual(Y_ref, Y)
 
+    @onlyCUDA
+    def test_layer_norm_gamma_beta_backward_dispatch_bands(self, device):
+        # Only fp32 was covered at M >= 128 before this PR
+        # (test_layer_norm_backwards_eps), and rms_norm had no gamma/beta
+        # backward coverage above M=2 anywhere in the repo. Sweep both the
+        # restored ROCm tile-shape band (M < kGammaBetaTwoPassMinM) and the
+        # two-pass band (M >= kGammaBetaTwoPassMinM) across fp16/bf16/fp32
+        # for both layer_norm and rms_norm.
+        # fp32 uses test_layer_norm_backwards_eps's default tolerances
+        # (atol=1e-4, rtol=1e-5) in the tiled band, but M >= 2048 routes
+        # through a block-parallel reduction whose summation order differs
+        # from the CPU reference's. That noise does not shrink with the
+        # reference magnitude, so near-zero entries need a larger atol;
+        # match the 1e-3 test_layer_norm_gamma_beta_backward_dispatch_boundaries
+        # uses for the same band.
+        tolerances = {
+            torch.float16: (1e-2, 1e-3),
+            torch.bfloat16: (1e-2, 1.6e-2),
+            torch.float32: (1e-4, 1e-5),
+        }
+        eps = 1e-5
+        for op in ("layer_norm", "rms_norm"):
+            for dtype in (torch.float16, torch.bfloat16, torch.float32):
+                for N in (768, 1024):
+                    for M in (128, 192, 1024, 2047, 2048, 4096):
+                        atol, rtol = tolerances[dtype]
+                        if dtype is torch.float32 and M >= 2048:
+                            atol, rtol = 1e-3, 1e-3
+                        msg = f"op={op} dtype={dtype} M={M} N={N}"
+                        x = torch.randn(M, N, dtype=dtype, device=device)
+                        weight = torch.randn(N, dtype=dtype, device=device)
+                        grad_out = torch.randn(M, N, dtype=dtype, device=device)
+                        x_cpu = x.float().cpu()
+                        weight_cpu = weight.float().cpu()
+                        grad_out_cpu = grad_out.float().cpu()
+
+                        if op == "layer_norm":
+                            bias = torch.randn(N, dtype=dtype, device=device)
+                            bias_cpu = bias.float().cpu()
+                            _, mean, rstd = torch.ops.aten.native_layer_norm.default(
+                                x, [N], weight, bias, eps)
+                            _, dgamma, dbeta = torch.ops.aten.native_layer_norm_backward.default(
+                                grad_out, x, [N], mean, rstd, weight, bias, [False, True, True])
+                            _, mean_cpu, rstd_cpu = torch.ops.aten.native_layer_norm.default(
+                                x_cpu, [N], weight_cpu, bias_cpu, eps)
+                            _, dgamma_ref, dbeta_ref = torch.ops.aten.native_layer_norm_backward.default(
+                                grad_out_cpu, x_cpu, [N], mean_cpu, rstd_cpu, weight_cpu, bias_cpu,
+                                [False, True, True])
+                            self.assertEqual(dgamma.float().cpu(), dgamma_ref, msg, atol=atol, rtol=rtol)
+                            self.assertEqual(dbeta.float().cpu(), dbeta_ref, msg, atol=atol, rtol=rtol)
+                        else:
+                            _, rstd = torch.ops.aten._fused_rms_norm.default(x, [N], weight, eps)
+                            _, dgamma = torch.ops.aten._fused_rms_norm_backward.default(
+                                grad_out, x, [N], rstd, weight, [False, True])
+                            # aten::_fused_rms_norm_backward has no CPU kernel, so build the
+                            # reference through the decomposed rms_norm autograd path instead.
+                            x_cpu = x_cpu.requires_grad_(True)
+                            weight_cpu = weight_cpu.requires_grad_(True)
+                            out_cpu = torch.nn.functional.rms_norm(x_cpu, [N], weight_cpu, eps)
+                            out_cpu.backward(grad_out_cpu)
+                            self.assertEqual(dgamma.float().cpu(), weight_cpu.grad, msg, atol=atol, rtol=rtol)
+
+    @onlyCUDA
+    def test_layer_norm_gamma_beta_backward_dispatch_boundaries(self, device):
+        # Pins the M=128 (simple-kernel cutoff), M=2048 (kGammaBetaTwoPassMinM),
+        # and M=65536 (huge-M switch) dispatch boundaries; previously only the
+        # M=65536-ish boundary had any coverage, via a single (131072, 32)
+        # shape in test_layer_norm_backwards_eps.
+        dtype = torch.float32
+        N = 64
+        eps = 1e-5
+        for M in (127, 128, 2047, 2048, 65535, 65536, 65537):
+            x = torch.randn(M, N, dtype=dtype, device=device)
+            weight = torch.randn(N, dtype=dtype, device=device)
+            bias = torch.randn(N, dtype=dtype, device=device)
+            grad_out = torch.randn(M, N, dtype=dtype, device=device)
+
+            _, mean, rstd = torch.ops.aten.native_layer_norm.default(x, [N], weight, bias, eps)
+            _, dgamma, dbeta = torch.ops.aten.native_layer_norm_backward.default(
+                grad_out, x, [N], mean, rstd, weight, bias, [False, True, True])
+
+            x_cpu, weight_cpu, bias_cpu, grad_out_cpu = (t.cpu() for t in (x, weight, bias, grad_out))
+            _, mean_cpu, rstd_cpu = torch.ops.aten.native_layer_norm.default(
+                x_cpu, [N], weight_cpu, bias_cpu, eps)
+            _, dgamma_ref, dbeta_ref = torch.ops.aten.native_layer_norm_backward.default(
+                grad_out_cpu, x_cpu, [N], mean_cpu, rstd_cpu, weight_cpu, bias_cpu, [False, True, True])
+
+            # The two-pass path (M >= kGammaBetaTwoPassMinM == 2048) reduces
+            # over all M rows in a different order than the CPU reference,
+            # so fp32 accumulation noise grows with M; its worst case is
+            # M=65535, just below the huge-M switch. Bump the tolerance for
+            # the whole two-pass/huge-M range rather than only M > 64*1024.
+            atol = 1e-3 if M >= 2048 else 1e-4
+            rtol = 1e-3 if M >= 2048 else 1e-4
+            msg = f"M={M}"
+            self.assertEqual(dgamma.cpu(), dgamma_ref, msg, atol=atol, rtol=rtol)
+            self.assertEqual(dbeta.cpu(), dbeta_ref, msg, atol=atol, rtol=rtol)
+
+    @onlyCUDA
+    @largeTensorTest("8GB")
+    def test_layer_norm_gamma_beta_backward_two_pass_at_huge_M(self, device):
+        # ShouldUseHugeMGammaBetaBackwardKernel gates the huge-M tiled path on
+        # N / warp_size < sm_count / 2; choose N so that predicate is false
+        # and LaunchTwoPassGammaBetaBackwardCUDAKernel actually runs at huge
+        # M, a combination with no in-tree coverage before this PR. N is
+        # derived from device properties since the threshold is arch-dependent.
+        props = torch.cuda.get_device_properties(device)
+        warp_size = getattr(props, "warp_size", 32)
+        N = warp_size * (props.multi_processor_count // 2 + 1)
+        M = 65537
+        dtype = torch.float16
+        eps = 1e-5
+
+        # All M rows identical (so mean/rstd are shared across rows) and dY
+        # constant reduces dgamma/dbeta to a closed form, so correctness can
+        # be checked without a second huge CPU reference tensor at this size.
+        x_row = torch.randn(N, dtype=torch.float32)
+        weight = torch.randn(N, dtype=dtype, device=device)
+        bias = torch.randn(N, dtype=dtype, device=device)
+        x = x_row.to(dtype=dtype, device=device).unsqueeze(0).expand(M, N).contiguous()
+        grad_out = torch.full((M, N), 1.0 / M, dtype=dtype, device=device)
+
+        _, mean, rstd = torch.ops.aten.native_layer_norm.default(x, [N], weight, bias, eps)
+        _, dgamma, dbeta = torch.ops.aten.native_layer_norm_backward.default(
+            grad_out, x, [N], mean, rstd, weight, bias, [False, True, True])
+
+        mean_f = x_row.mean()
+        rstd_f = torch.rsqrt(x_row.var(unbiased=False) + eps)
+        x_hat = (x_row - mean_f) * rstd_f
+        expected_dbeta = torch.ones(N)
+
+        self.assertEqual(dgamma.float().cpu(), x_hat, atol=5e-2, rtol=5e-2)
+        self.assertEqual(dbeta.float().cpu(), expected_dbeta, atol=5e-2, rtol=5e-2)
+
+    @onlyCUDA
+    def test_layer_norm_backward_undefined_gamma(self, device):
+        # Regression test for the crash this PR fixes: gamma.options() used
+        # to throw when gamma (weight) is undefined. F.layer_norm(..., weight=
+        # None, bias=b) with bias.requires_grad=True reaches
+        # LayerNormBackwardKernelImplInternal with an undefined gamma and a
+        # defined dbeta; nn.LayerNorm cannot produce this combination
+        # (elementwise_affine=False also drops bias), so it needs an explicit
+        # F.layer_norm call.
+        eps = 1e-5
+        M, N = 4096, 768
+        x = torch.randn(M, N, dtype=torch.float32, device=device)
+        bias = torch.randn(N, dtype=torch.float32, device=device, requires_grad=True)
+        grad_out = torch.randn(M, N, dtype=torch.float32, device=device)
+
+        out = torch.nn.functional.layer_norm(x, [N], None, bias, eps)
+        out.backward(grad_out)
+
+        bias_cpu = bias.detach().cpu().requires_grad_(True)
+        out_cpu = torch.nn.functional.layer_norm(x.cpu(), [N], None, bias_cpu, eps)
+        out_cpu.backward(grad_out.cpu())
+
+        self.assertEqual(bias.grad.cpu(), bias_cpu.grad, f"M={M} N={N}", atol=1e-4, rtol=1e-4)
+
     @onlyCPU
     def test_glu_bfloat16(self, device):
         def test_dtype(fn, input, dtype):


### PR DESCRIPTION
https://amd-hub.atlassian.net/browse/ROCM-24994

Upstream PR: https://github.com/pytorch/pytorch/pull/189405

Hugging Face model dropped **5-10%** after switching to tiled kernel (10+ model and tests). 

Implemented mixed approach, using combination of Tiled and Two Pass:

Hugging Face (huggingface_bart) performance is back:
Legacy Two pass performance=1652, 1644
Tiled performance                   =**1574, 1568**
Mixed performance                 =1649, 1652

Synthetic reproducer where performance from chess board like became  uniform, keeping benefits from both implementation:

# Layer Norm Backward Benchmark: Tiled only vs Tiled+Two pass

**Device:** AMD Instinct MI350X | **Warmup:** 20 | **Iters:** 100 | **Runs averaged:** 3  

## Summary (avg µs over 3 runs)

| Benchmark | Op | Shape | dtype | Branch | Tiled only | Tiled+Two pass | Δ (µs) | Speedup | Winner |
|-----------|-----|-------|-------|--------|------------|----------------|--------|---------|--------|
| tile8_small | layer_norm | (32, 512) | float16 | Tile-8 | 7.94 | 8.16 | -0.22 | 0.97× | ~tie |
| tile64_medium | layer_norm | (96, 768) | float16 | Tile-64 | 20.71 | 20.78 | -0.07 | 1.00× | ~tie |
| tile128_medium | layer_norm | (192, 1024) | bfloat16 | Tile-128 | 8.20 | 8.51 | -0.31 | 0.96× | ~tie |
| tile256_large | layer_norm | (4096, 1024) | float16 | Tile-256 | 31.07 | 13.12 | +17.95 | 2.37× | Two pass |
| tile256_bert | layer_norm | (1024, 768) | float16 | Tile-256 BERT | 11.15 | 11.05 | +0.10 | 1.01× | ~tie |
| tile256_large_bf16 | layer_norm | (4096, 1024) | bfloat16 | Tile-256 | 31.28 | 13.10 | +18.18 | 2.39× | Two pass |
| tile256_large_fp32 | layer_norm | (4096, 1024) | float32 | Tile-256 | 30.87 | 15.90 | +14.97 | 1.94× | Two pass |
| two_pass_huge_M | layer_norm | (131072, 64) | float16 | Two-pass M-parallel | 26.48 | 27.70 | -1.22 | 0.96× | ~tie |
| llm_hidden_4096 | layer_norm | (32, 4096, 4096) | bfloat16 | Tile-256 LLM | 509.65 | 513.38 | -3.73 | 0.99× | ~tie |
| gpt2_style | layer_norm | (8, 1024, 768) | float16 | Tile-256 GPT2 | 58.22 | 16.56 | +41.66 | 3.52× | Two pass |
| rms_tile256 | rms_norm | (4096, 1024) | float16 | Tile-256 rms | 22.34 | 11.18 | +11.16 | 2.00× | Two pass |
| rms_llm | rms_norm | (32, 4096, 4096) | bfloat16 | Tile-256 rms LLM | 476.18 | 476.03 | +0.15 | 1.00× | ~tie |
| rms_two_pass | rms_norm | (131072, 64) | float16 | Two-pass rms | 16.73 | 17.29 | -0.56 | 0.97× | ~tie |

Δ = Tiled only − Tiled+Two pass (negative = Two pass faster). Speedup = Tiled only / Tiled+Two pass.


Also result of generated test for correctness:
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[llm_hidden_4096] PASSED                                       [ 12%]
tests/test_correctness.py::test_rms_norm_gamma_backward_matches_cpu_reference[rms_two_pass] PASSED                                                 [ 16%]
tests/test_correctness.py::test_rms_norm_gamma_backward_matches_cpu_reference[rms_llm] PASSED                                                      [ 20%]
tests/test_correctness.py::test_configs_cover_all_tile_branches PASSED                                                                             [ 25%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[tile128_medium] PASSED                                        [ 29%]
tests/test_correctness.py::test_edge_case_shape_M_eq_1 PASSED                                                                                      [ 33%]
tests/test_correctness.py::test_rms_norm_autograd_matches_cpu_reference PASSED                                                                     [ 37%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[tile256_large] PASSED                                         [ 41%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[tile8_small] PASSED                                           [ 45%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[tile256_large_fp32] PASSED                                    [ 50%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[tile64_medium] PASSED                                         [ 54%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[tile256_bert] PASSED                                          [ 58%]
tests/test_correctness.py::test_output_mask_selects_expected_grads[dgamma_and_dbeta] PASSED                                                        [ 62%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[two_pass_huge_M] PASSED                                       [ 66%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[gpt2_style] PASSED                                            [ 70%]
tests/test_correctness.py::test_output_mask_selects_expected_grads[dgamma_only] PASSED                                                             [ 75%]
tests/test_correctness.py::test_rms_norm_gamma_backward_matches_cpu_reference[rms_tile256] PASSED                                                  [ 79%]
tests/test_correctness.py::test_noncontiguous_input_matches_reference PASSED                                                                       [ 83%]
tests/test_correctness.py::test_edge_case_shape_N_eq_1 PASSED                                                                                      [ 87%]
tests/test_correctness.py::test_layer_norm_gamma_beta_backward_matches_cpu_reference[tile256_large_bf16] PASSED                                    [ 91%]
tests/test_correctness.py::test_layer_norm_autograd_matches_cpu_reference PASSED                                                                   [ 95%]
tests/test_correctness.py::test_output_mask_selects_expected_grads[dbeta_only] PASSED                                                              [100%]

Used AI assistance from Cursor.

Short performance reproducer:
[layer_norm_gamma_beta_backward_reproducer.py](https://github.com/user-attachments/files/31031711/layer_norm_gamma_beta_backward_reproducer.py)
[run.sh](https://github.com/user-attachments/files/31031712/run.sh)
Pull Request resolved: https://github.com/pytorch/pytorch/pull/189405
Approved by: https://github.com/jeffdaily

