### PR TITLE
[UP][release/2.13] Cache BMM outer-product warp size

### DIFF
--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -1,3 +1,5 @@
+import functools
+
 import torch
 
 from ... import triton_utils as tu
@@ -36,6 +38,11 @@ def _bmm_outer_product_impl(
         return bmm_outer_product(a, b)
 
 
+@functools.cache
+def _get_warp_size(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).warp_size
+
+
 def _is_hip_grid_safe(a: torch.Tensor, b: torch.Tensor) -> bool:
     """Return whether the outer-product BMM launch is safe on this backend.
 
@@ -56,7 +63,7 @@ def _is_hip_grid_safe(a: torch.Tensor, b: torch.Tensor) -> bool:
     batch, m, _ = a.shape
     n = b.shape[2]
     grid_size, _, _ = _bmm_outer_product_launch_config(batch, m, n)
-    warp_size = torch.cuda.get_device_properties(a.device).warp_size
+    warp_size = _get_warp_size(a.get_device())
     threads_per_program = _TRITON_DEFAULT_NUM_WARPS * warp_size
     return grid_size * threads_per_program <= _HIP_MAX_LAUNCH_WORK_ITEMS
 


### PR DESCRIPTION
Follow-up to [ROCm/pytorch#3596](https://github.com/ROCm/pytorch/pull/3596).

Backport of landed [pytorch/pytorch#196368](https://github.com/pytorch/pytorch/pull/196368) to `release/2.13` as a single `cherry-pick -x` of upstream commit [`4d3ac9e`](https://github.com/pytorch/pytorch/commit/4d3ac9e8118d09bab1f3666cc9b42b07067bc0f2).

## Summary
- cache the HIP BMM outer-product guard's warp size by device index
- avoid querying device properties on every eligible outer-product BMM

Warp size is immutable for a device, so `_get_warp_size` uses `functools.cache` with the integer device index as its key. This follows the existing per-device cache pattern in `torch._native.ops.topk.flydsl_impl` and keeps `torch._native` independent of Inductor's heavier device-properties helper.

## Test Plan

The existing ROCm `test_hip_grid_limit_fallback` regression exercises this call path in CI.

The backported file passes targeted lint:

```bash
lintrunner --take FLAKE8,PYFMT,RUFF,CODESPELL,NEWLINE,SPACES,TABS torch/_native/ops/bmm_outer_product/triton_impl.py
```

Made with [Cursor](https://cursor.com)

cc @jeffdaily @jithunnair-amd @pruthvistony @ROCmSupport @jataylo