### PR TITLE
[UP][release/2.14] Guard native BMM outer-product launches and cache warp size

### DIFF
--- a/test/test_bmm_outer_product.py
+++ b/test/test_bmm_outer_product.py
@@ -3,12 +3,16 @@
 import torch
 from torch._native.ops.bmm_outer_product.triton_impl import (
     _bmm_outer_product_cond,
+    _HIP_MAX_LAUNCH_WORK_ITEMS,
+    _is_hip_grid_safe,
     _is_outer_product,
 )
 from torch.testing._internal.common_device_type import (
     deviceCountAtLeast,
     instantiate_device_type_tests,
     onlyAccelerator,
+    onlyCUDA,
+    skipCUDAIfNotRocm,
     skipXPUIf,
 )
 from torch.testing._internal.common_utils import (
@@ -87,6 +91,32 @@ class TestBmmOuterProductDevice(TestCase):
         a = torch.randn(8, 1, 1, device=device)
         b = torch.randn(8, 1, 1, device=device)
         self.assertEqual(torch.bmm(a, b), a @ b)
+
+    @onlyCUDA
+    @skipCUDAIfNotRocm
+    def test_hip_grid_limit_fallback(self, device):
+        from torch._native.ops.bmm_outer_product.triton_kernels import (
+            _bmm_outer_product_launch_config,
+            _TRITON_DEFAULT_NUM_WARPS,
+        )
+
+        warp_size = torch.cuda.get_device_properties(device).warp_size
+        threads_per_program = _TRITON_DEFAULT_NUM_WARPS * warp_size
+        batch = _HIP_MAX_LAUNCH_WORK_ITEMS // threads_per_program + 1
+        # M = N = 1 puts exactly one program in the grid per batch entry, so
+        # this batch is the first one whose launch exceeds the limit.
+        self.assertEqual(_bmm_outer_product_launch_config(batch, 1, 1)[0], batch)
+
+        a = torch.randn(1, 1, 1, device=device).expand(batch, -1, -1)
+        b = torch.randn(1, 1, 1, device=device).expand(batch, -1, -1)
+
+        # Only the decision is checked. torch.bmm is deliberately not called:
+        # rocBLAS tiles this shape as one 256-thread workgroup per batch entry,
+        # so on some architectures the ATen fallback reaches the same work-item
+        # limit and raises, which says nothing about the guard under test.
+        self.assertTrue(_is_hip_grid_safe(a[:-1], b[:-1]))
+        self.assertFalse(_is_hip_grid_safe(a, b))
+        self.assertFalse(_bmm_outer_product_cond(a, b))
 
     @onlyAccelerator
     def test_gradient_flow(self, device):

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -3,6 +3,11 @@ import torch
 from ... import triton_utils as tu
 
 
+# HIP rejects a launch once gridDim.x * blockDim.x reaches 2**32, and the
+# rejection leaves the HIP context unusable rather than raising cleanly.
+_HIP_MAX_LAUNCH_WORK_ITEMS = (1 << 32) - 1
+
+
 def _is_outer_product(a: torch.Tensor, b: torch.Tensor) -> bool:
     return (
         a.ndim == 3
@@ -32,6 +37,31 @@ def _is_acc_tensor(t: torch.Tensor) -> bool:
     return acc is not None and acc.type == t.device.type
 
 
+def _is_hip_grid_safe(a: torch.Tensor, b: torch.Tensor) -> bool:
+    """Return whether the outer-product BMM launch is safe on this backend.
+
+    Only HIP tensors are constrained; every other backend returns ``True``.
+    Unlike Inductor, this eager kernel does not retune its fixed launch
+    configuration, so oversized HIP launches decline the specialization and fall
+    back to ATen. ATen can still fail on shapes this large, but it fails cleanly
+    instead of leaving the HIP context unusable.
+    """
+    if torch.version.hip is None or a.device.type != "cuda":
+        return True
+
+    from .triton_kernels import (
+        _bmm_outer_product_launch_config,
+        _TRITON_DEFAULT_NUM_WARPS,
+    )
+
+    batch, m, _ = a.shape
+    n = b.shape[2]
+    grid_size, _, _ = _bmm_outer_product_launch_config(batch, m, n)
+    warp_size = torch.cuda.get_device_properties(a.device).warp_size
+    threads_per_program = _TRITON_DEFAULT_NUM_WARPS * warp_size
+    return grid_size * threads_per_program <= _HIP_MAX_LAUNCH_WORK_ITEMS
+
+
 def _bmm_outer_product_cond(
     a: torch.Tensor,
     b: torch.Tensor,
@@ -41,9 +71,12 @@ def _bmm_outer_product_cond(
     # a and b are read-only here: the kernel wraps them in ConstTensorWrapper and
     # reads through const_data_ptr(), so copy-on-write inputs are not
     # materialized and need not be excluded.
-    if _is_acc_tensor(a) and a.device == b.device and _is_outer_product(a, b):
-        return True
-    return False
+    return (
+        _is_acc_tensor(a)
+        and a.device == b.device
+        and _is_outer_product(a, b)
+        and _is_hip_grid_safe(a, b)
+    )
 
 
 def _register_for_dispatch_key(dispatch_key: str) -> None:

--- a/torch/_native/ops/bmm_outer_product/triton_impl.py
+++ b/torch/_native/ops/bmm_outer_product/triton_impl.py
@@ -1,3 +1,5 @@
+import functools
+
 import torch
 
 from ... import triton_utils as tu
@@ -37,6 +39,11 @@ def _is_acc_tensor(t: torch.Tensor) -> bool:
     return acc is not None and acc.type == t.device.type
 
 
+@functools.cache
+def _get_warp_size(device_index: int) -> int:
+    return torch.cuda.get_device_properties(device_index).warp_size
+
+
 def _is_hip_grid_safe(a: torch.Tensor, b: torch.Tensor) -> bool:
     """Return whether the outer-product BMM launch is safe on this backend.
 
@@ -57,7 +64,7 @@ def _is_hip_grid_safe(a: torch.Tensor, b: torch.Tensor) -> bool:
     batch, m, _ = a.shape
     n = b.shape[2]
     grid_size, _, _ = _bmm_outer_product_launch_config(batch, m, n)
-    warp_size = torch.cuda.get_device_properties(a.device).warp_size
+    warp_size = _get_warp_size(a.get_device())
     threads_per_program = _TRITON_DEFAULT_NUM_WARPS * warp_size
     return grid_size * threads_per_program <= _HIP_MAX_LAUNCH_WORK_ITEMS
 

--- a/torch/_native/ops/bmm_outer_product/triton_kernels.py
+++ b/torch/_native/ops/bmm_outer_product/triton_kernels.py
@@ -1,3 +1,5 @@
+import functools
+
 import triton
 import triton.language as tl
 
@@ -7,10 +9,18 @@ from torch._native.instrumentation import instrumented_triton_cache
 from ...triton import ConstTensorWrapper
 
 
-def _bmm_log_key(a, b, out, B, M, N, *strides, BLOCK_M, BLOCK_N) -> str:
+# Pin Triton's current default so the launch and its safety check use the
+# same number of warps.
+_TRITON_DEFAULT_NUM_WARPS = 4
+
+
+def _bmm_log_key(a, b, out, B, M, N, *strides, BLOCK_M, BLOCK_N, num_warps) -> str:
     # Receives the kernel's launch args; BLOCK_M/BLOCK_N are the constexprs
     # that (with shapes/dtype) form the Triton compile key.
-    return f"bmm_outer B={B} M={M} N={N} {a.dtype} BLOCK_M={BLOCK_M} BLOCK_N={BLOCK_N}"
+    return (
+        f"bmm_outer B={B} M={M} N={N} {a.dtype} "
+        f"BLOCK_M={BLOCK_M} BLOCK_N={BLOCK_N} num_warps={num_warps}"
+    )
 
 
 @instrumented_triton_cache("aten::bmm", key_fn=_bmm_log_key)
@@ -74,17 +84,31 @@ def _pick_block_sizes(m: int, n: int) -> tuple[int, int]:
     return block_m, min(triton.next_power_of_2(n), 128)
 
 
+@functools.lru_cache(maxsize=1024)
+def _bmm_outer_product_launch_config(
+    batch: int, m: int, n: int
+) -> tuple[int, int, int]:
+    """Return the 1D grid size and block sizes used to launch the kernel.
+
+    The grid has one entry for every (batch, M tile, N tile). Sharing this
+    calculation with the safety guard keeps the checked and launched grids identical.
+    """
+    block_m, block_n = _pick_block_sizes(m, n)
+    grid_size = batch * triton.cdiv(m, block_m) * triton.cdiv(n, block_n)
+    return grid_size, block_m, block_n
+
+
 def bmm_outer_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
     B, M, _ = a.shape
     N = b.shape[2]
 
     out = torch.empty(B, M, N, dtype=a.dtype, device=a.device)
 
-    BLOCK_M, BLOCK_N = _pick_block_sizes(M, N)
+    grid_size, BLOCK_M, BLOCK_N = _bmm_outer_product_launch_config(B, M, N)
 
     # a and b are read-only inputs; wrap them so a copy-on-write tensor is read
     # through const_data_ptr() and not materialized. out is written directly.
-    _bmm_outer_product_kernel[(B * triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),)](
+    _bmm_outer_product_kernel[(grid_size,)](
         ConstTensorWrapper(a),
         ConstTensorWrapper(b),
         out,
@@ -100,5 +124,6 @@ def bmm_outer_product(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
         out.stride(2),
         BLOCK_M=BLOCK_M,
         BLOCK_N=BLOCK_N,
+        num_warps=_TRITON_DEFAULT_NUM_WARPS,
     )
     return out


### PR DESCRIPTION
Backports the two changes that landed in `ROCm/pytorch:release/2.13` and also in support of https://amd-hub.atlassian.net/browse/ROCM-29320

1. [ROCm/pytorch#3596](https://github.com/ROCm/pytorch/pull/3596), from [pytorch/pytorch#194131](https://github.com/pytorch/pytorch/pull/194131): guard native BMM outer-product launches against the HIP work-item limit.
2. [ROCm/pytorch#3628](https://github.com/ROCm/pytorch/pull/3628), from [pytorch/pytorch#196368](https://github.com/pytorch/pytorch/pull/196368): cache the per-device warp size used by that guard.

Both commits were cherry-picked with `-x` onto `release/2.14`, in dependency order.

## Summary
- decline the eager native outer-product BMM specialization when its launch would exceed HIP's `2^32` work-item limit
- share the launch configuration between the guard and launch and pin `num_warps`, so their calculations cannot drift
- cache immutable warp size by device index instead of querying device properties on every eligible BMM
- add the focused ROCm boundary regression

`release/2.14` uses the newer device-generic test harness and COW/instrumentation implementation. Conflict resolution preserved that structure; the resulting three files match upstream after both changes landed.

## Test Plan

Targeted lint:

```bash
lintrunner --take FLAKE8,PYFMT,RUFF,CODESPELL,NEWLINE,SPACES,TABS,TESTOWNERS,TEST_HAS_MAIN \
  test/test_bmm_outer_product.py \
  torch/_native/ops/bmm_outer_product/triton_impl.py \
  torch/_native/ops/bmm_outer_product/triton_kernels.py
```

Fresh ROCm build (release/2.14 uses PEP 517, so `spin clean` replaces the build script's deprecated `setup.py clean` step):

```bash
spin clean
PYTORCH_INCREMENTAL_BUILD=1 bash /home/niromero/docker_workspace/framework_scripts/pytorch/build.sh
```

Installed build verification:

```text
torch: 2.14.0+gitf771270
git: f771270da583dd757e96254079d260479cde8226
hip: 7.14.60850
device: AMD Instinct MI250X / MI250
warp_size: 64
```

Tests:

```bash
python test/test_bmm_outer_product.py -k hip_grid_limit_fallback
# Ran 2 tests: OK (skipped=1)

python test/test_bmm_outer_product.py
# Ran 26 tests: OK (skipped=12)
```

Made with [Cursor](https://cursor.com)

cc @jeffdaily @jithunnair-amd @pruthvistony @ROCmSupport @jataylo