### PR TITLE
[release/2.14] Carry-forward ROCm cherry-picks from release/2.13

### DIFF
--- a/cmake/Dependencies.cmake
+++ b/cmake/Dependencies.cmake
@@ -1056,6 +1056,24 @@ if(USE_ROCM)
     if(HIPBLASLT_VEC_EXT)
       list(APPEND HIP_CXX_FLAGS -DHIPBLASLT_VEC_EXT)
     endif()
+    # composable_kernel has no gfx1250 support, so aten/src/ATen/CMakeLists.txt
+    # filters gfx1250 out of the ck_gemm target's HIP_ARCHITECTURES. When gfx1250
+    # is the only requested arch that list is empty and CMake fails at generate
+    # time with 'HIP_ARCHITECTURES is empty for target "ck_gemm"', so turn CK GEMM
+    # off entirely here -- before -DUSE_ROCM_CK_GEMM is added below, since the
+    # non-CK TUs guarded by that define (HIPBlas.cpp, HIPHooks.cpp, GroupedBlas.cpp)
+    # would otherwise reference symbols the unbuilt ck_gemm target never provides.
+    # Mirrors the USE_ROCM_CK_SDPA / USE_MSLK auto-disable pattern in
+    # aten/src/ATen/CMakeLists.txt. Remove once the CK submodule supports gfx1250.
+    if(USE_ROCM_CK_GEMM)
+      set(_ck_gemm_supported_arches ${PYTORCH_ROCM_ARCH})
+      list(REMOVE_ITEM _ck_gemm_supported_arches "gfx1250")
+      if(_ck_gemm_supported_arches STREQUAL "")
+        message(STATUS "USE_ROCM_CK_GEMM disabled: PYTORCH_ROCM_ARCH (${PYTORCH_ROCM_ARCH}) has no arch supported by composable_kernel")
+        caffe2_update_option(USE_ROCM_CK_GEMM OFF)
+      endif()
+      unset(_ck_gemm_supported_arches)
+    endif()
     if(USE_ROCM_CK_GEMM)
       list(APPEND HIP_CXX_FLAGS -DUSE_ROCM_CK_GEMM)
     endif()

--- a/test/inductor/test_autoheuristic.py
+++ b/test/inductor/test_autoheuristic.py
@@ -10,7 +10,7 @@ from torch._inductor.autoheuristic.autoheuristic_utils import AHContext
 from torch._inductor.runtime.runtime_utils import cache_dir
 from torch._inductor.test_case import run_tests, TestCase
 from torch._inductor.utils import get_gpu_shared_memory
-from torch.testing._internal.common_utils import skipIfXpu
+from torch.testing._internal.common_utils import skipIfRocm, skipIfXpu
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU, IS_A100, IS_H100
 
 
@@ -69,6 +69,7 @@ class AutoHeuristicTest(TestCase):
         # this test ensures that data is collected for pad_mm when autoheuristic_collect.pad_mm=True
         self.assert_autoheuristic_collected_data()
 
+    @skipIfRocm(msg="AutoHeuristic doesn't currently work on the ROCm stack")
     @skipIfXpu(msg="AutoHeuristic doesn't currently work on the XPU stack")
     @patch.dict(os.environ, {"TORCHINDUCTOR_AUTOHEURISTIC_COLLECT": "test"})
     def test_autoheuristic(self):

--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -59,6 +59,7 @@ from torch.testing._internal.common_device_type import (
     instantiate_device_type_tests,
     onlyCPU,
     onlyCUDA,
+    skipCUDAIf,
     skipMeta,
 )
 from torch.testing._internal.common_dtype import floating_types_and
@@ -14031,6 +14032,10 @@ class TestAutogradDeviceType(TestCase):
         self.assertIsNone(t1.grad)
         self.assertIsNone(t3.grad)
 
+    @skipCUDAIf(
+        True,
+        "Flaky test: https://github.com/pytorch/pytorch/issues/86735",
+    )
     @onlyCUDA
     def test_reentrant_parent_error_on_cpu(self, device):
         def _get_cuda_memory_usage():

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1403,6 +1403,7 @@ print(t.is_pinned())
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
+    @skipIfRocm(msg="ROCm cold HIP init causes 15s subprocess timeout on CI; flaky/slow-init, not a confirmed deadlock")
     def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
         # Separate process: a regression deadlocks the interpreter (non-reentrant lock).
         # Happy path is usually a few seconds; allow margin for slow CI / CUDA init.
@@ -3273,7 +3274,8 @@ torch.cuda.synchronize()
             after, baseline, "Leaked CUDA/RNG allocations after failed capture test"
         )
 
-    @skipIfRocmVersionLessThan((7, 14))
+    @skipIfRocm(msg="HIPCachingAllocator does not release reserved segments after a failed "
+                "graph capture; memory_reserved() does not recover to baseline")
     @xfailCUDAIfSM89OrLaterOnWindows
     @unittest.skipIf(
         not TEST_CUDA_GRAPH, "CUDA >= 11.0 or ROCM >= 5.3 required for graphs"

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -1403,6 +1403,37 @@ print(t.is_pinned())
             self.assertEqual(a, b)
             self.assertEqual(torch.cuda.initial_seed(), 2)
 
+    def test_lazy_call_reentrant_set_rng_state_does_not_deadlock(self):
+        # Separate process: a regression deadlocks the interpreter (non-reentrant lock).
+        # Happy path is usually a few seconds; allow margin for slow CI / CUDA init.
+        timeout_sec = 15
+        script = (
+            "import torch; "
+            "torch.cuda.init(); "
+            "state = torch.cuda.get_rng_state(); "
+            "torch.cuda._lazy_call(lambda: torch.cuda.set_rng_state(state)); "
+            "print('done')"
+        )
+        try:
+            proc = subprocess.run(
+                [sys.executable, "-c", script],
+                capture_output=True,
+                text=True,
+                timeout=timeout_sec,
+            )
+        except subprocess.TimeoutExpired as e:
+            self.fail(
+                f"lazy_call reentrancy subprocess did not finish within {timeout_sec}s "
+                "(likely deadlock in torch.cuda._lazy_call); "
+                f"cmd={e.cmd!r}"
+            )
+        self.assertEqual(
+            proc.returncode,
+            0,
+            msg=f"stdout={proc.stdout!r}\nstderr={proc.stderr!r}",
+        )
+        self.assertIn("done", proc.stdout)
+
     def test_specify_improper_device_name(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             fname = os.path.join(tmpdir, "tempfile.pt")

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5697,6 +5697,7 @@ print(f"{{r1}}, {{r2}}")
     @unittest.skipIf(
         IS_WINDOWS, "test relies on fork; Windows multiprocessing uses spawn"
     )
+    @unittest.skipIf(sys.version_info >= (3, 14), "test fails on Python 3.14+")
     def test_is_pinned_no_context(self):
         test_script = """\
 import torch

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -5614,6 +5614,7 @@ with torch.cuda.graph(g):
             )
             self.assertEqual(rc, "3")
 
+    @unittest.skipIf(TEST_WITH_ROCM, "Failed onr ROCm due to rocprofiler-sdk issue AIPROFSDK-840")
     @unittest.skipIf(not TEST_WITH_ROCM, "not relevant for CUDA testing")
     @skipIfRocmVersionAtLeast([7, 14])
     def test_hip_device_count(self):

--- a/test/test_foreach.py
+++ b/test/test_foreach.py
@@ -90,7 +90,7 @@ class ForeachFuncWrapper:
 
         # Skip profiler check for CUDA 12.6, 12.8 as the upgrade makes profiler results flaky
         # https://github.com/pytorch/pytorch/issues/148681. TODO: ADD IT BACK!!!
-        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)]
+        skip_profiler_check = _get_torch_cuda_version() in [(12, 6), (12, 8)] or TEST_WITH_ROCM
         if (
             is_cuda
             and not skip_profiler_check

--- a/test/test_nn.py
+++ b/test/test_nn.py
@@ -14204,6 +14204,8 @@ if __name__ == '__main__':
         self.assertLessEqual(maximal_linear_bias_grad_max_ulp_diff, expected_linear_bias_grad_max_ulp_diff,
                              msg=lambda msg: f"{msg}\nworst linear_bias-grad ULP {maximal_linear_bias_grad_max_ulp_diff} from kwargs={worst_linear_bias_grad_kwargs}")
 
+    @skipIfRocm(msg="ROCm fp32 GEMM ULP divergence: input-grad 952 > 854 tolerance bound "
+                "(TheRock math-lib build, rocBLAS/hipBLASLt accumulation)")
     @parametrize_test("bias", [False, True])
     @dtypes(torch.float32)
     def test_linear_cross_entropy_loss_default(self, device, dtype, bias):

--- a/torch/cuda/__init__.py
+++ b/torch/cuda/__init__.py
@@ -517,9 +517,16 @@ def is_initialized():
 
 
 def _lazy_call(callable, **kwargs):
+    # Do not invoke user callbacks while holding _initialization_lock
+    # they may call back into _lazy_call.
+    if is_initialized():
+        callable()
+        return
+
+    run_now = False
     with _initialization_lock:
         if is_initialized():
-            callable()
+            run_now = True
         else:
             # TODO(torch_deploy): this accesses linecache, which attempts to read the
             # file system to get traceback info. Patch linecache or do something
@@ -532,6 +539,9 @@ def _lazy_call(callable, **kwargs):
             else:
                 # Don't store the actual traceback to avoid memory cycle
                 _queued_calls.append((callable, traceback.format_stack()))
+
+    if run_now:
+        callable()
 
 
 _lazy_call(_check_capability)

--- a/torch/testing/_internal/common_nn.py
+++ b/torch/testing/_internal/common_nn.py
@@ -17,7 +17,7 @@ import torch.nn.functional as F
 from torch.nn import _reduction as _Reduction
 from torch.testing._internal import common_utils
 from torch.testing._internal.common_utils import TestCase, to_gpu, freeze_rng_state, is_iterable, \
-    gradcheck, gradgradcheck, set_default_dtype, skipIfTorchDynamo, TEST_WITH_ROCM
+    gradcheck, gradgradcheck, set_default_dtype, skipIfTorchDynamo, skipIfRocm, TEST_WITH_ROCM
 from torch.testing._internal.common_cuda import TEST_CUDA, SM90OrLater
 from torch.autograd.gradcheck import _get_numerical_jacobian, _iter_tensors
 from torch.autograd import Variable
@@ -1730,7 +1730,9 @@ def get_new_module_tests():
             check_gradgrad=False,
             desc='discontiguous',
             default_dtype=torch.double,
-            decorator=skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/117971")
+            decorator=lambda fn: skipIfTorchDynamo("https://github.com/pytorch/pytorch/issues/117971")(
+                skipIfRocm(msg="https://github.com/pytorch/pytorch/issues/186910")(fn)
+            ),
         ),
         dict(
             module_name='EmbeddingBag',


### PR DESCRIPTION
## Summary

Carry-forward of ROCm-specific commits from `release/2.13` onto `release/2.14` — the 2.14 analog of the 2.13 "IFU dedup" ([PR #3503](https://github.com/ROCm/pytorch/pull/3503)).

Starting point was the IFU delta surfaced by [PR #3591](https://github.com/ROCm/pytorch/pull/3591) (`release/2.13` → `release/2.14`): **74 commits** in `release/2.13` that are not in `release/2.14`. Each was analyzed and either dropped (already in 2.14, or 2.13-only plumbing) or cherry-picked here.

## Method

Applied the same rules as the [release/2.13 cherry-pick process](https://amd.atlassian.net/wiki/spaces/MLSE/pages/1819593560):

- **Drop – already in 2.14**: detected by patch-id equivalence (`git cherry`), by upstream PR number already present, or by content (e.g. an upstream PR backported to 2.13 that 2.14 already carries natively).
- **Drop – 2.13-only**: version bump, `related_commits`, dependency/requirements pins, and release-line CD/build changes (CUDA 12.9 revival, docker image pins, binary-build timeout, RC/PTX strip, etc.).
- **Carry-forward**: ROCm-specific fixes not present in 2.14 in any form.

Of the 74: **42 already in 2.14**, **20 dropped as 2.13-only** (incl. 2 release-line reverts that 2.14 intentionally keeps active), and **12 carry-forward candidates**. During cherry-pick, **4 candidates were found to be already in 2.14** (their content had been relocated/absorbed by upstream) and were dropped, leaving **9 commits** here.

## Commits carried forward (9)

| Source | Notes |
|--------|-------|
| Fix reentrant deadlock in `torch.cuda._lazy_call` (#3496) | clean |
| Skip ROCm-failing tests in test_cuda/test_nn (#3504) | **conflict resolved** — kept 2.14's `test_graph_capture_error...` cleanup body + took the `@skipIfRocm`; kept 2.14's `test_allocator_backend` (it already fixes the LD_LIBRARY_PATH root cause via `subprocess_env()`, so the 2.13 blanket skip was dropped) |
| skip test_hip_device_count (rocprofiler-sdk) | clean |
| skip flaky test_Embedding_discontiguous_cuda | clean |
| [RELEASE_ONLY] skip test_autoheuristic in-code (#180927) | clean |
| Skip profiler check for foreach tests on ROCm (#3262) | clean |
| Skip test_is_pinned_no_context on python 3.14+ | clean |
| Skip flaky test_reentrant_parent_error_on_cpu | clean |
| Filter out CK gemms for gfx1250-only arch (#3545) | clean |

## Candidates dropped during cherry-pick (already in 2.14)

- **rocm-smi deprecation (#3434)** — `release/2.14` already has zero `rocm_smi` references (replaced by the hipfile logic).
- **Enable linalg via hipSOLVER, remove Magma (#3455)** — all 6 backported upstream PRs (#180303, #187703, #185557, #187011, #186122, #188720) are already in 2.14 natively.
- **Stabilize ROCm 7.14 testing (#3525)** — 2.14 already carries the `skip_if_rocm_ver_atleast_multiprocess` / `getRocmVersion() >= (7,14)` guards and the same skip messages.
- **Add gfx1250 support in GroupedBlas (#3532)** — upstream #190703 deduplicated the arch gate into `ScaledBlasDeviceUtils`, which already includes `gfx1250` under `ROCM_VERSION >= 71400` in 2.14.

## Test plan

- [ ] TheRock CI wheel build + tests on gfx94X for Python 3.10–3.14
