### PR TITLE
Skip test_multi_grad_all_hooks on Windows

### DIFF
--- a/test/test_autograd.py
+++ b/test/test_autograd.py
@@ -10949,6 +10949,12 @@ for shape in [(1,), ()]:
         out = x * y
         out.sum().backward()
 
+    # On Windows the ROCm wheels are built with clang-cl, which does not emit
+    # dllexport for c10::Error subclass constructors inherited via
+    # `using Error::Error;` (llvm/llvm-project#162640). JIT-compiling this
+    # inline extension therefore fails to link/load against c10.
+    # Fixed on main by #175340, which is not in this release branch.
+    @unittest.skipIf(IS_WINDOWS, "Inline extension fails to load on Windows, see #181892")
     @scoped_load_inline
     def test_multi_grad_all_hooks(self, load_inline):
         t1 = torch.rand(2, requires_grad=True)


### PR DESCRIPTION
## Summary

Skips `TestAutograd.test_multi_grad_all_hooks` on Windows in this release branch.

The test JIT-builds an inline C++ extension with `load_inline()`. On Windows the ROCm wheels are built with `clang-cl`, which does not emit `dllexport` for the `c10::Error` subclass constructors that are inherited via `using Error::Error;` — upstream clang bug [llvm/llvm-project#162640](https://github.com/llvm/llvm-project/issues/162640). As a result `c10.dll` / `c10.lib` ship without:

- `c10::ValueError::ValueError(SourceLocation, std::string)`
- `c10::NotImplementedError::NotImplementedError(SourceLocation, std::string)`

The inline extension is compiled and linked with MSVC against that clang-cl-produced `c10.lib`, and `torch/extension.h` pulls in headers that reference both constructors (`ivalue_inl.h` via `TORCH_CHECK_VALUE`, `compiled_autograd.h` via `TORCH_CHECK_NOT_IMPLEMENTED`). So the test fails on Windows during extension build/load, long before it exercises `register_multi_grad_hook` — this is a packaging/toolchain issue, not an autograd defect.

## Why skip rather than fix here

The underlying export gap was fixed upstream on `main` by [pytorch#175340](https://github.com/pytorch/pytorch/pull/175340) (commit `03a98a4c424`, closes [#181892](https://github.com/pytorch/pytorch/issues/181892)), which adds explicit constructor declarations for every affected `Error` subclass. That landed on 2026-06-02, after `release/2.12` was cut on 2026-04-15, and is not being backported to this branch. Skipping keeps the branch green without carrying a C++ change.

Note the fix is present on `main`, `release/2.13` and `release/2.14`, so this skip is specific to this branch and should not be forward-ported.

## Details

- Gated on `IS_WINDOWS` rather than `TEST_WITH_ROCM`: the latter reads `PYTORCH_TEST_WITH_ROCM`, which is unset when the test is run directly via `pytest test/test_autograd.py` — the way this failure is actually reproduced. Every Windows build of this fork uses clang-cl, so `IS_WINDOWS` is the accurate gate.
- Only the `TestAutograd` copy is skipped. `TestMultithreadAutograd.test_multi_grad_all_hooks` shares the name but builds no extension and is left running.
- `IS_WINDOWS` and `unittest` were already imported in this file; there is precedent for the same pattern at `test_autograd.py:7241`.

## Test plan

- Change is a decorator addition only; no runtime behavior change on Linux.
- Verified `test/test_autograd.py` parses, and that the stacked `@unittest.skipIf(...)` / `@scoped_load_inline` order skips on Windows and passes the `load_inline` argument through normally elsewhere.
- Linux CI should be unaffected; the test continues to run there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
