### PR TITLE
[release/2.13] Port upstream #194022: scikit-image 0.26.0 and networkx 3.5 for python >= 3.13

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -107,10 +107,11 @@ mypy==1.16.0 ; platform_system == "Linux"
 #Pinned versions: 1.16.0
 #test that import: test_typing.py, test_type_hints.py
 
-networkx==2.8.8
+networkx==2.8.8 ; python_version < "3.13"
+networkx==3.0.0 ; python_version >= "3.13"
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
-#Pinned versions: 2.8.8
+#Pinned versions: 2.8.8, 3.0.0
 #test that import: functorch
 
 ninja==1.13.0
@@ -244,9 +245,10 @@ pygments==2.20.0
 #Pinned versions: 14.1.0
 #test that import:
 
-scikit-image==0.22.0
+scikit-image==0.22.0 ; python_version < "3.13"
+scikit-image==0.26.0 ; python_version >= "3.13"
 #Description: image processing routines
-#Pinned versions: 0.22.0
+#Pinned versions: 0.22.0, 0.26.0
 #test that import: test_nn.py
 
 #scikit-learn

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -108,10 +108,11 @@ mypy==1.16.0 ; platform_system == "Linux"
 #test that import: test_typing.py, test_type_hints.py
 
 networkx==2.8.8 ; python_version < "3.13"
-networkx==3.0.0 ; python_version >= "3.13"
+networkx==3.5 ; python_version >= "3.13"
+# scikit-image 0.26.0 requires networkx>=3.0
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
-#Pinned versions: 2.8.8, 3.0.0
+#Pinned versions: 2.8.8, 3.5
 #test that import: functorch
 
 ninja==1.13.0
@@ -247,6 +248,9 @@ pygments==2.20.0
 
 scikit-image==0.22.0 ; python_version < "3.13"
 scikit-image==0.26.0 ; python_version >= "3.13"
+# 0.22.0 has no cp313/cp314 wheel, so pip builds it from source and picks up an
+# unpinned pythran that no longer compiles under the -std=c++14 its meson build
+# uses. 0.26.0 ships cp313/cp313t/cp314/cp314t wheels, so there is no source build.
 #Description: image processing routines
 #Pinned versions: 0.22.0, 0.26.0
 #test that import: test_nn.py


### PR DESCRIPTION
Ports upstream pytorch/pytorch#194022 to `release/2.13`. Reported in ROCm/TheRock#7448.

Deliberately not using a closing keyword: that issue also covers the `nightly` torch ref, which resolves from `pytorch/pytorch` and is fixed by the upstream commit itself once it reaches a nightly cut.

## What breaks

Installing `.ci/docker/requirements-ci.txt` fails on py3.13 and py3.14 while pip builds `scikit-image==0.22.0` from source:

```
pythran/pythonic/include/types/assignable.hpp:37:44: error: 'is_integral_v' is not a
member of 'std'; did you mean 'is_integral'?
```

## Root cause

Nothing in this repo changed — an unpinned build-time dependency moved.

* `pythran` **0.19.0** was published on **2026-08-17 19:41 UTC**; its changelog entry is *"Bump C++ dependency to C++17"*.
* `scikit-image` 0.22.0 hardcodes `cpp_std=c++14` in its `meson.build` and consumes only pythran's include directory, never its cflags.
* `scikit-image` 0.22.0 lists a bare `'pythran'` in `build-system.requires`, so every source build resolves whatever is newest on PyPI.
* 0.22.0 publishes wheels for cp39–cp312 only, so py3.13/py3.14 are the only interpreters that compile it. py3.10–3.12 are unaffected.

First failure in CI was `2026-08-17T23:39:13Z`, under four hours after the upload.

## Fix

Identical to upstream: `scikit-image==0.26.0` and `networkx==3.5` for `python_version >= "3.13"`. The two blocks are byte-identical to `pytorch/pytorch@main`, comments included, so this branch does not diverge.

`networkx` has to move with `scikit-image` because 0.26.0 requires `networkx>=3.0` against a pinned `networkx==2.8.8` — bumping scikit-image alone is unsatisfiable. 3.5 rather than 3.0.0 because networkx 3.6.1 declares `requires_python !=3.14.1,>=3.11`, and 3.0.0 (2023-01-08, `requires_python >=3.8`) predates python 3.13 entirely.

Every other dependency of scikit-image 0.26.0 is already satisfied, so nothing else moves:

| Requirement | py3.13 | py3.14 | |
|---|---|---|---|
| `numpy>=1.24` | 2.1.2 | 2.3.4 | ok |
| `scipy>=1.11.4` | 1.14.1 | 1.16.2 | ok |
| `pillow>=10.1` | 12.2.0 | 12.2.0 | ok |
| `packaging>=21` | 24.2 | 24.2 | ok |
| `networkx>=3.0` | **2.8.8** | **2.8.8** | **bumped here** |
| `imageio`, `tifffile`, `lazy-loader` | unpinned | unpinned | ok |

## Verification

Marker coverage checked for py3.9 through py3.14 — exactly one version of each package on every interpreter, no gap or overlap, and py3.9–3.12 resolve exactly as before:

| | py3.9–3.12 | py3.13 | py3.14 |
|---|---|---|---|
| `networkx` | 2.8.8 (unchanged) | 3.5 | 3.5 |
| `scikit-image` | 0.22.0 (unchanged) | 0.26.0 | 0.26.0 |

## Risk

networkx is noted in this file as `#test that import: functorch`, so functorch tests are the place to watch. The pins themselves carry upstream's CI behind them.