### PR TITLE
[release/2.13] Unskip ROCSHMEM triton UTs on rocm 7.14

### DIFF
--- a/test/distributed/test_shmem_triton.py
+++ b/test/distributed/test_shmem_triton.py
@@ -6,7 +6,6 @@ import sys
 
 import torch
 import torch.distributed._symmetric_memory as symm_mem
-from torch.testing._internal.common_cuda import ROCM_VERSION
 from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     PLATFORM_SUPPORTS_SYMM_MEM,
@@ -14,11 +13,6 @@ from torch.testing._internal.common_distributed import (
 )
 from torch.testing._internal.common_utils import TEST_WITH_ROCM
 
-
-# Skip the entire module before importing SHMEM-specific modules.
-if TEST_WITH_ROCM and ROCM_VERSION >= (7, 14):
-    print("rocSHMEM Triton tests have known failures on ROCm 7.14 or newer")
-    sys.exit(0)
 
 if (
     not torch.backends.cuda.is_built()

--- a/torch/distributed/_symmetric_memory/_rocshmem_triton.py
+++ b/torch/distributed/_symmetric_memory/_rocshmem_triton.py
@@ -56,7 +56,7 @@ class RocshmemLibFinder:
 
         search_paths = [
             os.path.join(sysconfig.get_path("purelib"), "amd", "rocshmem", "lib"),
-            "/opt/rocm/lib",
+            os.path.join(os.environ.get("ROCM_PATH") or "/opt/rocm", "lib"),
             "/usr/local/lib",
             "/usr/lib",
         ]


### PR DESCRIPTION
- [ROCm/pytorch#3525](https://github.com/ROCm/pytorch/pull/3525) (`[release/2.13] Stabilize ROCm 7.14 testing on release/2.13`) added a module-level `sys.exit(0)` in `test/distributed/test_shmem_triton.py` for `ROCM_VERSION >= (7, 14)`. 

- This PR does two things:
  1. **Unskip** that 7.14 `sys.exit(0)`. Keep the existing capability skip when the SHMEM backend is unavailable.
  2. **Take the finder hunk** from upstream commit [`4a31e29`](https://github.com/pytorch/pytorch/commit/4a31e29fa5bfe9aa78774622437f68dd491bf2af) (`[ROCm][CI] Fix trunk rocSHMEM and CK failures`, from [pytorch/pytorch#188429](https://github.com/pytorch/pytorch/pull/188429)): search `$ROCM_PATH/lib` when `ROCM_PATH` is set, else `/opt/rocm/lib`.

- We did **not** take the rest of `4a31e29`. That commit also adds `@skipIfRocmVersionAtLeast([7, 14])` on `test/inductor/test_ck_backend.py`. That CK skip is already on `release/2.13` and is unrelated to this UT. Full `cherry-pick -x` of `4a31e29` would just restage it. We also did not backport the rest of #188429 (TheRock CI/docker switch).

## Test plan

- [x] TheRock `test_pytorch_wheels_full.yml`, `test_configs=distributed`, `tests_to_include=distributed/test_shmem_triton`
  - gfx94X / `linux-gfx942-1gpu-ccs-csp-ossci-rocm`: https://github.com/ROCm/TheRock/actions/runs/32195967020/job/95904033020
```
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_barrier PASSED [13.5964s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_fence PASSED [2.5392s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_get_nbi_False PASSED [1.3613s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_get_nbi_True PASSED [1.4139s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_get_ring PASSED [1.7522s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_put PASSED [1.6263s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_put_signal_add PASSED [1.5214s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_put_signal_set PASSED [1.5903s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_quiet PASSED [1.5085s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_signal_wait_until PASSED [0.0122s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_sync PASSED [1.5976s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_wait_until PASSED [1.2603s]

======================= 12 passed, 25 skipped in 32.21s ========================
```  

  - gfx950: https://github.com/ROCm/TheRock/actions/runs/32201312766/job/95915621757
```
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_barrier PASSED [8.2912s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_fence PASSED [1.2513s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_get_nbi_False PASSED [1.0780s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_get_nbi_True PASSED [1.0367s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_get_ring PASSED [1.1043s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_put PASSED [0.9847s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_put_signal_add PASSED [1.1261s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_put_signal_set PASSED [1.1993s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_quiet PASSED [1.1537s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_signal_wait_until PASSED [0.0080s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_sync PASSED [1.2694s]
distributed/test_shmem_triton.py::SHMEMTritonTest::test_triton_wait_until PASSED [1.0119s]

======================= 12 passed, 25 skipped in 22.50s ========================
```

- [x] Confirm the 12 Triton cases actually run (not a finder crash, not a module-level skip). Multiprocess alltoall/broadcast/reduces stay `@skip_if_rocm_multiprocess`.