### PR TITLE
[release/2.11] Port upstream #194022: scikit-image 0.26.0 and networkx 3.5 for python >= 3.13

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -107,10 +107,11 @@ mypy==1.17.1 ; platform_system == "Linux" and python_version >= "3.14"
 #test that import: test_typing.py, test_type_hints.py
 
 networkx==2.8.8 ; python_version < "3.13"
-networkx==3.0.0 ; python_version >= "3.13"
+networkx==3.5 ; python_version >= "3.13"
+# scikit-image 0.26.0 requires networkx>=3.0
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
-#Pinned versions: 2.8.8, 3.0.0
+#Pinned versions: 2.8.8, 3.5
 #test that import: functorch
 
 ninja==1.11.1.4
@@ -249,6 +250,9 @@ pygments==2.15.0
 
 scikit-image==0.22.0 ; python_version < "3.13"
 scikit-image==0.26.0 ; python_version >= "3.13"
+# 0.22.0 has no cp313/cp314 wheel, so pip builds it from source and picks up an
+# unpinned pythran that no longer compiles under the -std=c++14 its meson build
+# uses. 0.26.0 ships cp313/cp313t/cp314/cp314t wheels, so there is no source build.
 #Description: image processing routines
 #Pinned versions: 0.22.0, 0.26.0
 #test that import: test_nn.py

--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -106,11 +106,11 @@ mypy==1.17.1 ; platform_system == "Linux" and python_version >= "3.14"
 #Pinned versions: 1.16.0, 1.17.1
 #test that import: test_typing.py, test_type_hints.py
 
-networkx==2.8.8 ; python_version < "3.14"
-networkx==3.0.0 ; python_version >= "3.14"
+networkx==2.8.8 ; python_version < "3.13"
+networkx==3.0.0 ; python_version >= "3.13"
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
-#Pinned versions: 2.8.8
+#Pinned versions: 2.8.8, 3.0.0
 #test that import: functorch
 
 ninja==1.11.1.4
@@ -247,8 +247,8 @@ pygments==2.15.0
 #Pinned versions: 14.1.0
 #test that import:
 
-scikit-image==0.22.0 ; python_version < "3.14"
-scikit-image==0.26.0 ; python_version >= "3.14"
+scikit-image==0.22.0 ; python_version < "3.13"
+scikit-image==0.26.0 ; python_version >= "3.13"
 #Description: image processing routines
 #Pinned versions: 0.22.0, 0.26.0
 #test that import: test_nn.py


### PR DESCRIPTION
Ports upstream pytorch/pytorch#194022 to `release/2.11`. Reported in ROCm/TheRock#7448.

Deliberately not using a closing keyword: that issue also covers the `nightly` torch ref, which resolves from `pytorch/pytorch` and is fixed by the upstream commit itself once it reaches a nightly cut.

## Why this branch needs it too

`release/2.11` already splits `scikit-image` and `networkx` at py3.14 (#3423), which is why py3.14 is healthy here. **py3.13 is not** — it still falls in the `< "3.14"` bucket and gets `scikit-image==0.22.0`, which has no cp313 wheel and so is built from source. That build broke when `pythran` 0.19.0 was published on 2026-08-17 19:41 UTC and raised its C++ baseline to C++17, while scikit-image 0.22.0 hardcodes `cpp_std=c++14`:

```
pythran/pythonic/include/types/assignable.hpp:37:44: error: 'is_integral_v' is not a
member of 'std'; did you mean 'is_integral'?
```

## Fix

Adopts upstream's blocks verbatim rather than just moving the existing thresholds from 3.14 to 3.13. The two blocks are byte-identical to `pytorch/pytorch@main`, comments included, so this branch stops diverging from upstream here.

Two consequences worth calling out explicitly:

1. **py3.13** moves from `scikit-image` 0.22.0 / `networkx` 2.8.8 to 0.26.0 / 3.5 — this is the fix.
2. **py3.14** moves from `networkx==3.0.0` (pinned locally by #3423) to `3.5`. That configuration currently works, so this is a deliberate change to a green path in exchange for matching upstream. 3.5 is also the safer pin on its own merits: 3.0.0 was released 2023-01-08 with `requires_python >=3.8`, predating py3.13 entirely. Upstream avoids 3.6.1 because it declares `requires_python !=3.14.1,>=3.11`.

`scikit-image` 0.26.0's other requirements are already satisfied on py3.13 by this branch's existing pins — `numpy` 2.1.2 (needs >=1.24), `scipy` 1.14.1 (>=1.11.4), `pillow` 11.0.0 (>=10.1), `packaging` 25.0 (>=21); `imageio`, `tifffile` and `lazy-loader` are unpinned.

## Verification

Marker coverage checked for py3.9 through py3.14 — exactly one version of each package on every interpreter, with py3.9–3.12 unchanged:

| | py3.9–3.12 | py3.13 | py3.14 |
|---|---|---|---|
| `networkx` | 2.8.8 (unchanged) | 3.5 (was 2.8.8) | 3.5 (was 3.0.0) |
| `scikit-image` | 0.22.0 (unchanged) | 0.26.0 (was 0.22.0) | 0.26.0 (unchanged) |

Also fixes the networkx `#Pinned versions:` comment, left stale by #3423.

## Risk

The py3.14 networkx change is the only movement on an otherwise-green path. networkx is noted in this file as `#test that import: functorch`.