### PR TITLE
[release/2.11] Skip known-failing ROCm 7.14 and MemPool tests; fix test_typing name_fn

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -98,12 +98,11 @@ librosa==0.10.2 ; python_version == "3.12" and platform_machine != "s390x"
 #Pinned versions:
 #test that import:
 
-mypy==1.16.0 ; platform_system == "Linux" and python_version < "3.14"
-mypy==1.17.1 ; platform_system == "Linux" and python_version >= "3.14"
+mypy==1.16.0 ; platform_system == "Linux"
 # Pin MyPy version because new errors are likely to appear with each release
 # Skip on Windows as lots of type annotations are POSIX specific
 #Description: linter
-#Pinned versions: 1.16.0, 1.17.1
+#Pinned versions: 1.16.0
 #test that import: test_typing.py, test_type_hints.py
 
 networkx==2.8.8 ; python_version < "3.13"

--- a/test/distributed/test_ce_colls.py
+++ b/test/distributed/test_ce_colls.py
@@ -9,6 +9,7 @@ from torch.testing._internal.common_distributed import (
     MultiProcContinuousTest,
     requires_nccl_version,
     skip_if_lt_x_gpu,
+    skip_if_rocm_ver_atleast_multiprocess,
 )
 from torch.testing._internal.common_utils import requires_cuda_p2p_access, run_tests
 
@@ -61,6 +62,7 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
         return group_name, prof
 
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_ce_allgather(self):
         group_name, prof = self._init()
         dtype = torch.float
@@ -104,6 +106,7 @@ class NCCLCopyEngineCollectives(MultiProcContinuousTest):
         #     prof.export_chrome_trace("test_ce_allgather.json")
 
     @skip_if_lt_x_gpu(2)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_ce_alltoall(self):
         group_name, prof = self._init()
         dtype = torch.float

--- a/test/distributed/test_symmetric_memory.py
+++ b/test/distributed/test_symmetric_memory.py
@@ -40,6 +40,7 @@ from torch.testing._internal.common_distributed import (
     requires_multicast_support,
     skip_if_lt_x_gpu,
     skip_if_rocm_multiprocess,
+    skip_if_rocm_ver_atleast_multiprocess,
     skip_if_rocm_ver_lessthan_multiprocess,
 )
 from torch.testing._internal.common_utils import (
@@ -309,6 +310,7 @@ class SymmetricMemoryTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(4)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_subgroup(self) -> None:
         self._init_process()
 
@@ -1051,6 +1053,7 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(4)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_one_shot_all_reduce(self) -> None:
         self._init_process()
         group_name = dist.group.WORLD.group_name
@@ -1084,6 +1087,7 @@ class SymmMemCollectiveTest(MultiProcContinuousTest):
         not PLATFORM_SUPPORTS_SYMM_MEM, "SymmMem is not supported on this ROCm arch"
     )
     @skip_if_lt_x_gpu(4)
+    @skip_if_rocm_ver_atleast_multiprocess([7, 14])
     def test_two_shot_all_reduce(self) -> None:
         self._init_process()
         group_name = dist.group.WORLD.group_name

--- a/test/export/test_export_opinfo.py
+++ b/test/export/test_export_opinfo.py
@@ -25,6 +25,7 @@ from torch.testing._internal.common_utils import (
     IS_WINDOWS,
     run_tests,
     skipIfRocm,
+    skipIfRocmVersionAtLeast,
     TestCase,
 )
 from torch.utils import _pytree as pytree
@@ -148,6 +149,7 @@ selected_ops = {
 selected_op_db = [op for op in op_db if op.name in selected_ops]
 
 
+@skipIfRocmVersionAtLeast([7, 14])
 class TestExportOnFakeCuda(TestCase):
     # In CI, this test runs on a CUDA machine with cuda build
     # We set CUDA_VISIBLE_DEVICES="" to simulate a CPU machine with cuda build

--- a/test/test_cuda.py
+++ b/test/test_cuda.py
@@ -6328,6 +6328,7 @@ class TestMemPool(TestCase):
         finally:
             self._teardown_mempool_limited_memory_test()
 
+    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/180325")
     @serialTest()
     def test_mempool_no_split(self):
         torch.cuda.empty_cache()
@@ -6471,6 +6472,7 @@ class TestMemPool(TestCase):
             s = p.snapshot()
             self.assertEqual(len(s), 1, "Expected to have a single segment")
 
+    @unittest.skipIf(IS_LINUX, "https://github.com/pytorch/pytorch/issues/180367")
     @serialTest()
     def test_nested_mempool(self):
         torch.cuda.empty_cache()

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -53,6 +53,7 @@ from torch.testing._internal.common_utils import (
     parametrize,
     run_tests,
     serialTest,
+    skipIfRocmVersionAtLeast,
     skipIfTorchDynamo,
     TemporaryDirectoryName,
     TemporaryFileName,
@@ -958,6 +959,7 @@ class SerializationMixin:
             self.assertEqual(data, loaded_data)
 
     @unittest.skipIf(not IS_CI, "only check debug var is set in CI")
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_debug_set_in_ci(self):
         # This test is to make sure that the serialization debug flag is set in CI
         self.assertTrue(os.environ.get("TORCH_SERIALIZATION_DEBUG", "0") == "1")

--- a/test/test_typing.py
+++ b/test/test_typing.py
@@ -173,7 +173,7 @@ class TestTyping(TestCase):
     @parametrize(
         "path",
         get_test_cases(PASS_DIR),
-        name_fn=lambda b: os.path.relpath(b, start=PASS_DIR),
+        name_fn=lambda b: os.path.splitext(os.path.relpath(b, start=PASS_DIR))[0],
     )
     def test_success(self, path) -> None:
         output_mypy = self.get_mypy_output()
@@ -185,7 +185,7 @@ class TestTyping(TestCase):
     @parametrize(
         "path",
         get_test_cases(FAIL_DIR),
-        name_fn=lambda b: os.path.relpath(b, start=FAIL_DIR),
+        name_fn=lambda b: os.path.splitext(os.path.relpath(b, start=FAIL_DIR))[0],
     )
     def test_fail(self, path):
         __tracebackhide__ = True  # noqa: F841
@@ -224,7 +224,7 @@ class TestTyping(TestCase):
     @parametrize(
         "path",
         get_test_cases(REVEAL_DIR),
-        name_fn=lambda b: os.path.relpath(b, start=REVEAL_DIR),
+        name_fn=lambda b: os.path.splitext(os.path.relpath(b, start=REVEAL_DIR))[0],
     )
     def test_reveal(self, path):
         __tracebackhide__ = True  # noqa: F841

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -33,6 +33,7 @@ from torch.testing._internal.common_utils import (  # type: ignore[attr-defined]
     IS_SANDCASTLE,
     IS_WINDOWS,
     load_tests,
+    skipIfRocmVersionAtLeast,
 )
 from torch.utils._device import set_device
 from torch.utils._pytree import tree_all_only, tree_any
@@ -780,6 +781,7 @@ class TestAssert(TestCase):
 
 @unittest.skipIf(IS_SANDCASTLE, "cpp_extension is OSS only")
 class TestStandaloneCPPJIT(TestCase):
+    @skipIfRocmVersionAtLeast([7, 14])
     def test_load_standalone(self):
         build_dir = tempfile.mkdtemp()
         try:

--- a/torch/testing/_internal/common_distributed.py
+++ b/torch/testing/_internal/common_distributed.py
@@ -550,6 +550,23 @@ def skip_if_rocm_ver_lessthan_multiprocess(version=None):
     return decorator
 
 
+def skip_if_rocm_ver_atleast_multiprocess(version=None):
+    """Skips a test for ROCm if the version is at least the given tuple - multiprocess UTs"""
+
+    def decorator(func):
+        reason = None
+        if TEST_WITH_ROCM:
+            rocm_version = str(torch.version.hip)
+            rocm_version = rocm_version.split("-", maxsplit=1)[0]  # ignore git sha
+            rocm_version_tuple = tuple(int(x) for x in rocm_version.split("."))
+            if version is not None and rocm_version_tuple >= tuple(version):
+                reason = f"skip_if_rocm_ver_atleast_multiprocess: known failure on ROCm {rocm_version_tuple} (>= {version})"
+
+        return unittest.skipIf(reason is not None, reason)(func)
+
+    return decorator
+
+
 def skip_if_win32():
     return skip_but_pass_in_sandcastle_if(
         sys.platform == "win32",

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -2147,6 +2147,52 @@ def skipIfRocmVersionLessThan(version=None):
         return wrap_fn
     return dec_fn
 
+def lazy_skip_if(condition_fn, reason):
+    """Skip a test (function or class) when ``condition_fn()`` is true.
+
+    For function targets the condition is evaluated each time the test
+    runs, matching the historical PyTorch convention of checking skip
+    flags inside a wrapper. For class targets the condition is evaluated
+    once at class-decoration time and the standard ``__unittest_skip__``
+    attributes are set, since unittest's TestLoader makes class-level
+    skip decisions before instantiation.
+
+    Prefer this helper over hand-rolled ``@wraps + raise SkipTest``
+    wrappers, which silently drop classes from discovery when applied at
+    class scope.
+    """
+
+    def decorator(fn):
+        if isinstance(fn, type):
+            if condition_fn():
+                fn.__unittest_skip__ = True  # type: ignore[attr-defined]
+                fn.__unittest_skip_why__ = reason  # type: ignore[attr-defined]
+            return fn
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            if condition_fn():
+                raise unittest.SkipTest(reason)
+            return fn(*args, **kwargs)
+        return wrapper
+    return decorator
+
+# Skips a test on ROCm if the version is at least the given major.minor tuple.
+# Use for failures introduced in a ROCm release that pass on older versions,
+# e.g. skipIfRocmVersionAtLeast([7, 14]) skips on 7.14+ but runs on 7.2.x.
+# Built on lazy_skip_if so it works on both test methods and test classes.
+def skipIfRocmVersionAtLeast(version=None):
+    def _should_skip():
+        if not TEST_WITH_ROCM:
+            return False
+        rocm_version_tuple = getRocmVersion()
+        return (
+            rocm_version_tuple is not None
+            and version is not None
+            and rocm_version_tuple >= tuple(version)
+        )
+    return lazy_skip_if(_should_skip, f"ROCm version at least {version}: known failure")
+
 def skipIfNotMiopenSuggestNHWC(fn):
     @wraps(fn)
     def wrapper(*args, **kwargs):


### PR DESCRIPTION
## Summary

Cherry-pick targeted CI stabilizations onto `release/2.11` for TheRock / ROCm 7.14 testing. Test skips and test-infra helpers only.

- **MemPool + expandable segments** ([#185013](https://github.com/pytorch/pytorch/pull/185013)): skip `test_mempool_no_split` and `test_nested_mempool` on Linux while MemPool segment counting is incompatible with `expandable_segments` ([#180325](https://github.com/pytorch/pytorch/issues/180325), [#180367](https://github.com/pytorch/pytorch/issues/180367)).
- **ROCm 7.14 skips** ([#3525](https://github.com/pytorch/pytorch/pull/3525)): add `lazy_skip_if`, `skipIfRocmVersionAtLeast`, and `skip_if_rocm_ver_atleast_multiprocess`; skip known-failing export, serialization, utils, and distributed tests on ROCm ≥ 7.14.
- **test_typing** ([#192648](https://github.com/pytorch/pytorch/pull/192648)): fix parametrized `name_fn` to strip `.py` from subtest names (fixes `too many values to unpack` when running individual tests). Collapse `requirements-ci.txt` to a single `mypy==1.16.0` pin so `check_mypy_version.py` works.

## Test plan

- [x] `python test/test_cuda.py TestMemPool.test_mempool_no_split TestMemPool.test_nested_mempool` — skipped on Linux
- [x] `PYTORCH_TEST_WITH_ROCM=1 python test/test_serialization.py TestSerialization.test_debug_set_in_ci` — skipped on ROCm 7.14+
- [x] `PYTORCH_TEST_WITH_ROCM=1 python test/test_utils.py TestStandaloneCPPJIT.test_load_standalone` — skipped on ROCm 7.14+
- [x] `PYTORCH_TEST_WITH_ROCM=1 python test/export/test_export_opinfo.py TestExportOnFakeCudaCUDA` — skipped (9 tests)
- [x] `PYTORCH_TEST_WITH_ROCM=1 python test/distributed/test_ce_colls.py NCCLCopyEngineCollectives.test_ce_allgather NCCLCopyEngineCollectives.test_ce_alltoall` — skipped
- [x] `PYTORCH_TEST_WITH_ROCM=1 python test/distributed/test_symmetric_memory.py SymmetricMemoryTest.test_subgroup SymmMemCollectiveTest.test_one_shot_all_reduce SymmMemCollectiveTest.test_two_shot_all_reduce` — skipped
- [x] `python test/test_typing.py TestTyping` — 18/18 pass