### PR TITLE
[release/2.14] Bump torchvision commit to fix gaussian blur tests on rocm

### DIFF
--- a/related_commits
+++ b/related_commits
@@ -1,3 +1,3 @@
 ubuntu|pytorch|apex|release/1.14.0|e9173a42aa6363325bea8ddc71a0a6196cb01ed3|https://github.com/ROCm/apex
-ubuntu|pytorch|torchvision|release/0.29|0fba2e84fe255a2fcd81bd0b10c74d7fca99a89f|https://github.com/pytorch/vision
+ubuntu|pytorch|torchvision|release/0.29|b7d540b22fab0df4673898fb0aec2fc6954cddac|https://github.com/ROCm/vision
 ubuntu|pytorch|torchaudio|release/2.11.0.3|ba6dfeedd354a8d67ce0f299f93b0ff9361c59e1|https://github.com/ROCm/audio


### PR DESCRIPTION
Cherry-pick from upstream to fix gaussian blur tests on ROCm (ROCM-28892)