### PR TITLE
[UP][release/2.13] Guard native BMM outer-product launches against the HIP work-item limit

### DIFF
--- a/test/test_bmm_outer_product.py
+++ b/test/test_bmm_outer_product.py
@@ -3,7 +3,12 @@
 import unittest
 
 import torch
-from torch._native.ops.bmm_outer_product.triton_impl import _is_outer_product
+from torch._native.ops.bmm_outer_product.triton_impl import (
+    _bmm_outer_product_cond,
+    _HIP_MAX_LAUNCH_WORK_ITEMS,
+    _is_hip_grid_safe,
+    _is_outer_product,
+)
 from torch.testing._internal.common_utils import run_tests, skipIfXpu, TestCase
 from torch.testing._internal.inductor_utils import GPU_TYPE, HAS_GPU
 
@@ -70,6 +75,31 @@ class TestBmmOuterProduct(TestCase):
         a = torch.randn(8, 1, 1, device=GPU_TYPE)
         b = torch.randn(8, 1, 1, device=GPU_TYPE)
         self.assertEqual(torch.bmm(a, b), a @ b)
+
+    @unittest.skipIf(torch.version.hip is None, "requires ROCm")
+    def test_hip_grid_limit_fallback(self):
+        from torch._native.ops.bmm_outer_product.triton_kernels import (
+            _bmm_outer_product_launch_config,
+            _TRITON_DEFAULT_NUM_WARPS,
+        )
+
+        warp_size = torch.cuda.get_device_properties(GPU_TYPE).warp_size
+        threads_per_program = _TRITON_DEFAULT_NUM_WARPS * warp_size
+        batch = _HIP_MAX_LAUNCH_WORK_ITEMS // threads_per_program + 1
+        # M = N = 1 puts exactly one program in the grid per batch entry, so
+        # this batch is the first one whose launch exceeds the limit.
+        self.assertEqual(_bmm_outer_product_launch_config(batch, 1, 1)[0], batch)
+
+        a = torch.randn(1, 1, 1, device=GPU_TYPE).expand(batch, -1, -1)
+        b = torch.randn(1, 1, 1, device=GPU_TYPE).expand(batch, -1, -1)
+
+        # Only the decision is checked. torch.bmm is deliberately not called:
+        # rocBLAS tiles this shape as one 256-thread workgroup per batch entry,
+        # so on some architectures the ATen fallback reaches the same work-item
+        # limit and raises, which says nothing about the guard under test.
+        self.assertTrue(_is_hip_grid_safe(a[:-1], b[:-1]))
+        self.assertFalse(_is_hip_grid_safe(a, b))
+        self.assertFalse(_bmm_outer_product_cond(a, b))
 
     def test_gradient_flow(self):
         a = torch.randn(4, 8, 1, device=GPU_TYPE, requires_grad=True)

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -3,6 +3,11 @@ import torch
 from ... import triton_utils as tu
 
 
+# HIP rejects a launch once gridDim.x * blockDim.x reaches 2**32, and the
+# rejection leaves the HIP context unusable rather than raising cleanly.
+_HIP_MAX_LAUNCH_WORK_ITEMS = (1 << 32) - 1
+
+
 def _is_outer_product(a: torch.Tensor, b: torch.Tensor) -> bool:
     return (
         a.ndim == 3
@@ -31,6 +36,31 @@ def _bmm_outer_product_impl(
         return bmm_outer_product(a, b)
 
 
+def _is_hip_grid_safe(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Return whether the outer-product BMM launch is safe on this backend.
+
+    Only HIP tensors are constrained; every other backend returns ``True``.
+    Unlike Inductor, this eager kernel does not retune its fixed launch
+    configuration, so oversized HIP launches decline the specialization and fall
+    back to ATen. ATen can still fail on shapes this large, but it fails cleanly
+    instead of leaving the HIP context unusable.
+    """
+    if torch.version.hip is None or a.device.type != "cuda":
+        return True
+
+    from .triton_kernels import (
+        _bmm_outer_product_launch_config,
+        _TRITON_DEFAULT_NUM_WARPS,
+    )
+
+    batch, m, _ = a.shape
+    n = b.shape[2]
+    grid_size, _, _ = _bmm_outer_product_launch_config(batch, m, n)
+    warp_size = torch.cuda.get_device_properties(a.device).warp_size
+    threads_per_program = _TRITON_DEFAULT_NUM_WARPS * warp_size
+    return grid_size * threads_per_program <= _HIP_MAX_LAUNCH_WORK_ITEMS
+
+
 def _bmm_outer_product_cond(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -39,15 +69,14 @@ def _bmm_outer_product_cond(
 ) -> bool:
     a_is_cow = torch._C._is_cow_tensor(a)  # pyrefly: ignore[missing-attribute]
     b_is_cow = torch._C._is_cow_tensor(b)  # pyrefly: ignore[missing-attribute]
-    if (
+    return (
         a.is_cuda
         and b.is_cuda
         and a.device == b.device
         and _is_outer_product(a, b)
         and not (a_is_cow or b_is_cow)
-    ):
-        return True
-    return False
+        and _is_hip_grid_safe(a, b)
+    )
 
 
 def _register_for_dispatch_key(dispatch_key: str) -> None:

--- a/torch/_native/ops/bmm_outer_product/triton_kernels.py
+++ b/torch/_native/ops/bmm_outer_product/triton_kernels.py
@@ -1,7 +1,14 @@
+import functools
+
 import triton
 import triton.language as tl
 
 import torch
+
+
+# Pin Triton's current default so the launch and its safety check use the
+# same number of warps.
+_TRITON_DEFAULT_NUM_WARPS = 4
 
 
 @triton.jit
@@ -65,15 +72,29 @@ def _pick_block_sizes(m: int, n: int) -> tuple[int, int]:
     return block_m, min(triton.next_power_of_2(n), 128)
 
 
+@functools.lru_cache(maxsize=1024)
+def _bmm_outer_product_launch_config(
+    batch: int, m: int, n: int
+) -> tuple[int, int, int]:
+    """Return the 1D grid size and block sizes used to launch the kernel.
+
+    The grid has one entry for every (batch, M tile, N tile). Sharing this
+    calculation with the safety guard keeps the checked and launched grids identical.
+    """
+    block_m, block_n = _pick_block_sizes(m, n)
+    grid_size = batch * triton.cdiv(m, block_m) * triton.cdiv(n, block_n)
+    return grid_size, block_m, block_n
+
+
 def bmm_outer_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     B, M, _ = a.shape
     N = b.shape[2]
 
     out = torch.empty(B, M, N, dtype=a.dtype, device=a.device)
 
-    BLOCK_M, BLOCK_N = _pick_block_sizes(M, N)
+    grid_size, BLOCK_M, BLOCK_N = _bmm_outer_product_launch_config(B, M, N)
 
-    _bmm_outer_product_kernel[(B * triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),)](
+    _bmm_outer_product_kernel[(grid_size,)](
         a,
         b,
         out,
@@ -89,5 +110,6 @@ def bmm_outer_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         out.stride(2),
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
+        num_warps=_TRITON_DEFAULT_NUM_WARPS,
     )
     return out


### PR DESCRIPTION
Resolves: https://amd-hub.atlassian.net/browse/ROCM-29320. Request is from a high-priority customer.

Backport of landed [pytorch/pytorch#194131](https://github.com/pytorch/pytorch/pull/194131) to `release/2.13` as a single `cherry-pick -x` of upstream commit [`58a938a`](https://github.com/pytorch/pytorch/commit/58a938a422d785b35430328d5e718e7fb0e7c07e).

## Summary
- decline the eager native outer-product BMM specialization when its launch would
  exceed HIP's work-item limit, and fall back to ATen
- share the launch configuration between the guard and the launch, and pin
  `num_warps`, so the checked and launched grids cannot drift
- add a ROCm regression that pins the boundary from both sides

HIP rejects a launch once `gridDim.x * blockDim.x` reaches `2^32`. The eager
outer-product kernel launches a 1D grid with one program per (batch, M tile, N
tile) using a fixed configuration and, unlike Inductor, cannot grow its tiles to
shrink the grid, so it declines the specialization and falls back to ATen.

The limit is on total work items, so the boundary moves with the wave size and
the guard reads it from the device. For `M = N = 1` that is `B = 16,777,216` on
wave64 (CDNA) and `B = 33,554,432` on wave32 (RDNA).

At these sizes ATen can also fail on some architectures, but it raises a clean,
catchable `AcceleratorError`; the rejected Triton launch can leave the HIP
context unusable.

### Why this needs a guard

On gfx90a the rejected launch does not fail cleanly. Triton reports
`RuntimeError: Triton Error [HIP]: Code: 1, Messsage: invalid argument`, which
its knobs machinery then mangles into a `SystemError`, and the HIP context is
left unusable—the next allocation fails with
`AcceleratorError: CUDA error: invalid argument`.

### Boundary verification (gfx90a, wave64)

Measured by calling the launcher directly, bypassing the guard:

| B (M = N = 1) | work items | guard | unguarded launch |
|---|---|---|---|
| 16,777,215 | 4,294,967,040 | accept | succeeds, results correct |
| 16,777,216 | 4,294,967,296 (2^32) | decline | fails, HIP context left unusable |

The guard declines exactly the launches that fail and accepts every launch that
works.

## Test Plan

The upstream PR passed its full BMM outer-product suite and its ROCm regression
ran successfully on MI350 (gfx950, wave64).

The release backport's adapted files pass targeted lint:

```bash
lintrunner --take FLAKE8,PYFMT,RUFF,CODESPELL,NEWLINE,SPACES,TABS,TESTOWNERS,TEST_HAS_MAIN \
  test/test_bmm_outer_product.py \
  torch/_native/ops/bmm_outer_product/triton_impl.py \
  torch/_native/ops/bmm_outer_product/triton_kernels.py
```

`release/2.13` predates the upstream branch's device-generic test harness and
COW/instrumentation refactors. Conflict resolution preserves the release
branch's existing behavior while applying the landed launch guard, shared
configuration, explicit warp count, and regression test.

Made with [Cursor](https://cursor.com)

cc @jeffdaily @sunway513 @jithunnair-amd @pruthvistony @ROCmSupport @jataylo @hongxiayang @pragupta @jerrymannil @xinyazhang @voznesenskym @penguinwu @EikanWang @jgong5 @Guobing-Chen @XiaobingSuper @zhuhaozhe @blzheng @wenzhe-nrv @jiayisunx @ipiszy @kadeng @muchulee8 @amjames @chauhang @aakhundov @coconutruben
