### PR TITLE
[release/2.11] fix PicklingError handling for Python 3.14

### DIFF
--- a/torch/testing/_internal/distributed/distributed_test.py
+++ b/torch/testing/_internal/distributed/distributed_test.py
@@ -6,6 +6,7 @@ import json
 import math
 import operator
 import os
+import pickle
 import random
 import re
 import sys
@@ -6811,7 +6812,10 @@ class DistributedTest:
 
             b = Bar()
             gather_objects = [b for _ in range(dist.get_world_size())]
-            with self.assertRaises(AttributeError):
+            # Pickling a local class fails; the exception type depends on the
+            # Python version: AttributeError on <=3.13, PicklingError on >=3.14
+            # (CPython gh-139806). pickle.PickleError covers PicklingError.
+            with self.assertRaises((AttributeError, pickle.PickleError)):
                 dist.all_gather_object(
                     [None for _ in range(dist.get_world_size())],
                     gather_objects[self.rank],


### PR DESCRIPTION
Fix test_gather_object assertion for Python 3.14 PicklingError (#192811)
    
## Summary:
The test all_gather_objects a local class (unpicklable) and asserts an
error. The exception type changed: <=3.13 raised AttributeError, but 3.14
(CPython gh-139806) raises PicklingError from pickle.whichmodule() for
'<locals>' names. PicklingError is a PickleError, not an AttributeError, so
the stale assertRaises(AttributeError) no longer matches.

Fix the assertion to (AttributeError, pickle.PickleError), correct across
all supported versions (python_min_version = 3.10) while staying tight. The
fix belongs in the test, not production: normalizing pickle's exception type
in _object_to_tensor would mask a legitimate CPython change.

## Test plan:
Test Plan: on Python 3.14.4, assertRaises(AttributeError) around
pickle.Pickler().dump() of a local class ERRORS with PicklingError, while
assertRaises((AttributeError, pickle.PickleError)) PASSES; on 3.10-3.13 the
real AttributeError is also matched (issubclass). Full test needs a 4-GPU
nccl world:
`pytest torch/testing/_internal/distributed/distributed_test.py -k test_gather_object`

Authored with the assistance of an AI coding assistant.

Cherry-pick upstream #192811

Cherry-picked to release/2.12 branch via https://github.com/ROCm/pytorch/pull/3585

Cherry-picked to release/2.13 branch via https://github.com/ROCm/pytorch/pull/3586