### PR TITLE
[release/2.13] Pin pywavelets 1.9.0 for python 3.14

### DIFF
--- a/.ci/docker/requirements-ci.txt
+++ b/.ci/docker/requirements-ci.txt
@@ -332,9 +332,11 @@ tensorboard==2.18.0
 #test that import: test_tensorboard
 
 pywavelets==1.4.1 ; python_version < "3.12"
-pywavelets==1.7.0 ; python_version >= "3.12"
+pywavelets==1.7.0 ; python_version >= "3.12" and python_version < "3.14"
+pywavelets==1.9.0 ; python_version >= "3.14"
 #Description: This is a requirement of scikit-image, we need to pin
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
+# 1.7.0 has no cp314 wheel; 1.9.0 ships wheels for 3.14
 #Pinned versions: 1.4.1
 #test that import:
 


### PR DESCRIPTION
*✳️ Assisted by Claude Opus 5*

## Summary

Restores the python 3.14 `pywavelets` pin on `release/2.13`. This is a **missed cherry-pick**, not a new dependency problem — `release/2.12` and `release/2.14` already carry it.

```diff
-pywavelets==1.7.0 ; python_version >= "3.12"
+pywavelets==1.7.0 ; python_version >= "3.12" and python_version < "3.14"
+pywavelets==1.9.0 ; python_version >= "3.14"
 #Description: This is a requirement of scikit-image, we need to pin
 # it here because 1.5.0 conflicts with numpy 1.21.2 used in CI
+# 1.7.0 has no cp314 wheel; 1.9.0 ships wheels for 3.14
```

After this change the stanza is byte-identical to `release/2.14`.

## Motivation

`pywavelets 1.7.0` has no cp314 wheel, so on python 3.14 pip falls back to a source build. On Windows that build fails:

```
../pywt/_extensions/c/cwt.template.c: In function 'float_pi':
../pywt/_extensions/c/cwt.template.c:65:16: error: 'M_PI' undeclared (first use in this function)
   65 |         return M_PI;
```

so `Install test requirements` fails before pytest runs. Reported as ROCm/TheRock#7798 (4 jobs: gfx1151, gfx110X-all, gfx120X-all, gfx103X-all).

## Why only release/2.13

| branch | pywavelets pin | py3.14 |
|---|---|---|
| `release/2.12` | `1.7.0 ; >=3.12,<3.14` + `1.9.0 ; >=3.14` | OK |
| `release/2.13` | `1.7.0 ; python_version >= "3.12"` | **broken** |
| `release/2.14` | `1.7.0 ; >=3.12,<3.14` + `1.9.0 ; >=3.14` | OK |

The 2.12 fix is `a8418b814b0` (#3450, 2026-07-17); the 2.14 equivalent is `d24cbff527b` (#3574). #3516 (*"[CI][release/2.13] Cherry-pick dependency pins from 2.12"*, 2026-07-29) landed after #3450 and picked up `numba`, `pandas`, `scipy` and `typing-extensions`, but not the two `pywavelets` lines:

```
$ git show f99ad927bc4 -- .ci/docker/requirements-ci.txt | grep -E '^[+-].*(pywavelet|3\.14)'
+numba==0.61.2 ; python_version < "3.14" and platform_machine != "s390x"
+numba==0.64.0 ; python_version >= "3.14" and platform_machine != "s390x"
-pandas==2.2.3; python_version >= "3.12" and python_version < "3.14"
+pandas==2.2.3; python_version < "3.14"
-scipy==1.14.1 ; python_version > "3.11" and python_version < "3.14"
+scipy==1.14.1 ; python_version < "3.14"
-typing-extensions==4.12.2 ; python_version < "3.14"
-typing-extensions==4.15.0 ; python_version >= "3.14"
```

## Verification

- `pywavelets-1.9.0-cp314-cp314-win_amd64.whl` exists on PyPI. 1.9.0 is the **first** release with cp314 wheels (1.7.0 and 1.8.0 stop at cp313), so there is no source build at all.
- `pywavelets 1.9.0` requires `numpy>=1.25,<3`; this branch pins `numpy==2.3.4` for 3.14. Compatible.
- `scikit-image` lists `PyWavelets` only under its `docs` and `optional` extras, so the bump cannot affect it.
- Resolved all 69 requirements in this file under `platform_system=Windows, python_version=3.14` and checked PyPI wheel tags: after this change nothing else lacks a cp314 `win_amd64` wheel except `pwlf==2.2.1`, whose sdist is pure Python (no `.c`/`.pyx`/`.cpp` sources) and installs without a compiler.
- Same-run control group in ROCm/rockrel run `33466793774`: py3.14 x `release/2.12` and py3.14 x `release/2.14` **passed** `Install test requirements` on the same runners; only the `release/2.13` cells failed there.

Pins for python < 3.14 are untouched, so no other configuration changes.

## Note for the record

`pywavelets 1.9.0` has the identical `cwt.template.c` and still builds with `c_std=c17`, so the underlying `M_PI` bug is **not** fixed upstream — this pin works by avoiding the source build. The real defect is include ordering: `cwt.c -> cwt.h -> common.h -> (-DPY_EXTENSION) Python.h -> pyport.h -> <math.h>` pulls `math.h` in under `__STRICT_ANSI__` before `cwt.template.c:18` defines `_USE_MATH_DEFINES`, and mingw's `_INC_MATH` guard makes the later re-include a no-op. Linux is masked because CPython's `pyconfig.h` supplies `_XOPEN_SOURCE`. Worth filing at PyWavelets/pywt; it will recur on cp315.

## Test Plan

- [ ] Windows py3.14 x release/2.13 `Test PyTorch` jobs get past `Install test requirements`
- [ ] No resolution change for python 3.10-3.13 (markers untouched)

