### PR TITLE
[release/2.13] Bump torchvision commit to fix gaussian blur tests on rocm

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,3 +1,3 @@
 ubuntu|pytorch|apex|release/1.13.0|68f9dc9e316c24ab9c974fafd302e8a7a56fdcff|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.28|8fb87713a24951e639c494b0f2a8a81b5f8e33a6|https://github.com/pytorch/vision
+ubuntu|pytorch|torchvision|release/0.28|53881ee74892a7c22f2b16a84b15a00f64a8bf68|https://github.com/ROCm/vision
 ubuntu|pytorch|torchaudio|release/2.11.0.2|b3ec2afa3ae504ca600d5e08956eb13d6e2aee31|https://github.com/ROCm/audio


### PR DESCRIPTION
Cherry-pick from upstream to fix gaussian blur tests on ROCm (ROCM-28892)