### PR TITLE
[release/2.14] Cherry-pick Windows HIPIFY realpath fix for torchaudio (ROCM-29365)

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -1594,13 +1594,19 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
     if IS_HIP_EXTENSION:
         from .hipify import hipify_python
-        build_dir = os.getcwd()
+        # Resolve symlinks/junctions and Windows `subst` drive aliases so the
+        # build directory and the source paths use the same canonical form. On
+        # Windows CI the build runs under a `subst` drive (e.g. B:) while source
+        # paths may resolve to the real drive (e.g. C:); without this the
+        # `includes` scope below matches nothing and hipify silently skips the
+        # sources, leaving CUDA headers unhipified.
+        build_dir = os.path.realpath(os.getcwd())
         hipify_result = hipify_python.hipify(
             project_directory=build_dir,
             output_directory=build_dir,
             header_include_dirs=include_dirs,
             includes=[os.path.join(build_dir, '*')],  # limit scope to build_dir only
-            extra_files=[os.path.abspath(s) for s in sources],
+            extra_files=[os.path.realpath(s) for s in sources],
             show_detailed=True,
             is_pytorch_extension=True,
             hipify_extra_files_only=True,  # don't hipify everything in includes path
@@ -1608,7 +1614,7 @@ def CUDAExtension(name, sources, *args, **kwargs):
 
         hipified_sources = set()
         for source in sources:
-            s_abs = os.path.abspath(source)
+            s_abs = os.path.realpath(source)
             hipified_s_abs = (hipify_result[s_abs].hipified_path if (s_abs in hipify_result and
                               hipify_result[s_abs].hipified_path is not None) else s_abs)
             # setup() arguments must *always* be /-separated paths relative to the setup.py directory,


### PR DESCRIPTION
https://amd-hub.atlassian.net/browse/AIPYTORCH-1082

## Problem

TheRock `release/2.14` Windows ROCm wheel jobs fail on every Python version while building torchaudio GPU extensions with `fatal error: 'cuda_runtime_api.h' file not found` ([ROCm/TheRock#7591](https://github.com/ROCm/TheRock/issues/7591)). This is the same `B:` vs `C:` Windows `subst` drive mismatch that broke `release/2.13` ([ROCm/TheRock#7266](https://github.com/ROCm/TheRock/issues/7266)).

`release/2.14` already picked up the upstream relpath cross-drive fallback ([pytorch/pytorch#191743](https://github.com/pytorch/pytorch/pull/191743), cherry-picked to `release/2.13` as [ROCm/pytorch#3550](https://github.com/ROCm/pytorch/pull/3550)), but it is still missing the ROCm follow-up that normalizes paths with `os.path.realpath` so hipify's `includes=[build_dir/*]` filter matches GPU sources again.

Without that normalization, hipify silently skips torchaudio GPU sources, leaving raw `#include <cuda_runtime_api.h>` for hipcc.

## Changes

Cherry-pick of [ROCm/pytorch#3561](https://github.com/ROCm/pytorch/pull/3561) (`3a4c3a15758`) onto `release/2.14`:

- `build_dir = os.path.realpath(os.getcwd())`
- `extra_files=[os.path.realpath(s) for s in sources]`
- `s_abs = os.path.realpath(source)`

No ROCm/audio change is required for this failure mode — the pinned torchaudio commit is fine once PyTorch hipify runs correctly (same conclusion as the validated `release/2.13` fix in #3561).

## Validation

TheRock Windows dev wheel build, py 3.12, `gfx110X-all`, ROCm `10.1.0a20260822`, fork branch `ew/cherry-pick-3561-release-2.14`, `test_amdgpu_families=none` (build-only):

- **Passed:** [Build Multi-Arch Windows PyTorch Wheels (dev, 3.12, ew/cherry-pick-3561-release-2.14)](https://github.com/ROCm/TheRock/actions/runs/32739959573)

The runner used the `subst` B: drive (`B:\src\pytorch_audio` with sources resolving through `C:\scratch-b\...`), so the run exercised the cross-drive condition this fix targets.

- [x] torchaudio GPU sources hipified instead of skipped:
  - `libtorchaudio\cuda_utils.h -> libtorchaudio\hip_utils.h [ok]`
  - `libtorchaudio\rnnt\gpu\compute.cu -> compute.hip [ok]`
  - `libtorchaudio\forced_align\gpu\compute.cu -> compute.hip [ok]`
- [x] `hipcc` compiled `compute.hip` for `gfx1100/1101/1102/1103`; zero occurrences of `'cuda_runtime_api.h' file not found`
- [x] Wheels produced: `torch-2.14.0+git6f13913c.rocm10.1.0a20260822`, `torchaudio-2.11.0.3+gitba6dfeed.rocm10.1.0a20260822`, `torchvision-0.29.0a0+git0fba2e84.rocm10.1.0a20260822` (all cp312 win_amd64)
- [ ] Linux ROCm extension builds unaffected (regression check after merge)

Refs: [ROCM-29365](https://amd-hub.atlassian.net/browse/ROCM-29365), [AIPYTORCH-1019](https://amd-hub.atlassian.net/browse/AIPYTORCH-1019)


[ROCM-29365]: https://amd-hub.atlassian.net/browse/ROCM-29365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
