### PR TITLE
Disable origami for ROCm 10.0

### DIFF
--- a/test/inductor/test_origami.py
+++ b/test/inductor/test_origami.py
@@ -9,6 +9,10 @@ import torch
 from torch._dynamo.utils import counters
 from torch._inductor import config
 from torch._inductor.runtime.benchmarking import benchmarker
+from torch._inductor.template_heuristics.triton import (
+    _rocm_version as _th_rocm_version,
+    ORIGAMI_UNSUPPORTED_ROCM_VERSION,
+)
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import fresh_cache
 from torch._logging import trace_structured
@@ -33,6 +37,8 @@ PERF_SLOWDOWN_TOLERANCE = 1.05  # 5% tolerance on performance
 
 IS_ROCM = torch.version.hip is not None
 
+ORIGAMI_ROCM_SUPPORTED = IS_ROCM and _th_rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION
+
 try:
     import origami
 
@@ -48,6 +54,10 @@ if IS_ROCM:
 
 @unittest.skipIf(not HAS_GPU_AND_TRITON, "requires GPU and Triton")
 @unittest.skipIf(not IS_ROCM, "Origami integration is ROCm-only")
+@unittest.skipIf(
+    not ORIGAMI_ROCM_SUPPORTED,
+    "Origami is not supported on ROCm 10.0+",
+)
 @unittest.skipIf(not HAS_ORIGAMI, "Origami package is not installed")
 @unittest.skipIf(
     not (config.max_autotune and config.rocm.origami),
@@ -506,11 +516,13 @@ class TestOrigami(TestCase):
 
 
 @unittest.skipIf(
-    HAS_GPU_AND_TRITON and IS_ROCM, "Skipped on ROCm where origami is available"
+    HAS_GPU_AND_TRITON and ORIGAMI_ROCM_SUPPORTED,
+    "Skipped on ROCm < 10.0 where origami is available",
 )
 class TestOrigamiSkippedOnNonROCm(TestCase):
-    """Test that origami is properly skipped on non-ROCm devices (CUDA/CPU).
+    """Test that origami is properly skipped on unsupported environments.
 
+    Covers non-ROCm hardware (CUDA/CPU) and ROCm >= ORIGAMI_UNSUPPORTED_ROCM_VERSION.
     These tests verify that:
     1. origami configuration does not cause errors when disabled
     2. origami.select_topk_configs is not called on non-ROCm hardware
@@ -621,6 +633,54 @@ class TestOrigamiSkippedOnNonROCm(TestCase):
                 compiled = torch.compile(test_fn, dynamic=False)
                 result = compiled(a, b)
                 torch.testing.assert_close(result, expected, atol=1e-5, rtol=1e-5)
+
+
+class TestOrigamiVersionGate(TestCase):
+    """Unit tests for the _rocm_version / _origami_enabled() cutoff.
+
+    No GPU or origami package required: all paths are exercised by patching
+    the module-level _rocm_version directly.
+    """
+
+    def test_origami_enabled_below_cutoff(self):
+        """_origami_enabled() returns True on ROCm just below the cutoff."""
+        import torch._inductor.template_heuristics.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (9, 9)),
+            config.patch({"rocm.origami": True}),
+        ):
+            self.assertTrue(th._origami_enabled())
+
+    def test_origami_disabled_at_cutoff(self):
+        """_origami_enabled() returns False at exactly the cutoff version."""
+        import torch._inductor.template_heuristics.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (10, 0)),
+            config.patch({"rocm.origami": True}),
+        ):
+            self.assertFalse(th._origami_enabled())
+
+    def test_origami_disabled_above_cutoff(self):
+        """_origami_enabled() returns False above the cutoff version."""
+        import torch._inductor.template_heuristics.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (10, 1)),
+            config.patch({"rocm.origami": True}),
+        ):
+            self.assertFalse(th._origami_enabled())
+
+    def test_origami_config_off_below_cutoff(self):
+        """_origami_enabled() respects config.rocm.origami=False even below cutoff."""
+        import torch._inductor.template_heuristics.triton as th
+
+        with (
+            mock.patch.object(th, "_rocm_version", (9, 9)),
+            config.patch({"rocm.origami": False}),
+        ):
+            self.assertFalse(th._origami_enabled())
 
 
 if __name__ == "__main__":

--- a/torch/_inductor/config.py
+++ b/torch/_inductor/config.py
@@ -2648,6 +2648,7 @@ class rocm:
     #   - config.rocm.origami (this knob)
     #   - config.max_autotune_gemm_search_space == "DEFAULT"
     #   - rocm-origami is installed (else the import gate sets it inert)
+    #   - ROCm version < 10.0 (origami not supported on 10.0+)
     # Outside DEFAULT (e.g. EXHAUSTIVE) origami is silently bypassed with a
     # one-time warning; the regular config generator runs instead.
     #

--- a/torch/_inductor/template_heuristics/triton.py
+++ b/torch/_inductor/template_heuristics/triton.py
@@ -56,22 +56,36 @@ else:
 log = logging.getLogger(__name__)
 
 
-def _origami_enabled() -> bool:
-    """Check if origami GEMM optimization is enabled."""
-    return config.rocm.origami
-
-
 USE_META_WS = os.environ.get("TRITON_USE_META_WS", "0") == "0"
 
 # Check if running on ROCm
 IS_ROCM = torch.version.hip is not None
+
+_rocm_version = (
+    tuple(int(v) for v in torch.version.rocm.split(".")[:2])  # type: ignore[union-attr]
+    if torch.version.rocm is not None
+    else (0, 0)
+)
+# First ROCm version where origami is not supported.
+ORIGAMI_UNSUPPORTED_ROCM_VERSION = (10, 0)
+
+
+def _origami_enabled() -> bool:
+    """Check if origami GEMM optimization is enabled."""
+    return config.rocm.origami and _rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION
 
 
 # rocm-origami pip pkg is only available on ROCm builds and is only used when
 # both max_autotune and config.rocm.origami are enabled (env-var driven, set once
 # at config import). Cache the import here so the hot path never pays an exception
 # and CUDA/CPU/origami-disabled processes never attempt the import.
-if IS_ROCM and config.max_autotune and config.rocm.origami:
+# origami is not supported on ROCm 10.0+.
+if (
+    IS_ROCM
+    and _rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION
+    and config.max_autotune
+    and config.rocm.origami
+):
     try:
         import origami  # type: ignore[import-not-found]
     except ImportError:
@@ -82,6 +96,17 @@ if IS_ROCM and config.max_autotune and config.rocm.origami:
         )
 else:
     origami = None
+    if (
+        IS_ROCM
+        and config.rocm.origami
+        and _rocm_version >= ORIGAMI_UNSUPPORTED_ROCM_VERSION
+    ):
+        log.warning(
+            "ROCm origami GEMM selection is not supported on ROCm %d.%d+ "
+            "(detected %d.%d); origami disabled.",
+            *ORIGAMI_UNSUPPORTED_ROCM_VERSION,
+            *_rocm_version,
+        )
 
 
 # TODO(rocm-origami): replace these wrappers with public accessors when the


### PR DESCRIPTION
## Motivation

Origami is not supported on ROCm 10.0+. Left enabled, it would attempt to import/use `origami` on unsupported ROCm builds. This PR gates origami off for ROCm >= 10.0 so it only runs where it's actually supported.

## Technical Details

Adds a ROCm version gate in `torch/_inductor/heuristics/template/triton.py`:

- Parse `torch.version.rocm` into a `(major, minor)` tuple `_rocm_version`; introduce `ORIGAMI_UNSUPPORTED_ROCM_VERSION = (10, 0)`.
- `_origami_enabled()` now returns `config.rocm.origami and _rocm_version < ORIGAMI_UNSUPPORTED_ROCM_VERSION`.
- The cached `import origami` gate now also requires `_rocm_version < (10, 0)`; on ROCm >= 10.0 with the config knob on, `origami` is set to `None` and a one-time warning is logged.
- `torch/_inductor/config.py`: documents the new ROCm-version condition on the `rocm.origami` knob.

## Test Plan

`test/inductor/test_origami.py`:
- New `TestOrigamiVersionGate` unit tests (no GPU / no origami pkg required) patch `_rocm_version` to check `_origami_enabled()` across below-cutoff `(9,9)`, at-cutoff `(10,0)`, above-cutoff `(10,1)`, and config-off cases.
- Existing suites updated with an `ORIGAMI_ROCM_SUPPORTED` guard so origami-enabled tests skip on ROCm >= 10.0, and the "skipped" suite now covers unsupported ROCm too.

## Test Result

<!-- fill in with actual run output -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
