### PR TITLE
Pin least-privilege GITHUB_TOKEN on ROCm parity.yml

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -101,6 +101,10 @@ on:
         default: true
         type: boolean
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   setup-matrix:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Pins `GITHUB_TOKEN` on `.github/workflows/parity.yml` (`contents: read`, `actions: read`) so this ROCm-only workflow no longer inherits the repo default.
- Tracks [ROCM-27014](https://amd-hub.atlassian.net/browse/ROCM-27014) / Mythos SEC-00825. Other ROCm-owned workflows already declare `permissions:`; IFU write scopes are left unchanged.

## Test plan
- [ ] Confirm Actions still starts on `workflow_dispatch`
- [ ] Confirm checkout, artifact upload/download, and the summarize `gh api` artifact list still work
- [ ] Do not merge a blanket `contents: read` onto IFU tagging/PR workflows

> AI-assisted: this PR is the four-line `permissions:` block from triage. Please read the diff before marking ready for review.

Made with [Cursor](https://cursor.com)

[ROCM-27014]: https://amd-hub.atlassian.net/browse/ROCM-27014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ