### PR TITLE
[release/2.12] Fix missing stream synchronization in the threaded process group (#195281)

### DIFF
--- a/test/distributed/test_multi_threaded_pg.py
+++ b/test/distributed/test_multi_threaded_pg.py
@@ -22,7 +22,13 @@ from torch.testing._internal.common_distributed import (
     skip_if_lt_x_gpu,
     spawn_threads_and_init_comms,
 )
-from torch.testing._internal.common_utils import IS_SANDCASTLE, run_tests, TestCase
+from torch.testing._internal.common_utils import (
+    device_sleep,
+    get_cycles_per_ms,
+    IS_SANDCASTLE,
+    run_tests,
+    TestCase,
+)
 
 
 device_type = acc.type if (acc := torch.accelerator.current_accelerator()) else "cpu"
@@ -300,6 +306,45 @@ class TestCollectivesWithBaseClass(MultiThreadedTestCase):
         res_num = ((0 + self.world_size - 1) * self.world_size) / 2
         self.assertEqual(t0, torch.ones(3, 3) * res_num)
         self.assertEqual(t1, torch.ones(3, 3) * (res_num * 2))
+
+    @skip_if_lt_x_gpu(1)
+    def test_collectives_issued_from_side_stream(self):
+        # Threaded PG performs every rank's data movement on rank 0's stream, so
+        # it must synchronize with the stream each rank issued the collective
+        # from. FSDP2 relies on this: it all-gathers/reduce-scatters on private
+        # side streams.
+        device_module = torch.get_device_module(device_type)
+        # get_cycles_per_ms() is lru_cached and calibrates by timing a sleep
+        # kernel, so let one rank measure it on an otherwise idle device rather
+        # than have every rank contend and cache an under-measured value.
+        if self.rank == 0:
+            get_cycles_per_ms(device_type)
+        dist.barrier()
+        delay_cycles = int(200 * get_cycles_per_ms(device_type))
+        side_stream = device_module.Stream()
+        side_stream.wait_stream(device_module.current_stream())
+        with device_module.stream(side_stream):
+            if self.rank != 0:
+                # Rank 0 reads stale input unless it waits on this stream
+                device_sleep(device_type, delay_cycles)
+            inp = torch.full((8,), float(self.rank + 1), device=device_type)
+            all_gather_out = torch.empty((8 * self.world_size,), device=device_type)
+            dist.all_gather_single(all_gather_out, inp)
+            reduce_scatter_out = torch.empty((8,), device=device_type)
+            dist.reduce_scatter_single(reduce_scatter_out, all_gather_out)
+        device_module.current_stream().wait_stream(side_stream)
+
+        expected_all_gather = torch.cat(
+            [
+                torch.full((8,), float(rank + 1), device=device_type)
+                for rank in range(self.world_size)
+            ]
+        )
+        expected_reduce_scatter = torch.full(
+            (8,), float(self.world_size * (self.rank + 1)), device=device_type
+        )
+        self.assertEqual(all_gather_out, expected_all_gather)
+        self.assertEqual(reduce_scatter_out, expected_reduce_scatter)
 
     @skip_if_lt_x_gpu(1)
     def test_bwd_sees_fwd_pg(self):

--- a/torch/testing/_internal/distributed/multi_threaded_pg.py
+++ b/torch/testing/_internal/distributed/multi_threaded_pg.py
@@ -46,6 +46,44 @@ def ret_work(ret):
     return _create_work_from_future(fut)
 
 
+# Note [Threaded PG cross-stream synchronization]
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# A real process group is stream-ordered w.r.t. the stream that issued the
+# collective. Threaded PG instead performs the data movement for *all* ranks on
+# rank 0's thread, hence on rank 0's current stream. The current stream is
+# thread-local, so whenever a rank issues a collective from a side stream (FSDP2
+# does this for all-gather/reduce-scatter), rank 0's copies are unordered w.r.t.
+# that rank's producing and consuming kernels. Events restore the ordering that
+# a real backend would provide. Rank 0 records no input event of its own: its
+# copies already run on the stream that produced its data.
+def _accelerator_devices(data):
+    """Devices of the accelerator tensors in ``data``."""
+    accelerator = torch.accelerator.current_accelerator()
+    if accelerator is None:
+        return set()
+    return {
+        t.device
+        for t in flatten_list(data)
+        if isinstance(t, torch.Tensor) and t.device.type == accelerator.type
+    }
+
+
+def _record_current_stream_events(devices):
+    """Record an event on the current stream of every device in ``devices``."""
+    events = []
+    for device in devices:
+        event = torch.Event(device.type)
+        event.record(torch.accelerator.current_stream(device.index))
+        events.append((device, event))
+    return events
+
+
+def _wait_current_stream_events(events):
+    """Make the calling thread's current stream wait on ``events``."""
+    for device, event in events:
+        event.wait(torch.accelerator.current_stream(device.index))
+
+
 def binop_reduce(tensors, op):
     res = op(torch.stack(tensors), dim=0)
     if isinstance(res, torch.Tensor):
@@ -318,11 +356,22 @@ class Collective:
         self._count = 0
         self._done = False
 
+        # See Note [Threaded PG cross-stream synchronization]
+        self._devices = [set() for _ in range(world_size)]
+        self._input_events = [[] for _ in range(world_size)]
+        self._work_events = []
+
         self._pg = pg
 
     def join(self, rank, data):
         with self._start_cond:
             self._data[rank] = data
+            # See Note [Threaded PG cross-stream synchronization]
+            self._devices[rank] = _accelerator_devices(data)
+            if rank > 0:
+                self._input_events[rank] = _record_current_stream_events(
+                    self._devices[rank]
+                )
             self._count += 1
 
             # notify rank 0
@@ -349,9 +398,15 @@ class Collective:
                 )
                 if self._pg._terminate.is_set():
                     sys.exit("Test termination event occurs.")
+                _wait_current_stream_events(self._work_events)
             else:
                 # copy data around
+                for events in self._input_events:
+                    _wait_current_stream_events(events)
                 self._collective.work(self._data)
+                self._work_events = _record_current_stream_events(
+                    set().union(*self._devices)
+                )
                 self._done = True
                 self._done_cond.notify_all()
         return ret_work(data)


### PR DESCRIPTION
Fix missing stream synchronization in the threaded process group (#195281)

## Summary:

Threaded PG performs the data movement for all ranks on rank 0's thread, hence on rank 0's current stream. The current stream is thread-local, so a collective issued from a side stream is unordered w.r.t. rank 0's copies: rank 0 can read a rank's input before its copy-in has run, and a rank can read its output before rank 0 has written it. FSDP2 hits this on every collective because

FSDPCommContext.lazy_init gives each rank private all-gather and reduce-scatter streams. The host-side ordering in Collective.join was already correct, which is why the race went unnoticed for so long: it resolves favourably on NVIDIA CI and loses on ROCm, where it surfaces as check_sharded_parity gradient mismatches and diverging losses in the FSDP2 and replicate tests (ROCM-28104).

A real backend is stream-ordered w.r.t. the stream that issued the collective, and Collective.join now provides the same guarantee using events: every non-root rank records an event on the stream it issued from, rank 0 waits on those events before copying and records one afterwards, and the other ranks wait on that. The path is a no-op for CPU tensors. test_collectives_issued_from_side_stream covers the same ordering without involving FSDP.

## Reproduction:

The affected tests pass by luck on a fast enough GPU, so delay the producing side. In test_param_registration_after_forward, right before model(inp):

    if self.rank != 0:
        device_sleep(device_type.type, int(50 * get_cycles_per_ms(device_type.type)))

FSDP2's side streams wait on the rank's compute stream, so the sleep holds back the collective's inputs while rank 0 runs ahead. Without this change the test fails with 9/36 elements mismatched; with it, it passes. test_to_float64_after_init reproduces the same way with the sleep at the top of the training loop. Pull Request resolved: https://github.com/pytorch/pytorch/pull/195281 Approved by: https://github.com/jeffdaily


(cherry picked from commit d8cc87a096102c4a80744e19760668c020308826)

Cherry-picked to release/2.13 branch via https://github.com/ROCm/pytorch/pull/3613

Cherry-picked to release/2.14 branch via https://github.com/ROCm/pytorch/pull/3614