### PR TITLE
[release/2.13] [ROCm] Prefer TheRock _rocm_sdk_devel when locating ROCM_HOME (#196503)

### DIFF
--- a/torch/utils/cpp_extension.py
+++ b/torch/utils/cpp_extension.py
@@ -183,13 +183,36 @@ def _find_rocm_home() -> str | None:
     # Guess #1
     rocm_home = os.environ.get('ROCM_HOME') or os.environ.get('ROCM_PATH')
     if rocm_home is None:
-        # Guess #2: Support for ROCm distribution from TheRock
-        # rocm-sdk-core installs everything under <site-packages>/_rocm_sdk_core
-        # (include/, lib/, bin/, ...), so the module's own location is the
-        # ROCM_HOME we want. Use find_spec to locate it without importing.
-        spec = importlib.util.find_spec('_rocm_sdk_core')
-        if spec is not None and spec.origin is not None:
-            rocm_home = str(Path(spec.origin).parent.resolve())
+        # Guess #2: Support for ROCm distribution from TheRock.
+        # TheRock splits the SDK across wheels under site-packages:
+        #   _rocm_sdk_core  - HIP runtime, hipcc
+        #   _rocm_sdk_devel - the above plus math-library headers
+        #                     (hipblas, hipsparse, hipsolver, ...)
+        # Prefer devel when present so JIT extensions can include ATen CUDA
+        # headers that hipify to those libraries. Use find_spec to locate
+        # the package without importing it.
+        #
+        # pip install rocm[devel] only installs the unexpanded rocm_sdk_devel
+        # wheel (payload tar). The _rocm_sdk_devel package is created by
+        # `rocm-sdk init`. Do not expand here: it writes gigabytes into
+        # site-packages and this function runs at module import.
+        devel_spec = importlib.util.find_spec('_rocm_sdk_devel')
+        if (devel_spec is None or devel_spec.origin is None) and (
+            importlib.util.find_spec('rocm_sdk_devel') is not None
+        ):
+            logger.warning(
+                "The TheRock devel wheel is installed (rocm_sdk_devel) but has "
+                "not been expanded, so ROCM_HOME will fall back to "
+                "_rocm_sdk_core. Math-library headers will be missing and JIT "
+                "extensions on ROCm may fail with "
+                "'hipblas/hipblas.h: No such file or directory'. "
+                "Run `rocm-sdk init` to expand the devel payload."
+            )
+        for modname in ('_rocm_sdk_devel', '_rocm_sdk_core'):
+            spec = importlib.util.find_spec(modname)
+            if spec is not None and spec.origin is not None:
+                rocm_home = str(Path(spec.origin).parent.resolve())
+                break
     if rocm_home is None:
         # Guess #3
         hipcc_path = shutil.which('hipcc')


### PR DESCRIPTION
TheRock pip wheels split the SDK: `_rocm_sdk_core` has the HIP runtime and hipcc, while math-library headers (hipblas, hipsparse, hipsolver) live in `_rocm_sdk_devel`. `_find_rocm_home()` previously always selected core, so cpp_extension include_paths only added that include root. JIT extensions that include ATen CUDA headers (which hipify to hipblas/hipsparse/hipsolver) then fail to compile with `hipblas/hipblas.h: No such file or directory`.

Prefer `_rocm_sdk_devel` when that package is importable, falling back to `_rocm_sdk_core`

Warn if `rocm[devel]` is installed but not expanded via `rocm-sdk init`, instead of expanding at import time.

Test Plan:
```
python test_cuda.py TestMemPool.test_mempool_limited_memory_with_allocator
python test_cpp_extensions_jit.py
python test_cuda.py TestMemPool
```

Pull Request resolved: https://github.com/pytorch/pytorch/pull/196503
Approved by: https://github.com/jeffdaily, https://github.com/ethanwee1

(cherry picked from commit 54549a9046fc42c08ddf09df32ab6f031612cd39)