### PR TITLE
[release/2.14] Fix inline asm tests for AMD real-true16 (#193627)

### DIFF
--- a/test/higher_order_ops/test_inline_asm_elementwise.py
+++ b/test/higher_order_ops/test_inline_asm_elementwise.py
@@ -18,6 +18,9 @@ from torch.testing._internal.common_utils import (
     instantiate_parametrized_tests,
     MI200_ARCH,
     MI300_ARCH,
+    NAVI3_5_ARCH,
+    NAVI3_ARCH,
+    NAVI4_ARCH,
     NAVI_ARCH,
     parametrize,
     run_tests,
@@ -27,6 +30,10 @@ from torch.testing._internal.common_utils import (
     xfailIfNoAcceleratorTriton,
 )
 from torch.utils._triton import has_triton
+
+
+# Upstream Triton enables LLVM real-true16 for Navi3, Navi3.5, and Navi4.
+TRUE16_ARCH = (*NAVI3_ARCH, *NAVI3_5_ARCH, *NAVI4_ARCH)
 
 
 @dataclass
@@ -40,6 +47,24 @@ class AsmTestCase:
     pack: int = 1
     compile_only: bool = False
     min_sm: int = 70
+    true16_asm_str: str | None = None
+    true16_constraints: str | None = None
+
+
+def _get_asm_config(tc: AsmTestCase) -> tuple[str, str]:
+    if (
+        torch.version.hip
+        and (tc.true16_asm_str is not None or tc.true16_constraints is not None)
+        and evaluate_gfx_arch_within(TRUE16_ARCH)
+    ):
+        asm_str = tc.true16_asm_str if tc.true16_asm_str is not None else tc.asm_str
+        constraints = (
+            tc.true16_constraints
+            if tc.true16_constraints is not None
+            else tc.constraints
+        )
+        return asm_str, constraints
+    return tc.asm_str, tc.constraints
 
 
 TEST_CASES = [
@@ -167,8 +192,9 @@ TEST_CASES = [
     ),
     # Truncate u32 -> u16 (compile-only).
     # PTX: uses "h" (16-bit) output / "r" (32-bit) input constraints.
-    # AMDGCN: VGPRs are always 32-bit (no "h" equivalent), so we use "v"
-    # and extract the lower 16 bits via v_bfe_u32.
+    # AMDGCN: use "v" and extract the lower 16 bits via v_bfe_u32.  With
+    # real-true16, move the source's low half directly into the true16 output
+    # with v_mov_b16 instead of using a 32-bit instruction.
     AsmTestCase(
         "truncate_to_uint16",
         lambda: (torch.randint(0, 256, (100,), device="cuda", dtype=torch.int32),),
@@ -177,6 +203,7 @@ TEST_CASES = [
         torch.uint16,
         lambda x: x.to(torch.uint16),
         compile_only=True,
+        true16_asm_str="v_mov_b16 $0, $1.l",
     ),
     # Broadcasting
     AsmTestCase(
@@ -203,6 +230,9 @@ TEST_CASES = [
     # ROCm: Inductor feeds f32 values (upcasted for computation).  AMDGCN has no
     # "h" constraint for 16-bit regs, so we add in f32 and convert to the target
     # format.  PTX "h" constraints tell Triton to downcast before the asm.
+    # Under real-true16 the fp16 output is allocated to a VGPR half, which
+    # v_add_f32 cannot write; we route the f32 sum through physical v0 and
+    # declare it as a clobber so LLVM does not reuse it across the asm block.
     AsmTestCase(
         "add_fp16_native",
         lambda: (
@@ -218,6 +248,8 @@ TEST_CASES = [
         torch.float16,
         lambda x, y: x + y,
         compile_only=True,
+        true16_asm_str="v_add_f32 v0, $1, $2\nv_cvt_f16_f32 $0, v0",
+        true16_constraints="=v,v,v,~{v0}",
     ),
     # AMDGCN: v_cvt_pk_bf16_f32 packs two f32 values into bf16 in a single
     # 32-bit register.  We pass $0 twice — only the lower 16 bits (first
@@ -314,12 +346,13 @@ class TestInlineAsmElementwise(TestCase):
             self.skipTest("Requires gfx950+")
 
         inputs = tc.input_gen_fn()
+        asm_str, constraints = _get_asm_config(tc)
 
         def fn(*args):
             return inline_asm_elementwise(
                 *args,
-                asm_str=tc.asm_str,
-                constraints=tc.constraints,
+                asm_str=asm_str,
+                constraints=constraints,
                 dtype=tc.dtype,
                 pack=tc.pack,
             )
@@ -372,12 +405,13 @@ class TestInlineAsmElementwise(TestCase):
             self.skipTest("Requires gfx950+")
 
         inputs = tc.input_gen_fn()
+        asm_str, constraints = _get_asm_config(tc)
 
         def fn(*args):
             return inline_asm_elementwise(
                 *args,
-                asm_str=tc.asm_str,
-                constraints=tc.constraints,
+                asm_str=asm_str,
+                constraints=constraints,
                 dtype=tc.dtype,
                 pack=tc.pack,
             )

--- a/torch/testing/_internal/common_utils.py
+++ b/torch/testing/_internal/common_utils.py
@@ -105,8 +105,17 @@ SEED = 1234
 MI350_ARCH = ("gfx950",)
 MI300_ARCH = ("gfx942",)
 MI200_ARCH = ("gfx90a",)
-NAVI_ARCH = ("gfx1030", "gfx1100", "gfx1101", "gfx1200", "gfx1201")
+NAVI_ARCH = (
+    "gfx1030",
+    "gfx1100",
+    "gfx1101",
+    "gfx1150",
+    "gfx1151",
+    "gfx1200",
+    "gfx1201",
+)
 NAVI3_ARCH = ("gfx1100", "gfx1101")
+NAVI3_5_ARCH = ("gfx1150", "gfx1151")
 NAVI4_ARCH = ("gfx1200", "gfx1201")
 
 class ProfilingMode(Enum):


### PR DESCRIPTION
Cherry-pick of upstream commit ef3bf4b8b2039df7e0d11fd292a6ffc26e55a4f9 (pytorch/pytorch#193627) onto release/2.14. Already on rocm/pytorch develop, but missing from release/2.14, where it fails the nightly CI build on RDNA. Clean cherry-pick, no changes to the upstream diff.

## Summary

Fix the `inline_asm_elementwise` tests on AMD GPUs that use real 16-bit VGPR operands, specifically RDNA3, RDNA3.5, and RDNA4.

The existing inline-assembly strings were written for targets where 16-bit values are represented through 32-bit VGPR operands. On real-true16 targets, LLVM/Triton can lower 16-bit operands as VGPR subregisters such as `v0.l` and `v0.h`. This exposed invalid operand combinations in the fp16 addition and uint16 truncation test cases on gfx1201.

## Root cause

Two existing assembly sequences were incompatible with real-true16 operand lowering.

### Native fp16 addition

The original sequence reused the fp16 output operand as the destination of `v_add_f32`:

```asm
v_add_f32 $0, $1, $2
v_cvt_f16_f32 $0, $0
```

Because `$0` has an fp16 output type, it can be expanded to a 16-bit subregister such as `v0.l` or `v0.h`. However, `v_add_f32` requires a full 32-bit VGPR destination, producing invalid assembly such as:

```asm
v_add_f32 v0.l, v5, v0
```

The corrected sequence performs the f32 addition in an explicit full-width scratch VGPR and then converts the result into the fp16 output:

```asm
v_add_f32 v0, $1, $2
v_cvt_f16_f32 $0, v0
```

The scratch register is declared through the LLVM inline-assembly constraint:

```text
~{v0}
```

This is required because Triton passes the constraint string directly to LLVM. A GCC/Clang-style `+v` read-write constraint is not interpreted as a read-write operand here and could allow LLVM to place a live input in the scratch register. Declaring `v0` as clobbered makes the register modification visible to LLVM and prevents input corruption.

### Uint16 truncation

The existing uint16 truncation path used a 32-bit move for values that are lowered as true 16-bit operands. On real-true16 targets, this can generate an invalid combination of a 32-bit instruction and 16-bit subregister operands.

The real-true16 path now uses:

```asm
v_mov_b16 $0, $1.l
```

This matches the width of the output and correctly selects the low 16 bits of the input.

## Architecture scope

The real-true16 assembly is enabled only for the intended AMD architecture families:

- RDNA3: `gfx1100`, `gfx1101`
- RDNA3.5: `gfx1150`, `gfx1151`
- RDNA4: `gfx1200`, `gfx1201`

This change also:

- Adds `NAVI3_5_ARCH`.
- Adds `gfx1150` and `gfx1151` to `NAVI_ARCH`.
- Leaves the existing assembly unchanged for architectures outside the real-true16 target set.
Pull Request resolved: https://github.com/pytorch/pytorch/pull/193627
Approved by: https://github.com/jayfurmanek, https://github.com/jeffdaily

(cherry picked from commit ef3bf4b8b2039df7e0d11fd292a6ffc26e55a4f9)
