### PR TITLE
[c10d] Skip NCCL2 reconfiguration tests on ROCm (#193744)

### DIFF
--- a/test/distributed/test_c10d_fault_tolerance.py
+++ b/test/distributed/test_c10d_fault_tolerance.py
@@ -22,6 +22,7 @@ from torch.testing._internal.common_utils import (
     get_cycles_per_ms,
     run_tests,
     TEST_CUDA,
+    TEST_WITH_ROCM,
     TestCase,
 )
 
@@ -390,6 +391,11 @@ def _make_fault_tolerance_test_class(backend):
         cls = unittest.skipIf(
             not TEST_CUDA or torch.cuda.device_count() < 3,
             "fault tolerance CUDA tests require at least 3 GPUs",
+        )(cls)
+    if backend.name == "nccl2":
+        cls = unittest.skipIf(
+            TEST_WITH_ROCM,
+            "nccl2 reconfigure is not supported with RCCL",
         )(cls)
     return cls
 


### PR DESCRIPTION
## Human Note
Looking at differnt jobs it seems that the distributed rocm jobs always fail on this

## Agent Report
# Change

Added a class-level ROCm skip for the generated `Nccl2FaultToleranceTest` in `test/distributed/test_c10d_fault_tolerance.py`.

This is the narrowest test-layer guard because every test in that generated class requires NCCL2 reconfiguration, which RCCL rejects by design. The separately generated Gloo class remains enabled, and NVIDIA NCCL2 coverage remains enabled because the new condition is only `TEST_WITH_ROCM`. The runtime process-group validation remains unchanged.

# Validation

- With `PYTORCH_TEST_WITH_ROCM=1`, all 16 `Nccl2FaultToleranceTest` cases were skipped with the RCCL-specific reason.
- With the same simulated ROCm test flag, `GlooFaultToleranceTest.test_reconfigure_basic` passed across three worker processes.
- Without the ROCm flag, the NCCL2 test did not receive the RCCL skip; it was skipped by the pre-existing three-GPU requirement because this NVIDIA host has only two GPUs.
- `spin lint test/distributed/test_c10d_fault_tolerance.py` reported no lint issues.

# Remaining uncertainty

A supported NVIDIA NCCL2 test was not executed end-to-end locally due to the three-GPU requirement. The condition and focused skip-reason check confirm that NVIDIA builds retain the existing class.

<details>
<summary>Agent Worklog</summary>

# Objective

Prevent `Nccl2FaultToleranceTest` from running NCCL2 reconfiguration tests on ROCm, where RCCL does not implement the feature, without reducing Gloo or NVIDIA NCCL2 coverage.

# Investigation

- `test/distributed/test_c10d_fault_tolerance.py` generates separate Gloo and NCCL2 test classes from one shared reconfiguration test suite.
- Every test inherited by `Nccl2FaultToleranceTest` exercises a process group created with `enable_reconfigure=True`, directly or through `_create_reconfigured_pg`.
- `ProcessGroupNCCLBackend.cpp` intentionally rejects `enable_reconfigure=True` when compiled with `USE_ROCM`, reporting that NCCL2 reconfiguration is unsupported with RCCL.
- The process-group validation is therefore correct product behavior and should not be weakened for tests.
- Per-method skips would duplicate the same platform constraint across the entire generated NCCL2 class. Skipping the whole test file would incorrectly remove Gloo coverage.

# Change

Imported `TEST_WITH_ROCM` and applied a class-level ROCm skip only while generating `Nccl2FaultToleranceTest`. The Gloo class and NVIDIA NCCL2 class generation remain unchanged.

# Validation

Focused tests:

```text
PYTORCH_TEST_WITH_ROCM=1 ../.venv/bin/python test/distributed/test_c10d_fault_tolerance.py Nccl2FaultToleranceTest -v
```

Result: all 16 NCCL2 reconfiguration cases skipped with `nccl2 reconfigure is not supported with RCCL`.

```text
PYTORCH_TEST_WITH_ROCM=1 ../.venv/bin/python test/distributed/test_c10d_fault_tolerance.py GlooFaultToleranceTest.test_reconfigure_basic -v
```

Result: passed, confirming the ROCm condition does not suppress Gloo fault-tolerance coverage.

```text
../.venv/bin/python test/distributed/test_c10d_fault_tolerance.py Nccl2FaultToleranceTest.test_reconfigure_basic -v
```

Result: skipped only because this host has two GPUs while the test requires three; the RCCL skip was not active on the NVIDIA build.

Prerequisite check:

```text
spin lint test/distributed/test_c10d_fault_tolerance.py
```

Result: no lint issues.

# Remaining uncertainty

The full NVIDIA NCCL2 reconfiguration test could not run locally because the host has only two GPUs. The skip is explicitly gated by `TEST_WITH_ROCM`, so NVIDIA CI retains the existing tests.

</details>

---
*This PR was generated by [ptq](https://github.com/drisspg/pt_job_queue) with human review.*

Pull Request resolved: https://github.com/pytorch/pytorch/pull/193744
Approved by: https://github.com/pytorchgreenlight, https://github.com/jeanschmidt

(cherry picked from commit 1ff39b7395fdbfe6e9539e345112575b83223c3a)

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/TheRock/blob/main/GOVERNANCE.md#pull-requests.
