### PR TITLE
[release/2.13][ROCm] Use rocm-sdk-devel as ROCM_HOME for TheRock installs

### DIFF
--- a/test/test_cpp_extensions_jit.py
+++ b/test/test_cpp_extensions_jit.py
@@ -12,6 +12,8 @@ import sys
 import tempfile
 import unittest
 import warnings
+from pathlib import Path
+from unittest import mock
 
 import torch
 import torch.backends.cudnn
@@ -81,6 +83,81 @@ with tempfile.TemporaryDirectory() as tmpdir:
             text=True,
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+class TestFindRocmHome(common.TestCase):
+    """Guess #2 must prefer devel over core when ROCM_HOME/ROCM_PATH are unset.
+
+    PyTorch ROCm CI exports those env vars, so TestMemPool never reaches this
+    path. These mocks are what actually guards the TheRock JIT include bug.
+    """
+
+    def _spec(self, origin: str):
+        spec = mock.Mock()
+        spec.origin = origin
+        return spec
+
+    def _find_home(self, specs, env_home=None):
+        def find_spec(name, *args, **kwargs):
+            origin = specs.get(name)
+            return None if origin is None else self._spec(origin)
+
+        with mock.patch.dict(os.environ):
+            os.environ.pop("ROCM_HOME", None)
+            os.environ.pop("ROCM_PATH", None)
+            if env_home is not None:
+                os.environ["ROCM_HOME"] = env_home
+            with (
+                mock.patch(
+                    "torch.utils.cpp_extension.importlib.util.find_spec",
+                    side_effect=find_spec,
+                ),
+                mock.patch(
+                    "torch.utils.cpp_extension.shutil.which", return_value=None
+                ),
+                mock.patch(
+                    "torch.utils.cpp_extension.os.path.exists", return_value=False
+                ),
+                mock.patch.object(torch.version, "hip", "7.0"),
+            ):
+                return torch.utils.cpp_extension._find_rocm_home()
+
+    def test_prefers_devel_over_core_when_env_unset(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            devel = Path(tmp) / "_rocm_sdk_devel"
+            core = Path(tmp) / "_rocm_sdk_core"
+            devel.mkdir()
+            core.mkdir()
+            (devel / "__init__.py").write_text("")
+            (core / "__init__.py").write_text("")
+            home = self._find_home(
+                {
+                    "_rocm_sdk_devel": str(devel / "__init__.py"),
+                    "_rocm_sdk_core": str(core / "__init__.py"),
+                }
+            )
+        self.assertEqual(home, str(devel.resolve()))
+
+    def test_falls_back_to_core_when_devel_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            core = Path(tmp) / "_rocm_sdk_core"
+            core.mkdir()
+            (core / "__init__.py").write_text("")
+            home = self._find_home({"_rocm_sdk_core": str(core / "__init__.py")})
+        self.assertEqual(home, str(core.resolve()))
+
+    def test_env_rocm_home_wins_over_sdk_packages(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            devel = Path(tmp) / "_rocm_sdk_devel"
+            forced = Path(tmp) / "from-env"
+            devel.mkdir()
+            forced.mkdir()
+            (devel / "__init__.py").write_text("")
+            home = self._find_home(
+                {"_rocm_sdk_devel": str(devel / "__init__.py")},
+                env_home=str(forced),
+            )
+        self.assertEqual(home, str(forced))
 
 
 # There's only one test that runs gradcheck, run slow mode manually

--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -183,13 +183,18 @@ def _find_rocm_home() -> str | None:
     # Guess #1
     rocm_home = os.environ.get('ROCM_HOME') or os.environ.get('ROCM_PATH')
     if rocm_home is None:
-        # Guess #2: Support for ROCm distribution from TheRock
-        # rocm-sdk-core installs everything under <site-packages>/_rocm_sdk_core
-        # (include/, lib/, bin/, ...), so the module's own location is the
-        # ROCM_HOME we want. Use find_spec to locate it without importing.
-        spec = importlib.util.find_spec('_rocm_sdk_core')
-        if spec is not None and spec.origin is not None:
-            rocm_home = str(Path(spec.origin).parent.resolve())
+        # Guess #2: Support for ROCm distribution from TheRock, which installs
+        # everything under <site-packages>/_rocm_sdk_* (include/, lib/, bin/,
+        # ...), so the module's own location is the ROCM_HOME we want.
+        # Prefer rocm-sdk-devel: rocm-sdk-core is runtime-only and ships no math
+        # library headers, so the hipBLAS/hipSPARSE includes pulled in by ATen's
+        # HIP headers would not resolve. find_spec locates the packages without
+        # importing them, and never triggers the multi-GB devel expansion.
+        for pkg in ('_rocm_sdk_devel', '_rocm_sdk_core'):
+            spec = importlib.util.find_spec(pkg)
+            if spec is not None and spec.origin is not None:
+                rocm_home = str(Path(spec.origin).parent.resolve())
+                break
     if rocm_home is None:
         # Guess #3
         hipcc_path = shutil.which('hipcc')


### PR DESCRIPTION
## Problem

QA 2.13 Docker images fail four `TestMemPool` tests because `load_inline`
builds `dummy_allocator` with `-isystem …/_rocm_sdk_core/include`. Devel is
already installed; torch never puts it on the include path. Tracked in
ROCM-30466.

PyTorch ROCm CI exports `ROCM_HOME` from `rocm-sdk path --root`, so it never
hits Guess #2.

## Changes

Backport of pytorch/pytorch#195726: `_find_rocm_home()` prefers
`_rocm_sdk_devel` over `_rocm_sdk_core` via `find_spec`. Adds `TestFindRocmHome`
so CI covers Guess #2 with the env unset.

## Validation

Equivalent 2.14 QA image (container `rocm30466`), env unset: four `TestMemPool`
tests FAILED (errors=4) unpatched, OK patched. Same `_find_rocm_home` hunk.

`TestFindRocmHome` in that container, 3/3 passed in 4.667s (devel-over-core,
core fallback, env wins).

Upstream: https://github.com/pytorch/pytorch/pull/195726
