### PR TITLE
[release/2.11] Apply scikit-image/networkx py3.13 pins at 3.13, not 3.14

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -106,11 +106,12 @@ mypy==1.17.1 ; platform_system == "Linux" and python_version >= "3.14"
 #Pinned versions: 1.16.0, 1.17.1
 #test that import: test_typing.py, test_type_hints.py
 
-networkx==2.8.8 ; python_version < "3.14"
-networkx==3.0.0 ; python_version >= "3.14"
+networkx==2.8.8 ; python_version < "3.13"
+networkx==3.0.0 ; python_version >= "3.13"
+# scikit-image 0.26.0 requires networkx>=3.0
 #Description: creation, manipulation, and study of
 #the structure, dynamics, and functions of complex networks
-#Pinned versions: 2.8.8
+#Pinned versions: 2.8.8, 3.0.0
 #test that import: functorch
 
 ninja==1.11.1.4
@@ -247,8 +248,11 @@ pygments==2.15.0
 #Pinned versions: 14.1.0
 #test that import:
 
-scikit-image==0.22.0 ; python_version < "3.14"
-scikit-image==0.26.0 ; python_version >= "3.14"
+scikit-image==0.22.0 ; python_version < "3.13"
+scikit-image==0.26.0 ; python_version >= "3.13"
+# 0.22.0 has no cp313 wheel, so pip builds it from source and picks up an
+# unpinned pythran that no longer compiles under the -std=c++14 its meson build
+# uses. 0.26.0 ships cp313/cp314 wheels, so there is no source build.
 #Description: image processing routines
 #Pinned versions: 0.22.0, 0.26.0
 #test that import: test_nn.py


### PR DESCRIPTION
https://amd-hub.atlassian.net/browse/AIPYTORCH-1083

## Problem

PT 2.11 devel Docker builds fail on Python 3.13 in the RC4 UFB run ([unified-framework-builds run 32744079116](https://github.com/ROCm/unified-framework-builds/actions/runs/32744079116)) — `ubuntu:24.04 | py3.13` and `debian:trixie | py3.13` both fail, while py3.11, py3.12, py3.14 and CentOS Stream 9 pass.

The failing step installs `.ci/docker/requirements-ci.txt` and dies building `scikit-image==0.22.0` from source:

```
scikit-image==0.22.0 (from -r requirements-ci.txt (line 250))
  Downloading scikit_image-0.22.0.tar.gz (22.7 MB)
  Preparing metadata (pyproject.toml): finished with status 'error'
pythran/pythonic/operator_/mod.hpp:38:33: error: 'is_fundamental_v' is not a member of 'std'
pythran/pythonic/include/types/NoneType.hpp:170:26: fatal error: template instantiation depth exceeds maximum of 900
error: metadata-generation-failed
```

`release/2.11` gates the newer pins at `python_version >= "3.14"`, because [#3423](https://github.com/ROCm/pytorch/pull/3423) only targeted enabling py3.14 CI. py3.13 therefore still resolves `scikit-image==0.22.0`, which has no cp313 wheel, so pip builds it from source and pulls an unpinned pythran that no longer compiles under the `-std=c++14` its meson build uses.

`release/2.10`, `2.12`, `2.13` and `2.14` all gate at `>= "3.13"`; 2.11 is the outlier.

## Changes

`.ci/docker/requirements-ci.txt` — move both marker boundaries from `3.14` to `3.13`:

- `scikit-image==0.22.0 ; python_version < "3.13"` / `0.26.0 ; python_version >= "3.13"`
- `networkx==2.8.8 ; python_version < "3.13"` / `3.0.0 ; python_version >= "3.13"`

networkx must move with it because `scikit-image 0.26.0` requires `networkx>=3.0`. Behavior on py3.14 is unchanged — it already resolved these same versions.

This mirrors [#3576](https://github.com/ROCm/pytorch/pull/3576) on `release/2.13` (which ports upstream [#194022](https://github.com/pytorch/pytorch/pull/194022)), adapted to the pins that already exist on 2.11.

## Validation

UFB devel Docker build reproducing the exact failing configuration (`ubuntu:24.04`, py3.13, `device-all`, prereleases index, ROCm `10.0.0rc4`, torch `2.11.0`) against this branch:

- **Passed:** [unified-framework-builds run 32767073609](https://github.com/ROCm/unified-framework-builds/actions/runs/32767073609)

- [x] The new marker takes effect and py3.13 installs a wheel instead of building from source:

```
Ignoring scikit-image: markers 'python_version < "3.13"' don't match your environment
Collecting scikit-image==0.26.0 (from -r .ci/docker/requirements-ci.txt (line 252))
  Downloading scikit_image-0.26.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
Collecting networkx==3.0.0 (from -r .ci/docker/requirements-ci.txt (line 110))
  Downloading networkx-3.0-py3-none-any.whl
```

- [x] `requirements-ci.txt` install completes; no pythran compile and no `metadata-generation-failed` anywhere in the log
- [x] Image builds and tags successfully: `rocm/ufb-private:pytorch-2.11.0-ubuntu24.04-py3.13-prereleases-device-all-rocm10.0.0rc4-build-6b2f5559c2`
- [x] Wheels resolved as intended: `torch-2.11.0+rocm10.0.0rc4`, `torchaudio-2.11.0+rocm10.0.0rc4`, `torchvision-0.26.0+rocm10.0.0rc4`

py3.14 is unaffected by construction — the markers now select the same versions it already resolved, and those jobs pass today.

Note: the `release/2.10` failures in the same UFB run are unrelated — those jobs fail earlier with `No ROCm torch wheels found` for ROCm 10.0.0rc4, a wheel-availability problem rather than a dependency pin.

Refs: [ROCM-29961](https://amd-hub.atlassian.net/browse/ROCM-29961)


[ROCM-29961]: https://amd-hub.atlassian.net/browse/ROCM-29961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ