### PR TITLE
Pin GitHub Actions in ROCm-owned workflows (ROCM-27018)

### DIFF
--- a/.github/workflows/build_portable_linux_pytorch_dockers.yml
+++ b/.github/workflows/build_portable_linux_pytorch_dockers.yml
@@ -85,10 +85,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workflow files
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Checkout PyTorch source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ matrix.pytorch_repo }}
           ref: ${{ matrix.pytorch_branch }}
@@ -185,7 +185,7 @@ jobs:
           echo "Generated image tag: ${IMAGE_TAG}"
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERUSERNAME }}
           password: ${{ secrets.DOCKERTOKEN }}
@@ -256,10 +256,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout workflow files
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Checkout PyTorch source
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ inputs.pytorch_repo || 'pytorch/pytorch' }}
           ref: ${{ inputs.pytorch_branch || 'nightly' }}
@@ -361,7 +361,7 @@ jobs:
           echo "Generated image tag: ${IMAGE_TAG}"
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERUSERNAME }}
           password: ${{ secrets.DOCKERTOKEN }}

--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -142,10 +142,10 @@ jobs:
         arch: ${{ fromJson(needs.setup-matrix.outputs.arch-matrix) }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 
@@ -302,7 +302,7 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ needs.setup-matrix.outputs.prefix }}-results-${{ matrix.arch }}
           path: ${{ steps.upload-paths.outputs.paths }}
@@ -313,15 +313,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.10'
 
       - name: Download all per-arch CSV artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: ${{ needs.setup-matrix.outputs.prefix }}-results-*
           path: artifacts
@@ -403,7 +403,7 @@ jobs:
           cat "${OUTPUT}.md" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload parity summary markdown
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: parity-summary-md
           path: .automation_scripts/pytorch-unit-test-scripts/*_summary.md

--- a/.github/workflows/pin-actions-ratchet.yml
+++ b/.github/workflows/pin-actions-ratchet.yml
@@ -1,0 +1,65 @@
+# Fail CI if ROCm-owned workflow files use mutable GitHub Action refs
+# (tags like @v4, branches like @main/@master) instead of commit SHAs.
+# Addresses SEC-00829 / ROCM-27018.
+name: Pin Actions Ratchet
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/parity.yml'
+      - '.github/workflows/build_portable_linux_pytorch_dockers.yml'
+      - '.github/workflows/pin-actions-ratchet.yml'
+  push:
+    branches:
+      - develop
+    paths:
+      - '.github/workflows/parity.yml'
+      - '.github/workflows/build_portable_linux_pytorch_dockers.yml'
+      - '.github/workflows/pin-actions-ratchet.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Check ROCm workflow action pins
+        run: |
+          set -euo pipefail
+
+          # ROCm-owned workflows outside upstream PyTorch parity.
+          FILES=(
+            .github/workflows/parity.yml
+            .github/workflows/build_portable_linux_pytorch_dockers.yml
+          )
+
+          FAIL=0
+
+          for file in "${FILES[@]}"; do
+            if [[ ! -f "$file" ]]; then
+              echo "::warning::$file not found, skipping"
+              continue
+            fi
+
+            while IFS= read -r line; do
+              if [[ "$line" =~ uses:[[:space:]]*([^@[:space:]]+)@([^[:space:]]+) ]]; then
+                ref="${BASH_REMATCH[2]}"
+                if [[ ! "$ref" =~ ^[0-9a-f]{40}$ ]]; then
+                  echo "::error file=$file::Mutable action ref '@${ref}' — pin to a 40-char commit SHA"
+                  FAIL=1
+                fi
+              fi
+            done < <(grep -E 'uses:[[:space:]]*[^@[:space:]]+@' "$file" || true)
+          done
+
+          if [[ "$FAIL" -ne 0 ]]; then
+            echo ""
+            echo "Pin actions with: pinact run --only '${FILES[*]}'"
+            exit 1
+          fi
+
+          echo "All ROCm-owned workflow action refs are pinned to commit SHAs."

--- a/.github/workflows/pin-actions-ratchet.yml
+++ b/.github/workflows/pin-actions-ratchet.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/workflows/parity.yml'
       - '.github/workflows/build_portable_linux_pytorch_dockers.yml'
+      - '.github/workflows/pytorch_ifu.yml'
       - '.github/workflows/pin-actions-ratchet.yml'
   push:
     branches:
@@ -15,6 +16,7 @@ on:
     paths:
       - '.github/workflows/parity.yml'
       - '.github/workflows/build_portable_linux_pytorch_dockers.yml'
+      - '.github/workflows/pytorch_ifu.yml'
       - '.github/workflows/pin-actions-ratchet.yml'
 
 permissions:
@@ -35,6 +37,7 @@ jobs:
           FILES=(
             .github/workflows/parity.yml
             .github/workflows/build_portable_linux_pytorch_dockers.yml
+            .github/workflows/pytorch_ifu.yml
           )
 
           FAIL=0

--- a/.github/workflows/pytorch_ifu.yml
+++ b/.github/workflows/pytorch_ifu.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
@@ -57,7 +57,7 @@ jobs:
           repositories: pytorch
 
       - name: Checkout repository (${{ env.DOWNSTREAM_REPO }}) (full history)
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: ${{ env.DOWNSTREAM_REPO }}
           path: ${{ env.DOWNSTREAM_REPO }}


### PR DESCRIPTION
## Summary
- Pin action refs in ROCm-owned workflows:
  - `parity.yml` (7 refs)
  - `build_portable_linux_pytorch_dockers.yml` (6 refs)
  - `pytorch_ifu.yml` (2 refs: checkout, create-github-app-token)
- Add `pin-actions-ratchet.yml` CI gate to block mutable refs in those files going forward
- `parity-auto.yml` reviewed — no `uses:` action refs (inline bash + gh CLI only); no change needed

Addresses [ROCM-27018](https://amd-hub.atlassian.net/browse/ROCM-27018) / SEC-00829.

## Scope
ROCm-specific workflows only. Upstream-inherited `@main` refs (~350+) are unchanged and tracked separately via upstream PyTorch.

## Test plan
- [x] Pin Actions Ratchet workflow passes on this PR
- [ ] parity.yml, docker build, and IFU workflows still trigger correctly

[ROCM-27018]: https://amd-hub.atlassian.net/browse/ROCM-27018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ