### PR TITLE
[release/2.12] Build rocSHMEM for the requested gfx target, not gfx90a xnack variants

### DIFF
--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1476,14 +1476,7 @@ if(USE_ROCM)
     foreach(_arch ${PYTORCH_ROCM_ARCH})
       list(FIND ROCSHMEM_SUPPORTED_ARCH "${_arch}" _rocsmem_supported_idx)
       if(NOT _rocsmem_supported_idx EQUAL -1)
-        # rocSHMEM device archives are commonly built for gfx90a xnack variants,
-        # so map plain gfx90a to gfx90a:xnack-/gfx90a:xnack+ to match device
-        # symbols during HIP RDC link.
-        if(_arch STREQUAL "gfx90a")
-          list(APPEND _torch_rocshmem_build_arches "gfx90a:xnack-" "gfx90a:xnack+")
-        else()
-          list(APPEND _torch_rocshmem_build_arches "${_arch}")
-        endif()
+        list(APPEND _torch_rocshmem_build_arches "${_arch}")
       endif()
     endforeach()
     if(rocshmem_FOUND AND _torch_rocshmem_build_arches)


### PR DESCRIPTION
Drops the gfx90a→xnack± special case; builds `torch_rocshmem` for the requested target like every other arch. rocSHMEM ships xnack-agnostic device bitcode (`librocshmem_device_gfx90a.bc`, `target-cpu=gfx90a`), and the mapping matched per-xnack archives that ROCm/rocm-systems#4822 removed in April.

Fixes the split `torch_gfx90a:xnack±.kpack` stubs that break torch on MI250 (ROCm/TheRock#7081, ROCM-29326).

Scope: gfx90a only, minimal. The `list(FIND ...)` membership test is untouched; it needs bare-arch matching once ASan enables xnack uniformly (ROCm/TheRock#6624), tracked separately.