### PR TITLE
Fix test_cpuset num threads torch import

### DIFF
--- a/.ci/pytorch/test.sh
+++ b/.ci/pytorch/test.sh
@@ -453,8 +453,8 @@ test_cpuset_num_threads() {
     echo "taskset not available, skipping cpuset num_threads test"
     return
   fi
-  env -u OMP_NUM_THREADS -u MKL_NUM_THREADS taskset -c 0 python -c \
-    'import torch; n = torch.get_num_threads(); print("num_threads =", n); assert n == 1, n'
+  (cd test && env -u OMP_NUM_THREADS -u MKL_NUM_THREADS taskset -c 0 python -c \
+    'import torch; n = torch.get_num_threads(); print("num_threads =", n); assert n == 1, n')
   assert_git_not_dirty
 }
 


### PR DESCRIPTION
Change directory to 'test' before executing Python thread count check.

## Motivation
PyTorch UT default variant fails on docker images before any test modules run. The harness aborts in ~52s with:

ModuleNotFoundError: No module named 'torch.version'
This happens because test_cpuset_num_threads() (added upstream in https://github.com/pytorch/pytorch/pull/194605 for https://github.com/pytorch/pytorch/issues/193859) runs python -c 'import torch' from the repo root (/workspace/pytorch). On wheel+docker images, the checkout contains an unbuilt torch/ source tree alongside the installed wheel. Python resolves the source package first (no generated torch/version.py), so the harness fails before run_test.py starts.

Other inline import checks in the same test.sh already use cd test before python -c. This change aligns test_cpuset_num_threads with that pattern.


## Technical Details

File changed: .ci/pytorch/test.sh — test_cpuset_num_threads()

Change: wrap the cpuset smoke import in a subshell that runs from test/:

Why (cd test && ...): keeps the harness working directory unchanged for subsequent steps while ensuring import torch resolves to the installed wheel in site-packages, not the bare source tree.

## Test Plan
 Confirm repo-root python -c 'import torch' fails with ModuleNotFoundError: No module named 'torch.version'.
 Confirm cd test && python -c 'import torch' succeeds and torch.get_num_threads() == 1 under taskset -c 0.
 Confirm unpatched test_cpuset_num_threads harness command fails with the same error.
 Confirm PR fix ((cd test && ...)) makes test_cpuset_num_threads pass (num_threads = 1).

## Test Result

<html>
<body>
<!--StartFragment-->
Test | Result | Notes
-- | -- | --
import torch from repo root (/workspace/pytorch) | FAIL | ModuleNotFoundError: No module named 'torch.version' —
import torch from test/ (cd test) | PASS | Wheel import works

<!--EndFragment-->
</body>
</html>

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
